### PR TITLE
Move all command logging to use new logger

### DIFF
--- a/custom_typings/plylog.d.ts
+++ b/custom_typings/plylog.d.ts
@@ -3,10 +3,10 @@ declare module 'plylog' {
   class PolymerLogger {
     constructor(options: any)
     setLevel(newLevel: string)
-    error(message: string, metadata?: any)
-    warn(message: string, metadata?: any)
-    info(message: string, metadata?: any)
-    debug(message: string, metadata?: any)
+    error(...data: any[])
+    warn(...data: any[])
+    info(...data: any[])
+    debug(...data: any[])
   }
 
   export function setVerbose();

--- a/custom_typings/plylog.d.ts
+++ b/custom_typings/plylog.d.ts
@@ -3,10 +3,10 @@ declare module 'plylog' {
   class PolymerLogger {
     constructor(options: any)
     setLevel(newLevel: string)
-    error(...data: any[])
-    warn(...data: any[])
-    info(...data: any[])
-    debug(...data: any[])
+    error(message: string, metadata?: any)
+    warn(message: string, metadata?: any)
+    info(message: string, metadata?: any)
+    debug(message: string, metadata?: any)
   }
 
   export function setVerbose();

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "merge-stream": "^1.0.0",
     "minimatch-all": "^1.0.2",
     "multipipe": "^0.3.0",
-    "plylog": "^0.3.0",
+    "plylog": "^0.4.0",
     "polylint": "^2.10.0",
     "polyserve": "^0.11.0",
     "request": "^2.72.0",

--- a/src/build/analyzer.ts
+++ b/src/build/analyzer.ts
@@ -14,8 +14,10 @@ import * as path from 'path';
 import {Transform} from 'stream';
 import File = require('vinyl');
 import {parse as parseUrl} from 'url';
+import * as logging from 'plylog';
 
 const minimatchAll = require('minimatch-all');
+let logger = logging.getLogger('cli.build.analyzer');
 
 export class StreamAnalyzer extends Transform {
 
@@ -213,7 +215,7 @@ class StreamResolver implements Resolver {
       if (file) {
         deferred.resolve(file.contents.toString());
       } else {
-        console.log('No file found for', filepath);
+        logger.info('No file found for', filepath);
       }
       return true;
     }

--- a/src/build/build.ts
+++ b/src/build/build.ts
@@ -18,6 +18,7 @@ import * as path from 'path';
 import {PassThrough, Readable} from 'stream';
 import File = require('vinyl');
 import * as vfs from 'vinyl-fs';
+import * as logging from 'plylog';
 
 import {StreamAnalyzer, DepsIndex} from './analyzer';
 import {Bundler} from './bundle';
@@ -29,9 +30,11 @@ import {PrefetchTransform} from './prefetch';
 import {waitForAll, compose, ForkedVinylStream} from './streams';
 import {generateServiceWorker, parsePreCacheConfig, SWConfig} from './sw-precache';
 
+
 // non-ES compatible modules
 const findConfig = require('liftoff/lib/find_config');
 const minimatchAll = require('minimatch-all');
+let logger = logging.getLogger('cli.build.build');
 
 export interface BuildOptions {
   sources?: string[];

--- a/src/build/bundle.ts
+++ b/src/build/bundle.ts
@@ -13,6 +13,7 @@ import * as gulpif from 'gulp-if';
 import * as path from 'path';
 import {Transform} from 'stream';
 import File = require('vinyl');
+import * as logging from 'plylog';
 
 import {StreamAnalyzer, DepsIndex} from './analyzer';
 import {Logger} from './logger';
@@ -22,6 +23,7 @@ import {compose} from './streams';
 const minimatchAll = require('minimatch-all');
 const through = require('through2').obj;
 const Vulcanize = require('vulcanize');
+let logger = logging.getLogger('cli.build.bundle');
 
 export class Bundler extends Transform {
 
@@ -101,15 +103,15 @@ export class Bundler extends Transform {
   _buildBundles(): Promise<Map<string, string>> {
     return this._getBundles().then((bundles) => {
       if (this._verboseLogging) {
-        console.log('bundles:');
+        logger.info('bundles:');
         for (let url of bundles.keys()) {
           let deps = bundles.get(url);
           if (!deps) {
-            console.log('    no deps?');
+            logger.info('    no deps?');
           } else {
-            console.log(`  ${url} (${deps.length}):`);
+            logger.info(`  ${url} (${deps.length}):`);
             for (let dep of deps) {
-              console.log(`    ${dep}`);
+              logger.info(`    ${dep}`);
             }
           }
         }
@@ -149,7 +151,7 @@ export class Bundler extends Transform {
               reject(err);
             } else {
               if (this._verboseLogging) {
-                console.log(`vulcanized doc for ${fragment}: ${doc.length}`);
+                logger.info(`vulcanized doc for ${fragment}: ${doc.length}`);
               }
               resolve({
                 url: fragment,
@@ -222,7 +224,7 @@ export class Bundler extends Transform {
           .join('\n');
 
       if (this._verboseLogging) {
-        console.log('shared-bundle.html:\n', contents);
+        logger.info('shared-bundle.html:\n', contents);
       }
 
       this.sharedFile = new File({

--- a/src/build/logger.ts
+++ b/src/build/logger.ts
@@ -8,16 +8,19 @@
  * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
  */
 import * as stream from 'stream';
+import * as logging from 'plylog';
 import File = require('vinyl');
 
+let logger = logging.getLogger('cli.build.stream-transform');
+
 export class Logger extends stream.Transform {
-  prefix: String;
+  prefix: string;
   constructor(prefix: string) {
     super({objectMode: true});
     this.prefix = prefix || '';
   }
   _transform(file: File, encoding: string, callback: (error?, data?) => void): void {
-    console.log(this.prefix, file.path);
+    logger.info(this.prefix, file.path);
     callback(null, file);
   }
 }
@@ -29,7 +32,7 @@ export class StreamLogger extends stream.Transform {
     this.prefix = prefix || '';
   }
   _transform(buffer: Buffer, encoding: string, callback: (error?, data?) => void): void {
-    console.log(this.prefix, buffer.toString('base64'));
+    logger.info(this.prefix, buffer.toString('base64'));
     callback(null, buffer);
   }
 }

--- a/src/build/prefetch.ts
+++ b/src/build/prefetch.ts
@@ -10,10 +10,13 @@
 
 import * as dom5 from 'dom5';
 import * as path from 'path';
+import * as logging from 'plylog';
 import {Transform} from 'stream';
 import File = require('vinyl');
 
 import {StreamAnalyzer, DepsIndex} from './analyzer';
+
+let logger = logging.getLogger('cli.build.prefech');
 
 export class PrefetchTransform extends Transform {
   root: string;
@@ -132,8 +135,8 @@ export class PrefetchTransform extends Transform {
       }
 
       for (let leftover of this.fileMap.keys()) {
-        console.log(
-          'Warning: File was listed in fragments but not found in stream:',
+        logger.warn(
+          'File was listed in fragments but not found in stream:',
           leftover
         );
         this.push(this.fileMap.get(leftover));

--- a/src/build/stream-resolver.ts
+++ b/src/build/stream-resolver.ts
@@ -14,8 +14,10 @@ import * as path from 'path';
 import {Transform} from 'stream';
 import File = require('vinyl');
 import * as url from 'url';
+import * as logging from 'plylog';
 
 const minimatchAll = require('minimatch-all');
+let logger = logging.getLogger('cli.build.stream-resolver');
 
 export interface FileGetter {
   (filePath: string, deferred: Deferred<string>): void;
@@ -127,7 +129,7 @@ export class StreamResolver extends Transform /* implements Resolver */ {
         deferred.resolve(file.contents.toString());
       } else {
         if (this._deferreds.has(local)) {
-          console.warn(`${local} already requested`);
+          logger.warn(`${local} already requested`);
         }
         // Otherwise save the deffered to resolve later
         this._deferreds.set(local, deferred);

--- a/src/build/sw-precache.ts
+++ b/src/build/sw-precache.ts
@@ -10,12 +10,14 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
+import * as logging from 'plylog';
 import {PassThrough} from 'stream';
 import File = require('vinyl');
 
 // non-ES compatible modules
 const swPrecache = require('sw-precache');
 const Module = require('module');
+let logger = logging.getLogger('cli.build.sw-precache');
 
 export interface SWConfig {
   cacheId?: string,
@@ -70,7 +72,7 @@ export function generateServiceWorker(options: GenerateServiceWorkerOptions)
   // static files will be pre-cached
   swConfig.staticFileGlobs = precacheList;
 
-  console.log(`Generating service worker for ${options.buildRoot}`);
+  logger.info(`Generating service worker for ${options.buildRoot}`);
 
   return swPrecache.write(options.serviceWorkerPath, swConfig);
 }
@@ -84,8 +86,8 @@ export function parsePreCacheConfig(configFile: string): Promise<SWConfig> {
         try {
           config = require(configFile);
         } catch(e) {
-          console.error(`Could not load sw-precache config from ${configFile}`);
-          console.error(e);
+          logger.error(`Could not load sw-precache config from ${configFile}`);
+          logger.error(e);
         }
       }
       resolve(config);

--- a/src/build/uglify-transform.ts
+++ b/src/build/uglify-transform.ts
@@ -10,9 +10,11 @@
 
 import {Transform} from 'stream';
 import * as uglify from 'uglify-js';
+import * as logging from 'plylog';
 import File = require('vinyl');
 
-const UglifyOptions: uglify.MinifyOptions = {fromString: true};
+let logger = logging.getLogger('cli.build.uglify');
+const UglifyOptions: uglify.MinifyOptions = { fromString: true };
 
 export class UglifyTransform extends Transform {
 
@@ -27,7 +29,7 @@ export class UglifyTransform extends Transform {
         contents = uglify.minify(contents, UglifyOptions).code;
         file.contents = new Buffer(contents);
       } catch (err) {
-        console.error('Could not uglify',file.path);
+        logger.error('Could not uglify', file.path);
       }
     }
     callback(null, file);

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -12,6 +12,10 @@ import {ArgDescriptor} from 'command-line-args';
 import {CLI} from 'command-line-commands';
 
 import {Command} from './command';
+import * as logging from 'plylog';
+
+let logger = logging.getLogger('cli.build');
+
 
 export class BuildCommand implements Command {
   name = 'build';
@@ -40,9 +44,15 @@ export class BuildCommand implements Command {
       sources: options.sources,
       swPrecacheConfig: options['sw-precache-config']
     };
+    logger.debug('building with options', buildOptions);
+
     if (options.env && options.env.build) {
+      logger.debug('env.build() found in options');
+      logger.debug('building via env.build()...');
       return options.env.build(buildOptions, config);
     }
+
+    logger.debug('building via build()...');
     return build(buildOptions, config);
   }
 }

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -11,6 +11,10 @@
 import * as chalk from 'chalk';
 import {CLI} from 'command-line-commands';
 import * as commandLineArgs from 'command-line-args';
+import * as logging from 'plylog';
+
+let logger = logging.getLogger('cli.help');
+
 
 import {globalArguments} from '../args';
 import {Command} from './command';
@@ -69,6 +73,7 @@ export class HelpCommand implements Command {
         return;
       }
 
+      logger.debug('logging help for command', command.name);
       let argsCli = commandLineArgs(command.args);
       console.log(argsCli.getUsage({
         title: `polymer ${command.name}`,

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -14,6 +14,9 @@ import * as fs from 'fs';
 import * as logging from 'plylog';
 import * as chalk from 'chalk';
 
+let logger = logging.getLogger('cli.init');
+
+
 export class InitCommand implements Command {
   name = 'init';
 
@@ -37,8 +40,6 @@ export class InitCommand implements Command {
     const YeomanEnvironment = require('yeoman-environment');
 
     return new Promise((resolve, reject) => {
-      let logger = logging.getLogger('cli.init');
-
       logger.debug('creating yeoman environment...');
 
       let env = new YeomanEnvironment();

--- a/src/commands/lint.ts
+++ b/src/commands/lint.ts
@@ -13,7 +13,9 @@ import * as logging from 'plylog';
 
 import {Command} from './command';
 
+let logger = logging.getLogger('cli.lint');
 const polylint = require('polylint/lib/cli');
+
 
 export class LintCommand implements Command {
   name = 'lint';
@@ -55,8 +57,6 @@ export class LintCommand implements Command {
   ];
 
   run(options, config): Promise<any> {
-    let logger = logging.getLogger('cli.lint');
-
     if (config.inputs.length === 0) {
       let argsCli = commandLineArgs(this.args);
 

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -12,6 +12,10 @@ import {startServer, args as polyserveArgs} from 'polyserve';
 import {ServerOptions} from 'polyserve/lib/start_server';
 import {Command} from './command';
 import {Environment} from '../environment/environment';
+import * as logging from 'plylog';
+
+let logger = logging.getLogger('cli.serve');
+
 
 export class ServeCommand implements Command {
   name = 'serve';
@@ -61,7 +65,7 @@ export class ServeCommand implements Command {
   ];
 
   run(options, config): Promise<any> {
-    var serverOptions: ServerOptions = {
+    let serverOptions: ServerOptions = {
       root: config.root,
       port: options.port,
       hostname: options.hostname,
@@ -71,12 +75,16 @@ export class ServeCommand implements Command {
       packageName: options['package-name'],
     };
 
+    logger.debug('serving with options', serverOptions);
     const env: Environment = options.env;
 
     if (env && env.serve) {
-        return env.serve(serverOptions);
+      logger.debug('env.serve() found in options');
+      logger.debug('serving via env.serve()...');
+      return env.serve(serverOptions);
     }
 
+    logger.debug('serving via startServer()...');
     return startServer(serverOptions);
   }
 }

--- a/src/init/github.ts
+++ b/src/init/github.ts
@@ -11,6 +11,9 @@ import * as fs from 'fs';
 import {Github} from '../github/github';
 import * as path from 'path';
 import {Base} from 'yeoman-generator';
+import * as logging from 'plylog';
+
+let logger = logging.getLogger('cli.init');
 
 export interface GithubGeneratorOptions {
   requestApi?;
@@ -44,15 +47,14 @@ export function createGithubGenerator(githubOptions: GithubGeneratorOptions) {
 
     writing() {
       let done = this.async();
-      console.log(`Downloading latest release of ${owner}/${repo}`);
+      logger.info(`Downloading latest release of ${owner}/${repo}`);
       return this._github.extractLatestRelease(this.destinationRoot())
         .then(() => {
           done();
         })
         .catch((error) => {
-          console.error(`Could not download release from ${owner}/${repo}`);
-          console.error(error);
-          done();
+          logger.error(`Could not download release from ${owner}/${repo}`);
+          done(error);
         });
     }
 

--- a/test/commands/cli_test.js
+++ b/test/commands/cli_test.js
@@ -72,10 +72,11 @@ suite('The general CLI', () => {
   });
 
   test('sets the appropriate log levels when the --verbose & --quiet flags are used', () => {
+    let logger = logging.getLogger('TEST_LOGGER');
     let cli = new PolymerCli(['help', '--verbose']);
-    assert.equal(logging.level, 'debug');
+    assert.equal(logger.level, 'debug');
     let cli2 = new PolymerCli(['help', '--quiet']);
-    assert.equal(logging.level, 'error');
+    assert.equal(logger.level, 'error');
   });
 
 });


### PR DESCRIPTION
Everything old is using the new logger. All thats left to move over is within the smaller packages that polymer-cli pulls in.