### PR TITLE
Prettify the main help screen

### DIFF
--- a/custom_typings/command-line-args.d.ts
+++ b/custom_typings/command-line-args.d.ts
@@ -11,11 +11,13 @@ declare module 'command-line-args' {
       type?: Object;
       multiple?: boolean;
       defaultOption?: boolean;
+      group?: string;
     }
     interface UsageOpts {
       title?: string;
       header?: string;
       description?: string;
+      groups?: any;
     }
     interface CLI {
       parse(): any;

--- a/custom_typings/command-line-commands.d.ts
+++ b/custom_typings/command-line-commands.d.ts
@@ -9,7 +9,7 @@ declare module 'command-line-commands' {
 
     interface Command {
       name: string;
-      options: {[name: string]: string};
+      options: {[name: string]: string|{[name: string]: string}};
     }
 
     interface CLI {

--- a/src/args.ts
+++ b/src/args.ts
@@ -1,0 +1,64 @@
+/**
+ * @license
+ * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ */
+
+import {ArgDescriptor} from './commands/command';
+import {Environment} from './environment/environment'
+import {buildEnvironment} from './environments/environments'
+
+export const globalArguments: ArgDescriptor[] = [
+  {
+    name: 'env',
+    description: 'The environment to use to specialize certain commands, '
+        + 'like build',
+    type: function(value): Environment {
+      return buildEnvironment(value);
+    },
+    group: 'global',
+  },
+  {
+    name: 'entrypoint',
+    description: 'The main HTML file that will requested for all routes.',
+    group: 'global',
+  },
+  {
+    name: 'shell',
+    type: String,
+    description: 'The app shell HTML import',
+    group: 'global',
+  },
+  {
+    name: 'fragment',
+    type: String,
+    multiple: true,
+    description: 'HTML imports that are loaded on-demand.',
+    group: 'global',
+  },
+  {
+    name: 'root',
+    type: String,
+    description: 'The directory in which to find sources and place build. ' +
+        'Defaults to current working directory',
+        group: 'global',
+  },
+  {
+    name: 'verbose',
+    description: 'turn on debugging output',
+    type: Boolean,
+    alias: 'v',
+    group: 'global',
+  },
+  {
+    name: 'quiet',
+    description: 'silence output',
+    type: Boolean,
+    alias: 'q',
+    group: 'global',
+  },
+];

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -1,6 +1,19 @@
-import {Command} from './command';
+/**
+ * @license
+ * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ */
+
+import * as chalk from 'chalk';
 import {CLI} from 'command-line-commands';
 import * as commandLineArgs from 'command-line-args';
+
+import {globalArguments} from '../args';
+import {Command} from './command';
 
 export class HelpCommand implements Command {
   name = 'help';
@@ -20,16 +33,28 @@ export class HelpCommand implements Command {
   }
 
   printGeneralUsage() {
-    console.log(`\nUsage: polymer <command>\n`);
-    console.log(`polymer supports the following commands:`);
+    console.log(helpHeader);
+    console.log(chalk.bold.underline(`Available Commands\n`));
     for (let command of this.commands.values()) {
-      console.log(`  ${command.name}\t\t${command.description}`);
+      console.log(`  ${chalk.bold(command.name)}\t\t${command.description}`);
     }
-    console.log(`\nRun \`polymer help <command>\` for help with a specific command.\n`);
+    this.printGlobalOptions();
+    console.log(`\nRun \`polymer help <command>\` for help with a specific ` +
+        `command.\n`);
+  }
+
+  printGlobalOptions() {
+    let globalCli = commandLineArgs(globalArguments);
+    console.log(globalCli.getUsage({
+      groups: {
+        global: 'Global Options',
+      }
+    }));
   }
 
   run(options, config): Promise<any> {
     return new Promise<any>((resolve, _) => {
+
       if (!options || !options.command) {
         this.printGeneralUsage();
         resolve(null);
@@ -37,6 +62,7 @@ export class HelpCommand implements Command {
       }
 
       let command = this.commands.get(options.command);
+
       if (!command) {
         this.printGeneralUsage();
         resolve(null);
@@ -48,7 +74,25 @@ export class HelpCommand implements Command {
         title: `polymer ${command.name}`,
         description: command.description,
       }));
+      this.printGlobalOptions();
       resolve(null);
     });
   }
 }
+
+const h = chalk.bold.underline;
+const b = chalk.blue;
+const m = chalk.magenta;
+const title = h('Polymer-CLI');
+const description = 'The multi-tool for Polymer projects';
+const usage = 'Usage: \`polymer <command> [options ...]\`';
+
+const helpHeader = '\n' +
+    b('   /\\˜˜/   ') + m('/\\˜˜/') + b('\\   ') + '\n' +
+    b('  /__\\/   ') + m('/__\\/') + b('__\\  ') + '  ' + title + '\n' +
+    b(' /\\  /   ') + m('/\\  /') + b('\\  /\\ ') + '\n' +
+    b('/__\\/   ') + m('/__\\/  ') + b('\\/__\\') + '  ' + description + '\n' +
+    b('\\  /\\  ') + m('/\\  /   ') + b('/\\  /') + '\n' +
+    b(' \\/__\\') + m('/__\\/   ') + b('/__\\/ ') + '  ' + usage + '\n' +
+    b('  \\  ') + m('/\\  /   ') + b('/\\  /  ') + '\n' +
+    b('   \\') + m('/__\\/   ') + b('/__\\/   ') + '\n';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,6 +23,7 @@
     "node_modules/typescript/lib/lib.core.es6.d.ts"
   ],
   "files": [
+    "src/args.ts",
     "src/build/analyzer.ts",
     "src/build/build.ts",
     "src/build/bundle.ts",


### PR DESCRIPTION
This groups options so we can show the global options for each command.

Also adds the polymer logo :)

```

   /\˜˜/   /\˜˜/\   
  /__\/   /__\/__\    Polymer-CLI
 /\  /   /\  /\  /\ 
/__\/   /__\/  \/__\  The multi-tool for Polymer projects
\  /\  /\  /   /\  /
 \/__\/__\/   /__\/   Usage: `polymer <command> [options ...]`
  \  /\  /   /\  /  
   \/__\/   /__\/   

Available Commands

  build		Builds an application-style project
  help		Shows this help message, or help for a specific command
  init		Initializes a Polymer project
  lint		Lints the project
  serve		Runs the polyserve development server
  test		Runs web-component-tester

Global Options

  --env                 The environment to use to specialize certain commands, like build             
  --entrypoint          The main HTML file that will requested for all routes.                        
  --shell string        The app shell HTML import                                                     
  --fragment string[]   HTML imports that are loaded on-demand.                                       
  --root string         The directory in which to find sources and place build. Defaults to current   
                        working directory                                                             
  -v, --verbose         turn on debugging output                                                      
  -q, --quiet           silence output                                                                


Run `polymer help <command>` for help with a specific command.

```