### PR TITLE
Make sure unbundled precache deps list is complete

### DIFF
--- a/src/build/build.ts
+++ b/src/build/build.ts
@@ -130,7 +130,9 @@ export function build(options?: BuildOptions, config?: ProjectConfig): Promise<a
     waitForAll([unbundledPhase, bundledPhase])
       .then(() => analyzer.analyze)
       .then((depsIndex) => {
-        let unbundledDeps = Array.from(depsIndex.depsToFragments.keys());
+        let unbundledDeps = analyzer.allFragments
+            .concat(Array.from(depsIndex.depsToFragments.keys()));
+
         let bundledDeps = analyzer.allFragments
             .concat(bundler.sharedBundleUrl);
 


### PR DESCRIPTION
Include all the fragments and shell, just as bundled build does

Fixes #128 Unbundled build is missing fragments and shell in sw-precache