### PR TITLE
Update call to copyTpl() to not throw in latest ejs

### DIFF
--- a/src/init/application/application.ts
+++ b/src/init/application/application.ts
@@ -66,11 +66,7 @@ export class ApplicationGenerator extends Base {
     let elementName = this.props.elementName;
 
     this.fs.copyTpl(
-      [
-        `${this.templatePath()}/**/*`,
-        `${this.templatePath()}/**/.*`,
-        `!**/_*`,
-      ],
+      `${this.templatePath()}/**/?(.)!(_)*`,
       this.destinationPath(),
       this.props);
 

--- a/src/init/element/element.ts
+++ b/src/init/element/element.ts
@@ -62,11 +62,7 @@ export class ElementGenerator extends Base {
     let name = this.props.name;
 
     this.fs.copyTpl(
-      [
-        `${this.templatePath()}/**/*`,
-        `${this.templatePath()}/**/.*`,
-        `!**/_*`,
-      ],
+      `${this.templatePath()}/**/?(.)!(_)*`,
       this.destinationPath(),
       this.props);
 

--- a/test/init/application_test.js
+++ b/test/init/application_test.js
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ */
+
+'use strict';
+
+const yoAssert = require('yeoman-assert');
+const helpers = require('yeoman-test');
+const ApplicationGenerator
+  = require('../../lib/init/application/application').ApplicationGenerator;
+
+suite('init/application', () => {
+
+  test('creates expected files while ignoring filenames with dangling underscores', (done) => {
+
+    helpers
+      .run(ApplicationGenerator)
+      .on('end', (a) => {
+        yoAssert.file(['bower.json']);
+        yoAssert.noFile(['src/_element/_element.html']);
+        done();
+      });
+
+  });
+
+});

--- a/test/init/element_test.js
+++ b/test/init/element_test.js
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ */
+
+'use strict';
+
+const yoAssert = require('yeoman-assert');
+const helpers = require('yeoman-test');
+const ElementGenerator
+  = require('../../lib/init/element/element').ElementGenerator;
+
+suite('init/element', () => {
+
+  test('creates expected files while ignoring filenames with dangling underscores', (done) => {
+
+    helpers
+      .run(ElementGenerator)
+      .on('end', (a) => {
+        yoAssert.file(['bower.json']);
+        yoAssert.noFile(['_element.html']);
+        done();
+      });
+
+  });
+
+});

--- a/test/init/github_test.js
+++ b/test/init/github_test.js
@@ -15,8 +15,8 @@ const path = require('path');
 const yoAssert = require('yeoman-assert');
 const helpers = require('yeoman-test');
 
-const createGithubGenerator =
-    require('../../lib/init/github.js').createGithubGenerator;
+const createGithubGenerator
+  = require('../../lib/init/github').createGithubGenerator;
 
 suite('init/github', () => {
 


### PR DESCRIPTION
This bug was introduced by a breaking change in `mem-fs-editor`/`ejs`, that caused a previously supported behavior to throw. While original behavior may be restored downstream, we can fix this problem for ourselves today with this PR. See https://github.com/Polymer/polymer-cli/issues/206#issuecomment-221736928 for more info.

/cc @justinfagnani 