### PR TITLE
Removes unneccesary liftoff dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "gunzip-maybe": "^1.3.1",
     "hydrolysis": "^1.23.3",
     "inquirer": "^1.0.2",
-    "liftoff": "^2.2.1",
     "merge-stream": "^1.0.0",
     "minimatch-all": "^1.0.2",
     "multipipe": "^0.3.0",


### PR DESCRIPTION
The function we were using liftoff for was mostly delegated to findup
a dependency we are already using. This replaces liftoff with a findup-
only implementation, allowing us to remove liftoff (and it's ~50 deps)
from our dep tree.

Also adds some logging.

/cc @garlicnation 