### PR TITLE
Remove unused generator-polymer-init dependency

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -65,7 +65,7 @@ gulp.task('eslint', () =>
     .pipe(eslint.failAfterError()));
 
 gulp.task('depcheck', () =>
-  depcheck(__dirname, {ignoreMatches: ['generator-polymer-init']})
+  depcheck(__dirname, {})
     .then((result) => {
       let invalidFiles = Object.keys(result.invalidFiles) || [];
       let invalidJsFiles = invalidFiles.filter((f) => f.endsWith('.js'));

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "dom5": "^1.3.1",
     "findup": "^0.1.5",
     "fs-extra": "^0.30.0",
-    "generator-polymer-init": "^0.0.3",
     "github": "^0.2.4",
     "gulp": "^3.9.1",
     "gulp-html-minifier": "^0.1.8",


### PR DESCRIPTION
element & application templates are now internal to polymer-cli.

I'll add a deprecation notice to the `generator-polymer-init` README as well.

/cc @garlicnation 