### PR TITLE
Support --help & --version flags

### DIFF
--- a/src/polymer-cli.ts
+++ b/src/polymer-cli.ts
@@ -42,6 +42,21 @@ export class PolymerCli {
   }
 
   run(args) {
+    // If the "--version"/"-v" flag is ever present, just print
+    // the current version. Useful for globally installed CLIs.
+    if (args.indexOf('--version') > -1 || args.indexOf('-v') > -1) {
+      console.log(require('../package.json').version);
+      return;
+    }
+
+    // Alias the "--help"/"-h" flag to run the help command for the given
+    // command. This gets us around some limitations in our arguments
+    // parsers and keeps us from having to implement additional help logic
+    // inside of each command.
+    if (args.indexOf('--help') > -1 || args.indexOf('-h') > -1) {
+      args = ['help', args[0]];
+    }
+
     this.cli = commandLineCommands(this.commandDescriptors);
     let cliCommand = this.cli.parse(args);
     let command = this.commands.get(cliCommand.name || 'help');

--- a/test/commands/cli_test.js
+++ b/test/commands/cli_test.js
@@ -1,0 +1,72 @@
+/**
+ * @license
+ * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ */
+
+'use strict';
+
+const packageJSON = require('../../package.json');
+const assert = require('chai').assert;
+const PolymerCli = require('../../lib/polymer-cli').PolymerCli;
+const sinon = require('sinon');
+
+suite('The general CLI', () => {
+
+  test('displays general help when no command is called', () => {
+    let cli = new PolymerCli();
+    let helpCommand = cli.commands.get('help');
+    let helpCommandSpy = sinon.spy(helpCommand, 'run');
+    cli.run([]);
+    assert.isOk(helpCommandSpy.calledOnce);
+    assert.deepEqual(helpCommandSpy.firstCall.args, [undefined]);
+  });
+
+  test('displays general help when unknown command is called', () => {
+    let cli = new PolymerCli();
+    let helpCommand = cli.commands.get('help');
+    let helpCommandSpy = sinon.spy(helpCommand, 'run');
+    cli.run(['THIS_IS_SOME_UNKNOWN_COMMAND']);
+    assert.isOk(helpCommandSpy.calledOnce);
+    assert.deepEqual(helpCommandSpy.firstCall.args, [undefined]);
+  });
+
+  test('displays command help when called with the --help flag', () => {
+    let cli = new PolymerCli();
+    let helpCommand = cli.commands.get('help');
+    let helpCommandSpy = sinon.spy(helpCommand, 'run');
+    cli.run(['build', '--help']);
+    assert.isOk(helpCommandSpy.calledOnce);
+    assert.deepEqual(helpCommandSpy.firstCall.args, [{command: 'build'}]);
+  });
+
+  test('displays command help when called with the -h flag', () => {
+    let cli = new PolymerCli();
+    let helpCommand = cli.commands.get('help');
+    let helpCommandSpy = sinon.spy(helpCommand, 'run');
+    cli.run(['init', '-h']);
+    assert.isOk(helpCommandSpy.calledOnce);
+    assert.deepEqual(helpCommandSpy.firstCall.args, [{command: 'init'}]);
+  });
+
+  test('displays version information when called with the --version flag', () => {
+    let cli = new PolymerCli();
+    let consoleLogSpy = sinon.spy(console, 'log');
+    cli.run(['--version']);
+    assert.isOk(consoleLogSpy.calledWithExactly(packageJSON.version));
+    consoleLogSpy.restore();
+  });
+
+  test('displays version information when called with the -v flag', () => {
+    let cli = new PolymerCli();
+    let consoleLogSpy = sinon.spy(console, 'log');
+    cli.run(['-v']);
+    assert.isOk(consoleLogSpy.calledWithExactly(packageJSON.version));
+    consoleLogSpy.restore();
+  });
+
+});

--- a/test/commands/help_test.js
+++ b/test/commands/help_test.js
@@ -16,6 +16,15 @@ const sinon = require('sinon');
 
 suite('help', () => {
 
+  test('displays help for a specific command when called with that command', () => {
+    let cli = new PolymerCli();
+    let helpCommand = cli.commands.get('help');
+    let helpCommandSpy = sinon.spy(helpCommand, 'run');
+    cli.run(['help', 'build']);
+    assert.isOk(helpCommandSpy.calledOnce);
+    assert.deepEqual(helpCommandSpy.firstCall.args, [{command: 'build'}]);
+  });
+
   test('displays general help when the help command is called with no arguments', () => {
     let cli = new PolymerCli();
     let helpCommand = cli.commands.get('help');
@@ -23,24 +32,6 @@ suite('help', () => {
     cli.run(['help']);
     assert.isOk(helpCommandSpy.calledOnce);
     assert.deepEqual(helpCommandSpy.firstCall.args, [{}]);
-  });
-
-  test('displays general help when no command is called', () => {
-    let cli = new PolymerCli();
-    let helpCommand = cli.commands.get('help');
-    let helpCommandSpy = sinon.spy(helpCommand, 'run');
-    cli.run([]);
-    assert.isOk(helpCommandSpy.calledOnce);
-    assert.deepEqual(helpCommandSpy.firstCall.args, [undefined]);
-  });
-
-  test('displays general help when unknown command is called', () => {
-    let cli = new PolymerCli();
-    let helpCommand = cli.commands.get('help');
-    let helpCommandSpy = sinon.spy(helpCommand, 'run');
-    cli.run(['THIS_IS_SOME_UNKNOWN_COMMAND']);
-    assert.isOk(helpCommandSpy.calledOnce);
-    assert.deepEqual(helpCommandSpy.firstCall.args, [undefined]);
   });
 
 });


### PR DESCRIPTION
Previously, both `--help/-h` & `--version/-v` flags would throw errors if they were used. To implement these across commands, the global `polymer-cli` now watches for and handles them.

CR @justinfagnani 