### PR TITLE
serve: -o opens app-shell projects to the entrypoint, not the component

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "multipipe": "^0.3.0",
     "plylog": "^0.4.0",
     "polylint": "^2.10.0",
-    "polyserve": "^0.11.0",
+    "polyserve": "^0.12.0",
     "request": "^2.72.0",
     "resolve": "^1.1.7",
     "sw-precache": "^3.1.1",

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -69,11 +69,20 @@ export class ServeCommand implements Command {
   ];
 
   run(options, config): Promise<any> {
+    let openPath;
+    if (config.entrypoint && config.shell) {
+      let rootLength = (config.root && config.root.length) || 0;
+      openPath = config.entrypoint.substring(config.root.length);
+      if (openPath == 'index.html' || openPath == '/index.html') {
+        openPath = '/';
+      }
+    }
     let serverOptions: ServerOptions = {
       root: config.root,
       port: options.port,
       hostname: options.hostname,
       open: options.open,
+      openPath: openPath,
       browser: options.browser,
       componentDir: options['component-dir'],
       packageName: options['package-name'],


### PR DESCRIPTION
Fixes #158 