### PR TITLE
Fix build bundling on windows

### DIFF
--- a/custom_typings/slash.d.ts
+++ b/custom_typings/slash.d.ts
@@ -1,0 +1,3 @@
+declare module 'slash' {
+  export function slash(source: string): string;
+}

--- a/test/build/bundle_test.js
+++ b/test/build/bundle_test.js
@@ -23,6 +23,7 @@ const Bundler = bundle.Bundler;
 const StreamAnalyzer = analyzer.StreamAnalyzer;
 
 const root = path.resolve('/root');
+var isPlatformWin = /^win/.test(process.platform);
 
 suite('Bundler', () => {
 
@@ -96,6 +97,21 @@ suite('Bundler', () => {
       ));
     return link != null;
   };
+
+  suite('urlFromPath()', () => {
+
+    // TODO(fschott): Get path-related tests working in multiple environments
+    if(!isPlatformWin) {
+      test('creates a URL path relative to root when called with a file path', () => setupTest({
+        entrypoint: 'entrypointA.html',
+        files: [framework(), entrypointA()],
+      }).then((files) => {
+        let urlPath = bundler.urlFromPath('/root/src/123.html');
+        assert.equal(urlPath, 'src/123.html');
+      }));
+    }
+
+  });
 
   test('entrypoint only', () => setupTest({
     entrypoint: 'entrypointA.html',


### PR DESCRIPTION
Fixes #222

Previously, we were relying on path.posix.normalize() to convert unix & windows paths to the posix path format, to be returned as a URL path. However, path.posix.normalize() doesn't convert windows paths to posix. Example:

```
> path.posix.normalize('/src/123.html')
'/src/123.html'
> path.posix.normalize('\\src\\123.html')
'\\src\\123.html // expected url format `/src/123/html`
```

Both @justinfagnani  and I have looked into this, and the conclusion is that Node does not support this conversion natively. 

This commit adds the [slash](https://www.npmjs.com/package/slash) library to handle this conversion instead. This is a simple, well-supported package used by babel and some other major projects.

Our original worry was that escaped back slashes would be incorrectly converted, but Windows will actually not allow any slashes in file names, escaped or otherwise. See:
\- http://stackoverflow.com/a/10708449
\- https://msdn.microsoft.com/en-us/library/windows/desktop/aa365247(v=vs.85).aspx

On Mac & Unix, backslashes are allowed in file names. This means that slash will not properly convert those strings:

```
> path.posix.normalize('/src/this_file_has_escaped\\_see.html')
'/src/this_file_has_escaped/_see.html'
```

However, the files we are converting and checking against are all meant for HTML import URL paths. Backward slashes are not allowed in URLs (RFC 2396) and most browsers will just convert them to forward slashes. So this case would already be erroneous, and as a result we do not really need to support it. One possible enhancement would be to throw a helpful error if we detect a backward slash in a posix formatted path, because right now we'll just silently convert it to a forward slash separator.