### PR TITLE
Add logging framework, add logging to main & init command

### DIFF
--- a/bin/polymer.js
+++ b/bin/polymer.js
@@ -17,6 +17,7 @@ process.title = 'polymer';
 
 resolve('polymer-cli', {basedir: process.cwd()}, function(error, path) {
   let lib = path ? require(path) : require('..');
-  let cli = new lib.PolymerCli();
-  cli.run(process.argv.slice(2));
+  let args = process.argv.slice(2);
+  let cli = new lib.PolymerCli(args);
+  cli.run();
 });

--- a/custom_typings/plylog.d.ts
+++ b/custom_typings/plylog.d.ts
@@ -1,0 +1,15 @@
+declare module 'plylog' {
+
+  class PolymerLogger {
+    constructor(options: any)
+    setLevel(newLevel: string)
+    error(message: string, metadata?: any)
+    warn(message: string, metadata?: any)
+    info(message: string, metadata?: any)
+    debug(message: string, metadata?: any)
+  }
+
+  export function setVerbose();
+  export function setQuiet();
+  export function getLogger(name: string): PolymerLogger;
+}

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "merge-stream": "^1.0.0",
     "minimatch-all": "^1.0.2",
     "multipipe": "^0.3.0",
+    "plylog": "^0.2.0",
     "polylint": "^2.10.0",
     "polyserve": "^0.11.0",
     "request": "^2.72.0",

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -12,6 +12,7 @@ import {Command} from './command';
 import {ArgDescriptor} from 'command-line-args';
 import {PolykartGenerator} from '../templates/polykart';
 
+import * as logging from 'plylog';
 import *  as YeomanEnvironment from 'yeoman-environment';
 
 // NOTE(fschott) 05-02-2015: Yeoman needs to load our generator in a non-standard way via require.resolve.
