### PR TITLE
Fix duplicate argument definitions.

### DIFF
--- a/src/commands/lint.ts
+++ b/src/commands/lint.ts
@@ -17,7 +17,39 @@ export class LintCommand implements Command {
 
   description = 'Lints the project';
 
-  args = polylint.argumentDefinitions;
+  args = [
+    {
+      name: "policy",
+      type: String,
+      alias: "p",
+      description: "Your jsconf.json policy file.",
+      defaultValue: null
+    },
+    {
+      name: "config-file",
+      type: String,
+      defaultValue: "bower.json",
+      description: (
+        "If inputs are specified, look for `config-field` in this JSON file."
+      )
+    },
+    {
+      name: "config-field",
+      type: String,
+      defaultValue: "main",
+      description: (
+        "If config-file is used for inputs, this field determines which " +
+        "file(s) are linted."
+      )
+    },
+    {
+      name: "no-recursion",
+      type: Boolean,
+      description: (
+        "Only report errors on specified input files, not from their dependencies."
+      )
+    }
+  ];
 
   run(options, config): Promise<any> {
     return polylint.runWithOptions(options)

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -18,7 +18,47 @@ export class ServeCommand implements Command {
 
   description = 'Runs the polyserve development server';
 
-  args = polyserveArgs;
+  args = [
+      {
+          name: 'port',
+          alias: 'p',
+          description: 'The port to serve from. Defaults to 8080',
+          type: Number,
+      },
+      {
+          name: 'hostname',
+          alias: 'H',
+          description: 'The hostname to serve from. Defaults to localhost',
+          type: String,
+      },
+      {
+          name: 'package-name',
+          alias: 'n',
+          description: 'The package name to use for the root directory. Defaults to' +
+              ' reading from bower.json',
+          type: String,
+      },
+      {
+          name: 'open',
+          alias: 'o',
+          description: 'The page to open in the default browser on startup.',
+          type: Boolean,
+      },
+      {
+          name: 'browser',
+          alias: 'b',
+          description: 'The browser(s) to open with when using the --open option.' +
+              ' Defaults to your default web browser.',
+          type: String,
+          multiple: true,
+      },
+      {
+          name: 'open-path',
+          description: 'The URL path to open when using the --open option.' +
+              ' Defaults to "index.html".',
+          type: String,
+      },
+  ];
 
   run(options, config): Promise<any> {
     var serverOptions: ServerOptions = {


### PR DESCRIPTION
Fixes #114 

Existing tests now catch duplicate argument definitions across all commands because the detection is done in the CLI constructor.