### PR TITLE
Refactor project-config to make polymer-cli testable /w configuration

### DIFF
--- a/test/commands/lint_test.js
+++ b/test/commands/lint_test.js
@@ -1,0 +1,44 @@
+/**
+ * @license
+ * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ */
+
+'use strict';
+
+const path = require('path');
+const assert = require('chai').assert;
+const ProjectConfig = require('../../lib/project-config').ProjectConfig;
+const PolymerCli = require('../../lib/polymer-cli').PolymerCli;
+const polylintCli = require('polylint/lib/cli');
+const sinon = require('sinon');
+
+suite('lint', () => {
+
+  let polylintCliStub;
+
+  setup(function() {
+    polylintCliStub = sinon.stub(polylintCli, 'runWithOptions').returns(Promise.resolve());
+  });
+
+  teardown(() => {
+    polylintCliStub.restore();
+  });
+
+  test('lints the entrypoint, shell, and fragments when no specific inputs are given', () => {
+    let testLintConfig = new ProjectConfig(null, {
+      entrypoint: 'index.html',
+      fragments: ['foo.html'],
+      shell: 'bar.html',
+    });
+    let cli = new PolymerCli(['lint'], testLintConfig);
+    cli.run();
+    assert.isOk(polylintCliStub.calledOnce);
+    assert.deepEqual(polylintCliStub.firstCall.args[0].input, [`${path.sep}index.html`, `${path.sep}bar.html`, `${path.sep}foo.html`]);
+  });
+
+});

--- a/test/config/project-config_test.js
+++ b/test/config/project-config_test.js
@@ -14,7 +14,16 @@ const path = require('path');
 const ProjectConfig = require('../../lib/project-config').ProjectConfig;
 
 suite('Project Config', () => {
-  test('sane defaults', () => {
+
+  test('reads options from config file', () => {
+    let defaultOptions = ProjectConfig.fromConfigFile(path.join(__dirname, 'polymer.json'));
+    assert.deepEqual(defaultOptions, {
+      entrypoint: 'foo.html',
+      fragments: ['bar.html'],
+    });
+  });
+
+  test('sane config defaults', () => {
     let config = new ProjectConfig();
     assert.equal(config.root, process.cwd());
     assert.equal(config.entrypoint, path.resolve('index.html'));
@@ -22,7 +31,15 @@ suite('Project Config', () => {
     assert.deepEqual(config.fragments, []);
   });
 
-  test('read from flags', () => {
+  test('sets config from options object', () => {
+    let defaultOptions = ProjectConfig.fromConfigFile(path.join(__dirname, 'polymer.json'));
+    let config = new ProjectConfig(defaultOptions);
+    assert.equal(config.root, process.cwd());
+    assert.equal(config.entrypoint, path.resolve('foo.html'));
+    assert.deepEqual(config.fragments, [path.resolve('bar.html')])
+  });
+
+  test('read config from flags', () => {
     let config = new ProjectConfig(null, {
       entrypoint: 'index.html',
       fragments: ['foo.html'],
@@ -34,15 +51,9 @@ suite('Project Config', () => {
     assert.deepEqual(config.fragments, [path.resolve('foo.html')]);
   });
 
-  test('inits from config file', () => {
-    let config = new ProjectConfig(path.join(__dirname, 'polymer.json'));
-    assert.equal(config.root, process.cwd());
-    assert.equal(config.entrypoint, path.resolve('foo.html'));
-    assert.deepEqual(config.fragments, [path.resolve('bar.html')])
-  });
-
-  test('flags override config file', () => {
-    let config = new ProjectConfig(path.join(__dirname, 'polymer.json'), {
+  test('flags override default config values', () => {
+    let defaultOptions = ProjectConfig.fromConfigFile(path.join(__dirname, 'polymer.json'));
+    let config = new ProjectConfig(defaultOptions, {
       entrypoint: 'bar.html',
       fragments: [],
       shell: 'zizz.html',


### PR DESCRIPTION
I was running into problems testing different commands with different configurations, so I've refactored `polymer-cli` & `project-configuration` to read from an optional configuration object when given, instead of always reading directly from file.

#232 illustrates this usefulness, which I've split out from this work for clarity.

/cc @justinfagnani @garlicnation 