@@ -30,7 +31,7 @@ export class InitCommand implements Command {
       description: 'The template name',
       type: String,
       defaultOption: true,
-    },
+    }
   ];
 
   run(options, config): Promise<any> {
@@ -39,10 +40,15 @@ export class InitCommand implements Command {
     const YeomanEnvironment = require('yeoman-environment');
 
     return new Promise((resolve, reject) => {
+      let logger = logging.getLogger('cli.init');
       let templateName = options['name'] || 'polymer-init';
+
+      logger.debug('creating yeoman environment...');
       let env = new YeomanEnvironment();
       env.register(require.resolve('generator-polymer-init'), 'polymer-init:app');
       env.registerStub(PolykartGenerator, 'polykart:app');
+
+      logger.debug('running template...', templateName);
       env.run(templateName, {}, () => resolve());
     });
   }

--- a/test/commands/cli_test.js
+++ b/test/commands/cli_test.js
@@ -12,8 +12,9 @@
 
 const Config = require('../../lib/project-config').ProjectConfig;
 const packageJSON = require('../../package.json');
-const assert = require('chai').assert;
 const PolymerCli = require('../../lib/polymer-cli').PolymerCli;
+const logging = require('plylog');
+const assert = require('chai').assert;
 const sinon = require('sinon');
 
 suite('The general CLI', () => {
@@ -21,28 +22,28 @@ suite('The general CLI', () => {
   const defaultConfig = new Config();
 
   test('displays general help when no command is called', () => {
-    let cli = new PolymerCli();
+    let cli = new PolymerCli([]);
     let helpCommand = cli.commands.get('help');
     let helpCommandSpy = sinon.spy(helpCommand, 'run');
-    cli.run([]);
+    cli.run();
     assert.isOk(helpCommandSpy.calledOnce);
     assert.deepEqual(helpCommandSpy.firstCall.args, [undefined, defaultConfig]);
   });
 
   test('displays general help when unknown command is called', () => {
-    let cli = new PolymerCli();
+    let cli = new PolymerCli(['THIS_IS_SOME_UNKNOWN_COMMAND']);
     let helpCommand = cli.commands.get('help');
     let helpCommandSpy = sinon.spy(helpCommand, 'run');
-    cli.run(['THIS_IS_SOME_UNKNOWN_COMMAND']);
+    cli.run();
     assert.isOk(helpCommandSpy.calledOnce);
     assert.deepEqual(helpCommandSpy.firstCall.args, [undefined, defaultConfig]);
   });
 
   test('displays command help when called with the --help flag', () => {
-    let cli = new PolymerCli();
+    let cli = new PolymerCli(['build', '--help']);
     let helpCommand = cli.commands.get('help');
     let helpCommandSpy = sinon.spy(helpCommand, 'run');
-    cli.run(['build', '--help']);
+    cli.run();
     assert.isOk(helpCommandSpy.calledOnce);
     assert.deepEqual(
       helpCommandSpy.firstCall.args,
@@ -51,10 +52,10 @@ suite('The general CLI', () => {
   });
 
   test('displays command help when called with the -h flag', () => {
-    let cli = new PolymerCli();
+    let cli = new PolymerCli(['init', '-h']);
     let helpCommand = cli.commands.get('help');
     let helpCommandSpy = sinon.spy(helpCommand, 'run');
-    cli.run(['init', '-h']);
+    cli.run();
     assert.isOk(helpCommandSpy.calledOnce);
     assert.deepEqual(
       helpCommandSpy.firstCall.args,
@@ -63,19 +64,18 @@ suite('The general CLI', () => {
   });
 
   test('displays version information when called with the --version flag', () => {
-    let cli = new PolymerCli();
+    let cli = new PolymerCli(['--version']);
     let consoleLogSpy = sinon.spy(console, 'log');
-    cli.run(['--version']);
+    cli.run();
     assert.isOk(consoleLogSpy.calledWithExactly(packageJSON.version));
     consoleLogSpy.restore();
   });
 
-  test('displays version information when called with the -v flag', () => {
-    let cli = new PolymerCli();
-    let consoleLogSpy = sinon.spy(console, 'log');
-    cli.run(['-v']);
-    assert.isOk(consoleLogSpy.calledWithExactly(packageJSON.version));
-    consoleLogSpy.restore();
+  test('sets the appropriate log levels when the --verbose & --queit flags are used', () => {
+    let cli = new PolymerCli(['help', '--verbose']);
+    assert.equal(logging.configOptions.level, 'debug');
+    let cli2 = new PolymerCli(['help', '--quiet']);
+    assert.equal(logging.configOptions.level, 'error');
   });
 
 });

--- a/test/commands/help_test.js
+++ b/test/commands/help_test.js
@@ -19,10 +19,10 @@ suite('help', () => {
   const defaultConfig = new Config();
 
   test('displays help for a specific command when called with that command', () => {
-    let cli = new PolymerCli();
+    let cli = new PolymerCli(['help', 'build']);
     let helpCommand = cli.commands.get('help');
     let helpCommandSpy = sinon.spy(helpCommand, 'run');
-    cli.run(['help', 'build']);
+    cli.run();
     assert.isOk(helpCommandSpy.calledOnce);
     assert.deepEqual(
       helpCommandSpy.firstCall.args,
@@ -31,10 +31,10 @@ suite('help', () => {
   });
 
   test('displays general help when the help command is called with no arguments', () => {
-    let cli = new PolymerCli();
+    let cli = new PolymerCli(['help']);
     let helpCommand = cli.commands.get('help');
     let helpCommandSpy = sinon.spy(helpCommand, 'run');
-    cli.run(['help']);
+    cli.run();
     assert.isOk(helpCommandSpy.calledOnce);
     assert.deepEqual(helpCommandSpy.firstCall.args, [{}, defaultConfig]);
   });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -55,6 +55,7 @@
     "custom_typings/github.d.ts",
     "custom_typings/hydrolysis.d.ts",
     "custom_typings/node.d.ts",
+    "custom_typings/plylog.d.ts",
     "custom_typings/temp.d.ts",
     "custom_typings/vinyl-fs.d.ts",
     "custom_typings/web-component-tester.d.ts",


### PR DESCRIPTION
Fixes #95

This PR adds basic logging to the Main CLI runner, and the init command. Once this is merged we can logging to each of the other commands as needed.

We've built a simple logger to be shared across polymer CLIs & libraries. See https://github.com/Polymer/plylog/blob/master/index.js for the logic there & please open an issue if you have any comments there.

/cc @justinfagnani @azakus 

