### PR TITLE
Remove duplicate temp dependency in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
     "gulp-typings": "^1.3.6",
     "run-sequence": "^1.2.0",
     "sinon": "^1.17.4",
-    "temp": "^0.8.3",
     "tslint": "^3.10.2",
     "vinyl-fs-fake": "^1.1.0",
     "yeoman-assert": "^2.2.1",


### PR DESCRIPTION
This is causing npm warnings on install

/cc @justinfagnani 