### PR TITLE
Fix issue where polymer-cli throws when help flag is provided alone

### DIFF
--- a/src/args.ts
+++ b/src/args.ts
@@ -55,6 +55,13 @@ export const globalArguments: ArgDescriptor[] = [
     group: 'global',
   },
   {
+    name: 'help',
+    description: 'print out helpful usage information',
+    type: Boolean,
+    alias: 'h',
+    group: 'global',
+  },
+  {
     name: 'quiet',
     description: 'silence output',
     type: Boolean,

--- a/test/commands/cli_test.js
+++ b/test/commands/cli_test.js
@@ -27,7 +27,16 @@ suite('The general CLI', () => {
     let helpCommandSpy = sinon.spy(helpCommand, 'run');
     cli.run();
     assert.isOk(helpCommandSpy.calledOnce);
-    assert.deepEqual(helpCommandSpy.firstCall.args, [undefined, defaultConfig]);
+    assert.deepEqual(helpCommandSpy.firstCall.args, [{}, defaultConfig]);
+  });
+
+  test('displays general help when no command is called with the --help flag', () => {
+    let cli = new PolymerCli(['--help']);
+    let helpCommand = cli.commands.get('help');
+    let helpCommandSpy = sinon.spy(helpCommand, 'run');
+    cli.run();
+    assert.isOk(helpCommandSpy.calledOnce);
+    assert.deepEqual(helpCommandSpy.firstCall.args, [{}, defaultConfig]);
   });
 
   test('displays general help when unknown command is called', () => {
@@ -36,7 +45,7 @@ suite('The general CLI', () => {
     let helpCommandSpy = sinon.spy(helpCommand, 'run');
     cli.run();
     assert.isOk(helpCommandSpy.calledOnce);
-    assert.deepEqual(helpCommandSpy.firstCall.args, [undefined, defaultConfig]);
+    assert.deepEqual(helpCommandSpy.firstCall.args, [{}, defaultConfig]);
   });
 
   test('displays command help when called with the --help flag', () => {


### PR DESCRIPTION
Fixes #189. Also gets rid of the last, now-unnecessary manual args parsing and replaces it with our more robust global-argument handling.

/cc @justinfagnani 