### PR TITLE
Remove an unnecessary import and instead tell depcheck its safe to ignore

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "init": "typings install",
     "build": "if [ ! -f typings/main.d.ts ]; then npm run init; fi; tsc",
-    "test": "depcheck . && gulp test"
+    "test": "depcheck . --ignores 'generator-polymer-init' && gulp test"
   },
   "repository": {
     "type": "git",

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -16,11 +16,6 @@ import {PolykartGenerator} from '../templates/polykart';
 // not ES modules compatible
 const YeomanEnvironment = require('yeoman-environment');
 
-// NOTE(fschott) 05-02-2015: Yeoman needs to load our generator in a non-standard way via require.resolve.
-// We include this here so that our dependency-usage-checking test can still pass. If you no longer see
-// generator-polymer-init used in this file, it is safe to remove this code.
-require('generator-polymer-init');
-
 export class InitCommand implements Command {
   name = 'init';
 


### PR DESCRIPTION
A small change related to #79. Since we care about loading time we should use this (arguably simpler) way to fix the `depcheck` error that the call to require `generator-polymer-init` originally silenced.