### PR TITLE
Add demo and description for element template

### DIFF
--- a/src/init/element/templates/_element.html
+++ b/src/init/element/templates/_element.html
@@ -1,5 +1,11 @@
 <link rel="import" href="../polymer/polymer.html">
 
+<!--
+    <%= description %>
+    
+    @demo demo/index.html 
+-->
+
 <dom-module id="<%= name %>">
   <template>
     <style>

--- a/src/init/element/templates/_element.html
+++ b/src/init/element/templates/_element.html
@@ -1,9 +1,10 @@
 <link rel="import" href="../polymer/polymer.html">
 
 <!--
-    <%= description %>
-    
-    @demo demo/index.html 
+`<%= name %>`
+<%= description %>
+
+@demo demo/index.html 
 -->
 
 <dom-module id="<%= name %>">


### PR DESCRIPTION
Currently there is no demo reference in the element template.
Thus when creating a new element and serving it, there is no demo option, although the demo folder and demo template are created. It will be more consistent to include the demo reference (`@demo`) given that the demo template is provided.