### PR TITLE
Add input support for lint command

### DIFF
--- a/src/commands/lint.ts
+++ b/src/commands/lint.ts
@@ -21,6 +21,14 @@ export class LintCommand implements Command {
 
   args = [
     {
+      name: 'input',
+      type: String,
+      alias: 'i',
+      defaultOption: true,
+      multiple: true,
+      description: 'Files and/or folders to lint. Exclusive. Defaults to cwd.'
+    },
+    {
       name: 'policy',
       type: String,
       alias: 'p',
@@ -45,10 +53,21 @@ export class LintCommand implements Command {
       )
     },
     {
-      name: 'no-recursion',
+      name: 'follow-dependencies',
       type: Boolean,
       description: (
-        'Only report errors on specified input files, not from their dependencies.'
+        'Follow through and lint dependencies. This is default behavior ' +
+        'when linting your entire application via the entrypoint, shell, ' +
+        'and fragment arguments.'
+      )
+    },
+    {
+      name: 'no-follow-dependencies',
+      type: Boolean,
+      description: (
+        'Only lint the files provided, ignoring dependencies. This is ' +
+        'default behavior when linting a specific list of files provided ' +
+        'via the input argument.'
       )
     }
   ];
@@ -57,12 +76,12 @@ export class LintCommand implements Command {
     // Defer dependency loading until this specific command is run
     const polylint = require('polylint/lib/cli');
 
-    if (config.inputs.length === 0) {
+    let lintFiles: string[] = options.input
+      || config.inputs.map((i) => i.substring(config.root.length));
+    if (lintFiles.length === 0) {
+      logger.warn('No inputs specified. Please use the --input, --entrypoint, ' +
+        '--shell or --fragment flags');
       let argsCli = commandLineArgs(this.args);
-
-      logger.warn('No inputs specified. Please use the --entrypoint, --shell ' +
-          'or --fragment flags');
-
       console.info(argsCli.getUsage({
         title: `polymer ${this.name}`,
         description: this.description,
@@ -70,15 +89,24 @@ export class LintCommand implements Command {
       return Promise.resolve();
     }
 
+    // Default to false if input files are provided, otherwise default to true
+    let followDependencies = !options.input;
+    if (options['follow-dependencies']) {
+      followDependencies = true;
+    } else if (options['no-follow-dependencies']) {
+      followDependencies = false;
+    }
+
     return polylint.runWithOptions({
-      input: config.inputs.map((i) => i.substring(config.root.length)),
+      input: lintFiles,
       root: config.root,
       // TODO: read into config
       bowerdir: 'bower_components',
       policy: options.policy,
       'config-file': options['config-file'],
       'config-field': options['config-field'],
-      'no-recursion': options['no-recursion'],
+      // NOTE: `no-recursion` has the opposite behavior of `follow-dependencies`
+      'no-recursion': !followDependencies,
     }).then(() => null);
   }
 }

--- a/test/commands/lint_test.js
+++ b/test/commands/lint_test.js
@@ -20,9 +20,15 @@ const sinon = require('sinon');
 suite('lint', () => {
 
   let polylintCliStub;
+  let defaultTestConfig;
 
   setup(function() {
     polylintCliStub = sinon.stub(polylintCli, 'runWithOptions').returns(Promise.resolve());
+    defaultTestConfig = new ProjectConfig(null, {
+      entrypoint: 'index.html',
+      fragments: ['foo.html'],
+      shell: 'bar.html',
+    });
   });
 
   teardown(() => {
@@ -30,15 +36,56 @@ suite('lint', () => {
   });
 
   test('lints the entrypoint, shell, and fragments when no specific inputs are given', () => {
-    let testLintConfig = new ProjectConfig(null, {
-      entrypoint: 'index.html',
-      fragments: ['foo.html'],
-      shell: 'bar.html',
-    });
-    let cli = new PolymerCli(['lint'], testLintConfig);
+    let cli = new PolymerCli(['lint'], defaultTestConfig);
     cli.run();
     assert.isOk(polylintCliStub.calledOnce);
-    assert.deepEqual(polylintCliStub.firstCall.args[0].input, [`${path.sep}index.html`, `${path.sep}bar.html`, `${path.sep}foo.html`]);
+    assert.deepEqual(polylintCliStub.firstCall.args[0].input, [
+      `${path.sep}index.html`,
+      `${path.sep}bar.html`,
+      `${path.sep}foo.html`,
+    ]);
+  });
+
+  test('lints the given files when provided through the `input` argument', () => {
+    let cli = new PolymerCli(['lint', '--input', 'PATH/TO/TEST_THIS_FILE.html'], defaultTestConfig);
+    cli.run();
+    assert.isOk(polylintCliStub.calledOnce);
+    assert.deepEqual(polylintCliStub.firstCall.args[0].input, ['PATH/TO/TEST_THIS_FILE.html']);
+  });
+
+  test('lints the given files when provided through the default arguments', () => {
+    let cli = new PolymerCli(['lint', 'PATH/TO/TEST_THIS_FILE.html'], defaultTestConfig);
+    cli.run();
+    assert.isOk(polylintCliStub.calledOnce);
+    assert.deepEqual(polylintCliStub.firstCall.args[0].input, ['PATH/TO/TEST_THIS_FILE.html']);
+  });
+
+  test('follow and lint dependencies by default when no specific inputs are given', () => {
+    let cli = new PolymerCli(['lint'], defaultTestConfig);
+    cli.run();
+    assert.isOk(polylintCliStub.calledOnce);
+    assert.equal(polylintCliStub.firstCall.args[0]['no-recursion'], false);
+  });
+
+  test('does not follow and lint dependencies when specific inputs are given', () => {
+    let cli = new PolymerCli(['lint', 'PATH/TO/TEST_THIS_FILE.html'], defaultTestConfig);
+    cli.run();
+    assert.isOk(polylintCliStub.calledOnce);
+    assert.equal(polylintCliStub.firstCall.args[0]['no-recursion'], true);
+  });
+
+  test('follows and lint dependencies when "follow-dependencies" argument is true', () => {
+    let cli = new PolymerCli(['lint', '--follow-dependencies', 'PATH/TO/TEST_THIS_FILE.html'], defaultTestConfig);
+    cli.run();
+    assert.isOk(polylintCliStub.calledOnce);
+    assert.equal(polylintCliStub.firstCall.args[0]['no-recursion'], false);
+  });
+
+  test('does not follow and lint dependencies when "no-follow-dependencies" argument is true', () => {
+    let cli = new PolymerCli(['lint', '--no-follow-dependencies'], defaultTestConfig);
+    cli.run();
+    assert.isOk(polylintCliStub.calledOnce);
+    assert.equal(polylintCliStub.firstCall.args[0]['no-recursion'], true);
   });
 
 });


### PR DESCRIPTION
*NOTE: this is built off of the project-config work I just pushed into #231, so the "files changed" is currently a little noisy. See the individual commit for less noise.*

This adds support for linting of explicit files via the `input` default argument. This has been supported in our [polymer documentation](https://github.com/Polymer/docs2/blob/master/app/1.0/docs/tools/polymer-cli.md#lint-elements-lint) & README but was never actually supported by our code.

~~This also fixes an issue that seems to have been introduced with the Windows path fixes, by removing the leading slash that polylint was not expecting.~~ Pulling into its own PR

Fixes #227
/cc @justinfagnani @garlicnation 