### PR TITLE
Update package.json engines and travis version testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: node_js
 node_js:
+  - "6"
   - "5"
+  - "4"
 sudo: false
 before_script:
   - npm install

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.1.0",
   "description": "A commandline tool for Polymer projects",
   "main": "lib/polymer-cli.js",
+  "engines" : {
+    "node" : ">=4.0"
+  },
   "bin": {
     "polymer": "bin/polymer.js"
   },


### PR DESCRIPTION
Being explicit in both our package.json & travis testing is enough to handle #63 IMO. Now ff anyone tries to install the CLI with an earlier version of Node they'll get a warning at install time.