### PR TITLE
Optimize command imports to only load when command is run

### DIFF
--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -12,7 +12,6 @@ import {ArgDescriptor} from 'command-line-args';
 import {CLI} from 'command-line-commands';
 
 import {Command} from './command';
-import {build} from '../build/build';
 
 export class BuildCommand implements Command {
   name = 'build';
@@ -48,6 +47,9 @@ export class BuildCommand implements Command {
   ];
 
   run(options): Promise<any> {
+    // Defer dependency loading until this specific command is run
+    var build = require('../build/build').build;
+
     return build({
       main: options.main,
       shell: options.shell,

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -11,11 +11,6 @@
 import {Command} from './command';
 import {ArgDescriptor} from 'command-line-args';
 
-import {PolykartGenerator} from '../templates/polykart';
-
-// not ES modules compatible
-const YeomanEnvironment = require('yeoman-environment');
-
 export class InitCommand implements Command {
   name = 'init';
 
@@ -31,6 +26,10 @@ export class InitCommand implements Command {
   ];
 
   run(options): Promise<any> {
+    // Defer dependency loading until this specific command is run
+    const PolykartGenerator = require('../templates/polykart').PolykartGenerator;
+    const YeomanEnvironment = require('yeoman-environment');
+
     return new Promise((resolve, reject) => {
       let templateName = options['name'] || 'polymer-init';
       let env = new YeomanEnvironment();

--- a/src/commands/test.ts
+++ b/src/commands/test.ts
@@ -1,6 +1,4 @@
 import {Command} from './command';
-import * as wct from 'web-component-tester';
-// import * as process from 'process';
 
 export class TestCommand implements Command {
   name = 'test';
@@ -119,6 +117,9 @@ export class TestCommand implements Command {
   ];
 
   run(options): Promise<void> {
+    // Defer dependency loading until this specific command is run
+    var wct = require('web-component-tester');
+
     return new Promise<void>((resolve, reject) => {
       wct.cli.run(process.env, process.argv.slice(3), process.stdout,
         (error) => {


### PR DESCRIPTION
Fixes #79

#### Old startup time:
```
$ time polymer --version
real	0m2.667s
user	0m1.625s
sys	0m0.299s
```

#### New startup time:
```
$ time polymer --version
real	0m0.671s
user	0m0.511s
sys	0m0.073s
```

Each dependency that has been optimized to load at run-time was previously adding at least 300ms a piece to the overall load time. `PolykartGenerator` was adding 1 second!. The remaining ~670ms time is mostly taken up by loading the dependencies of `lint` & `serve`, which cannot be easily optimized because their commands rely on the arguments defined within their dependencies. We'll need to revisit this pattern if we want to optimize further.