### PR TITLE
Add update-notify to notify users when their cli is out of date

### DIFF
--- a/bin/polymer.js
+++ b/bin/polymer.js
@@ -11,9 +11,16 @@
  * Code distributed by Google as part of the polymer project is also
  * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
  */
-var resolve = require('resolve');
-
 process.title = 'polymer';
+
+const resolve = require('resolve');
+const updateNotifier = require('update-notifier');
+const packageJson = require('../package.json');
+
+// Update Notifier: Asynchronously check for package updates and, if needed,
+// notify on the next time the CLI is run.
+// See https://github.com/yeoman/update-notifier#how for how this works.
+updateNotifier({pkg: packageJson}).notify();
 
 resolve('polymer-cli', {basedir: process.cwd()}, function(error, path) {
   let lib = path ? require(path) : require('..');

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "temp": "^0.8.3",
     "through2": "^2.0.1",
     "uglify-js": "^2.6.2",
+    "update-notifier": "^0.7.0",
     "vinyl": "^1.1.1",
     "vinyl-fs": "^2.4.3",
     "vulcanize": "^1.14.8",


### PR DESCRIPTION
Yeoman, Bower, web-component-tester, and a bunch of other familiar tools all use this tool to update users when their CLI is out of date. This should help version proliferation and solve headaches  for both users and developers (support costs).

/cc @garlicnation @justinfagnani 