### PR TITLE
Split url-from-path logic out and into its own file

### DIFF
--- a/src/build/url-from-path.ts
+++ b/src/build/url-from-path.ts
@@ -1,0 +1,57 @@
+/**
+ * @license
+ * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ */
+
+/**
+ * CODE ADAPTED FROM THE "SLASH" LIBRARY BY SINDRE SORHUS
+ * https://github.com/sindresorhus/slash
+ *
+ * ORIGINAL LICENSE:
+ * The MIT License (MIT)
+ *
+ * Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)*
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy*
+ * of this software and associated documentation files (the "Software"), to deal*
+ * in the Software without restriction, including without limitation the rights*
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell*
+ * copies of the Software, and to permit persons to whom the Software is*
+ * furnished to do so, subject to the following conditions:*
+ *
+ * The above copyright notice and this permission notice shall be included in*
+ * all copies or substantial portions of the Software.*
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR*
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,*
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE*
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER*
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,*
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN*
+ * THE SOFTWARE.
+ */
+
+import * as path from 'path';
+
+export default function urlFromPath(root, filepath) {
+  console.log(root, filepath);
+  if (!filepath.startsWith(root)) {
+    throw new Error(`file path is not in root: ${filepath} (${root})`);
+  }
+
+  // On windows systems, convert filesystem path to URL by replacing slashes
+  let isPlatformWin = /^win/.test(process.platform);
+  let isExtendedLengthPath = /^\\\\\?\\/.test(filepath);
+  let hasNonAscii = /[^\x00-\x80]+/.test(filepath);
+  if (isPlatformWin && !isExtendedLengthPath && !hasNonAscii) {
+    return path.win32.relative(root, filepath).replace(/\\/g, '/');
+  }
+
+  // Otherwise, just return the relative path between the two
+  return path.relative(root, filepath);
+}

--- a/test/build/bundle_test.js
+++ b/test/build/bundle_test.js
@@ -23,7 +23,6 @@ const Bundler = bundle.Bundler;
 const StreamAnalyzer = analyzer.StreamAnalyzer;
 
 const root = path.resolve('/root');
-var isPlatformWin = /^win/.test(process.platform);
 
 suite('Bundler', () => {
 
@@ -97,21 +96,6 @@ suite('Bundler', () => {
       ));
     return link != null;
   };
-
-  suite('urlFromPath()', () => {
-
-    // TODO(fschott): Get path-related tests working in multiple environments
-    if(!isPlatformWin) {
-      test('creates a URL path relative to root when called with a file path', () => setupTest({
-        entrypoint: 'entrypointA.html',
-        files: [framework(), entrypointA()],
-      }).then((files) => {
-        let urlPath = bundler.urlFromPath('/root/src/123.html');
-        assert.equal(urlPath, 'src/123.html');
-      }));
-    }
-
-  });
 
   test('entrypoint only', () => setupTest({
     entrypoint: 'entrypointA.html',

--- a/test/build/url-from-path_test.js
+++ b/test/build/url-from-path_test.js
@@ -1,0 +1,52 @@
+/**
+ * @license
+ * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ */
+
+'use strict';
+
+const assert = require('chai').assert;
+const urlFromPath = require('../../lib/build/url-from-path').default;
+
+const WIN_ROOT_PATH = 'C:\\Users\\TEST_USER\\TEST_ROOT';
+const MAC_ROOT_PATH = '/Users/TEST_USER/TEST_ROOT';
+var isPlatformWin = /^win/.test(process.platform);
+
+suite('urlFromPath()', () => {
+
+  test('throws error when path is not in root', () => {
+    assert.throws(function() {
+      urlFromPath(MAC_ROOT_PATH, '/some/other/path/shop-app.html');
+    });
+  });
+
+  if (isPlatformWin) {
+
+    test('creates a URL path relative to root when called in a Windows environment', () => {
+      let shortPath = urlFromPath(WIN_ROOT_PATH, WIN_ROOT_PATH + '\\shop-app.html');
+      assert.equal(shortPath, 'shop-app.html');
+      let medPath = urlFromPath(WIN_ROOT_PATH, WIN_ROOT_PATH + '\\src\\shop-app.html');
+      assert.equal(medPath, 'src/shop-app.html');
+      let longPath = urlFromPath(WIN_ROOT_PATH, WIN_ROOT_PATH + '\\bower_components\\app-layout\\docs.html');
+      assert.equal(longPath, 'bower_components/app-layout/docs.html');
+    });
+
+  } else {
+
+    test('creates a URL path relative to root when called in a Posix environment', () => {
+      let shortPath = urlFromPath(MAC_ROOT_PATH, MAC_ROOT_PATH + '/shop-app.html');
+      assert.equal(shortPath, 'shop-app.html');
+      let medPath = urlFromPath(MAC_ROOT_PATH, MAC_ROOT_PATH + '/src/shop-app.html');
+      assert.equal(medPath, 'src/shop-app.html');
+      let longPath = urlFromPath(MAC_ROOT_PATH, MAC_ROOT_PATH + '/bower_components/app-layout/docs.html');
+      assert.equal(longPath, 'bower_components/app-layout/docs.html');
+    });
+
+  }
+
+});


### PR DESCRIPTION
This splits our `urlFromPath()` logic out of the bundler and into it's own module. This allows us to add back the proper license for the slash library, as well as clean up some duplicate code by refactoring analyzer to use the module as well.

/cc @garlicnation 