### PR TITLE
Install dependencies via smarter yeoman method

### DIFF
--- a/src/templates/polykart.ts
+++ b/src/templates/polykart.ts
@@ -50,7 +50,7 @@ export function getGenerator(options?) {
     }
 
     install() {
-      (<any>this).bowerInstall();
+      this.installDependencies();
     }
   }
 }


### PR DESCRIPTION
Fixes #57 and #40 

This seems to be the "yeoman way" to handle installing dependencies. It says "hey I'm installing all needed dependencies" (by checking for bower.json & package.json) "if anything fails make sure you look into it". It's also included in the TS definition while bowerInstall isn't, which is another good sign.

@addyosmani might be able to confirm that this is correct.