### PR TITLE
Remove silently failing depcheck task from build-all task

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -26,7 +26,7 @@ const tsProject = typescript.createProject('tsconfig.json');
 
 gulp.task('init', () => gulp.src("./typings.json").pipe(typings()));
 
-gulp.task('lint', ['tslint', 'eslint', 'depcheck']);
+gulp.task('lint', ['tslint', 'eslint']);
 
 gulp.task('build', () =>
   mergeStream(


### PR DESCRIPTION
This will allow polymer-cli to build properly until we can figure out why `depcheck` is silently failing.

@justinfagnani suggest merging and pushing out a new patch version asap