### PR TITLE
Refactor init command tests and make the cli commands more testable

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,6 @@
     "gulp-tslint": "^5.0.0",
     "gulp-typescript": "^2.13.4",
     "gulp-typings": "^1.3.6",
-    "mockery": "^1.7.0",
     "run-sequence": "^1.2.0",
     "sinon": "^1.17.4",
     "tslint": "^3.10.2",

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -15,7 +15,7 @@ import {BuildOptions} from '../build/build';
 import {Command} from './command';
 import * as logging from 'plylog';
 
-let logger = logging.getLogger('cli.build');
+let logger = logging.getLogger('cli.command.build');
 
 
 export class BuildCommand implements Command {

--- a/src/commands/command.ts
+++ b/src/commands/command.ts
@@ -6,7 +6,7 @@ export interface Command {
   name: string;
   description: string;
   args: ArgDescriptor[];
-  run(options: {[name: string]: string}, config: ProjectConfig): Promise<any>;
+  run(options: { [name: string]: string }, config: ProjectConfig): Promise<any>;
 }
 
 export {ArgDescriptor} from 'command-line-args';

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -13,7 +13,7 @@ import {CLI} from 'command-line-commands';
 import * as commandLineArgs from 'command-line-args';
 import * as logging from 'plylog';
 
-let logger = logging.getLogger('cli.help');
+let logger = logging.getLogger('cli.command.help');
 
 
 import {globalArguments} from '../args';

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -9,29 +9,10 @@
  */
 
 import {Command} from './command';
-import {execSync} from 'child_process';
 import {ArgDescriptor} from 'command-line-args';
-import * as fs from 'fs';
 import * as logging from 'plylog';
-import * as chalk from 'chalk';
-import {ApplicationGenerator} from '../init/application/application';
-import {ElementGenerator} from '../init/element/element';
-import * as YeomanEnvironment from 'yeoman-environment';
 
-let logger = logging.getLogger('cli.init');
-
-const templateDescriptions = {
-  'element': 'A blank element template',
-  'application': 'A blank application template',
-  'app-drawer-template': 'A starter application template, with navigation and "PRPL pattern" loading',
-  'shop': 'The "Shop" Progressive Web App demo',
-};
-
-interface GeneratorDescription {
-  name: string;
-  value: string;
-  short: string;
-}
+let logger = logging.getLogger('cli.command.init');
 
 export class InitCommand implements Command {
   name = 'init';
@@ -48,123 +29,21 @@ export class InitCommand implements Command {
   ];
 
   run(options, config): Promise<any> {
-    // Defer dependency loading until this specific command is run
-    const inquirer = require('inquirer');
-    const YeomanEnvironment = require('yeoman-environment');
+    // Defer dependency loading until needed
+    const polymerInit = require('../init/init');
 
-    return new Promise((resolve, reject) => {
-      logger.debug('creating yeoman environment...');
-
-      let env = new YeomanEnvironment();
-
-      registerDefaultGenerators(env);
-
-      env.lookup(() => {
-        let generators = env.getGeneratorsMeta();
-
-        let runGenerator = (generatorName: string, templateName?: string) => {
-          let generator = generators[generatorName];
-          if (generator) {
-            logger.info(`Running template ${templateName || generatorName}`);
-            logger.debug(`Running generator ${generatorName}`);
-            env.run(generatorName, {}, () => resolve());
-          } else {
-            logger.warn(`Template ${options.name} not found`);
-            reject(`Template ${options.name} not found`);
-          }
-        };
-
-        if (options.name) {
-          let generatorName = `polymer-init-${options.name}:app`;
-          runGenerator(generatorName, options.name);
-        } else {
-          let polymerInitGenerators = Object.keys(generators)
-              .filter((k) => k.startsWith('polymer-init')
-                  && k !== 'polymer-init:app');
-          let choices = polymerInitGenerators.map((generatorName: string) => {
-            let generator = generators[generatorName];
-            return getGeneratorDescription(generator, generatorName);
-          });
-          // Some windows emulators (mingw) don't handle arrows correctly
-          // https://github.com/SBoudrias/Inquirer.js/issues/266
-          // Fall back to rawlist and use number input
-          // Credit to https://gist.github.com/geddski/c42feb364f3c671d22b6390d82b8af8f
-          let isMinGW = checkIsMinGW();
-          let prompt = {
-            type: isMinGW ? 'rawlist' : 'list',
-            name: 'generatorName',
-            message: 'Which starter template would you like to use?',
-            choices: choices,
-          };
-          inquirer.prompt([prompt]).then((answers) => {
-            let generatorName = answers.generatorName;
-            runGenerator(generatorName, getDisplayName(generatorName));
-          });
-        }
+    if (options.name) {
+      let templateName = options.name;
+      let generatorName = `polymer-init-${templateName}:app`;
+      logger.debug('template name provided', {
+        generator: generatorName,
+        template: templateName,
       });
-    });
-  }
-}
-
-function registerDefaultGenerators(env: YeomanEnvironment): void {
-  const createGithubGenerator =
-    require('../init/github').createGithubGenerator;
-  env.registerStub(ElementGenerator, 'polymer-init-element:app');
-  env.registerStub(ApplicationGenerator, 'polymer-init-application:app');
-  let shopGenerator = createGithubGenerator({
-    owner: 'Polymer',
-    repo: 'shop',
-  });
-  env.registerStub(shopGenerator, 'polymer-init-shop:app');
-  let appDrawerGenerator = createGithubGenerator({
-    owner: 'Polymer',
-    repo: 'app-drawer-template',
-  });
-  env.registerStub(appDrawerGenerator,
-    'polymer-init-app-drawer-template:app');
-}
-
-function checkIsMinGW(): boolean {
-  let isWindows = /^win/.test(process.platform);
-  if (isWindows) {
-    // uname might not exist if using cmd or powershell,
-    // which would throw an exception
-    try {
-      let uname = execSync('uname -s').toString();
-      return !!/^mingw/i.test(uname);
-    } catch (e) {
+      return polymerInit.runGenerator(generatorName, options);
     }
+
+    logger.debug('no template name provided, prompting user...');
+    return polymerInit.promptGeneratorSelection();
   }
-  return false;
-}
-
-function getGeneratorDescription(generator: YeomanEnvironment.GeneratorMeta, generatorName: string): GeneratorDescription {
-  let description = 'no description';
-  let name = getDisplayName(generatorName);
-
-  if (templateDescriptions.hasOwnProperty(name)) {
-    description = templateDescriptions[name];
-  } else if (generator.resolved && generator.resolved !== 'unknown') {
-    let findup = require('findup');
-    let metapath = findup('package.json', {cwd: generator.resolved});
-    if (metapath) {
-      let meta = JSON.parse(fs.readFileSync(metapath, 'utf8'));
-      description = meta.description;
-    }
-  }
-
-  return {
-    name: `${name}: ${chalk.dim(description)}`,
-    value: generatorName,
-    // inquirer is broken and doesn't print descriptions :(
-    // keeping this so things work when it does
-    short: name,
-  };
-}
-
-function getDisplayName(generatorName: string) {
-  let nameEnd = generatorName.indexOf(':');
-  if (nameEnd === -1) nameEnd = generatorName.length;
-  return generatorName.substring('polymer-init-'.length, nameEnd);
 }
 

--- a/src/commands/lint.ts
+++ b/src/commands/lint.ts
@@ -13,7 +13,7 @@ import * as logging from 'plylog';
 
 import {Command} from './command';
 
-let logger = logging.getLogger('cli.lint');
+let logger = logging.getLogger('cli.command.lint');
 const polylint = require('polylint/lib/cli');
 
 

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -14,7 +14,7 @@ import {Command} from './command';
 import {Environment} from '../environment/environment';
 import * as logging from 'plylog';
 
-let logger = logging.getLogger('cli.serve');
+let logger = logging.getLogger('cli.command.serve');
 
 
 export class ServeCommand implements Command {

--- a/src/init/init.ts
+++ b/src/init/init.ts
@@ -1,0 +1,181 @@
+/**
+ * @license
+ * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ */
+
+import {execSync} from 'child_process';
+import * as fs from 'fs';
+import * as logging from 'plylog';
+import * as chalk from 'chalk';
+import * as findup from 'findup';
+import {ApplicationGenerator} from '../init/application/application';
+import {ElementGenerator} from '../init/element/element';
+import * as YeomanEnvironment from 'yeoman-environment';
+import * as inquirer from 'inquirer';
+import {createGithubGenerator} from '../init/github';
+
+let logger = logging.getLogger('init');
+
+const templateDescriptions = {
+  'element': 'A blank element template',
+  'application': 'A blank application template',
+  'app-drawer-template': 'A starter application template, with navigation and "PRPL pattern" loading',
+  'shop': 'The "Shop" Progressive Web App demo',
+};
+
+interface GeneratorDescription {
+  name: string;
+  value: string;
+  short: string;
+}
+
+let shopGenerator = createGithubGenerator({
+  owner: 'Polymer',
+  repo: 'shop',
+});
+
+let appDrawerGenerator = createGithubGenerator({
+  owner: 'Polymer',
+  repo: 'app-drawer-template',
+});
+
+function checkIsMinGW(): boolean {
+  let isWindows = /^win/.test(process.platform);
+  if (!isWindows) {
+    return false;
+  }
+
+  // uname might not exist if using cmd or powershell,
+  // which would throw an exception
+  try {
+    let uname = execSync('uname -s').toString();
+    return !!/^mingw/i.test(uname);
+  } catch (err) {
+    logger.debug('`uname -s` failed to execute correctly', {err: err.message});
+    return false;
+  }
+}
+
+function getGeneratorDescription(generator: YeomanEnvironment.GeneratorMeta, generatorName: string): GeneratorDescription {
+  let name = getDisplayName(generatorName);
+  let description;
+
+  if (templateDescriptions.hasOwnProperty(name)) {
+    description = templateDescriptions[name];
+  } else if (generator.resolved && generator.resolved !== 'unknown') {
+    try {
+      let metapath = findup.sync(generator.resolved, 'package.json');
+      let meta = JSON.parse(fs.readFileSync(metapath, 'utf8'));
+      description = meta.description;
+    } catch (err) {
+      if (err.message === 'not found') {
+        logger.debug('no package.json found for generator');
+      } else {
+        logger.debug('problem reading/parsing package.json for generator', {
+          generator: generatorName,
+          err: err.message,
+        });
+      }
+      description = '';
+    }
+  }
+
+  return {
+    name: `${name}  ${chalk.dim(description)}`,
+    value: generatorName,
+    // inquirer is broken and doesn't print descriptions :(
+    // keeping this so things work when it does
+    short: name,
+  };
+}
+
+function getDisplayName(generatorName: string) {
+  let nameEnd = generatorName.indexOf(':');
+  if (nameEnd === -1) {
+    nameEnd = generatorName.length;
+  }
+  return generatorName.substring('polymer-init-'.length, nameEnd);
+}
+
+export function createYeomanEnvironment(): Promise<any> {
+  return new Promise((resolve, reject) => {
+    let env = new YeomanEnvironment();
+    env.registerStub(ElementGenerator, 'polymer-init-element:app');
+    env.registerStub(ApplicationGenerator, 'polymer-init-application:app');
+    env.registerStub(shopGenerator, 'polymer-init-shop:app');
+    env.registerStub(appDrawerGenerator, 'polymer-init-app-drawer-template:app');
+    env.lookup((err) => {
+      if (err) {
+        reject(err);
+        return;
+      }
+      resolve(env);
+    });
+  });
+}
+
+export function runGenerator(generatorName, options): Promise<any> {
+  options = options || {};
+  let templateName = options.templateName || generatorName;
+
+  return new Promise((resolve, reject) => {
+    resolve(options.env || createYeomanEnvironment());
+  }).then(function(env) {
+    let generators = env.getGeneratorsMeta();
+    let generator = generators[generatorName];
+    if (!generator) {
+      logger.error(`Template ${templateName} not found`);
+      throw new Error(`Template ${templateName} not found`);
+    }
+
+    logger.info(`Running template ${options.templateName || generatorName}`);
+    logger.debug(`Running generator ${generatorName}`);
+    return new Promise((resolve, reject) => {
+      env.run(generatorName, {}, () => resolve());
+    });
+  });
+}
+
+export function promptGeneratorSelection(options): Promise<any> {
+  options = options || {};
+
+  return new Promise((resolve, reject) => {
+    resolve(options.env || createYeomanEnvironment());
+  }).then(function(env) {
+    let generators = env.getGeneratorsMeta();
+    let polymerInitGenerators = Object.keys(generators)
+      .filter((k) => k.startsWith('polymer-init') && k !== 'polymer-init:app');
+    let choices = polymerInitGenerators.map((generatorName: string) => {
+      let generator = generators[generatorName];
+      return getGeneratorDescription(generator, generatorName);
+    });
+
+    // Some windows emulators (mingw) don't handle arrows correctly
+    // https://github.com/SBoudrias/Inquirer.js/issues/266
+    // Fall back to rawlist and use number input
+    // Credit to https://gist.github.com/geddski/c42feb364f3c671d22b6390d82b8af8f
+    let isMinGW = checkIsMinGW();
+    let prompt = {
+      type: isMinGW ? 'rawlist' : 'list',
+      name: 'generatorName',
+      message: 'Which starter template would you like to use?',
+      choices: choices,
+    };
+
+    return inquirer.prompt([prompt]).then((answers) => {
+      let generatorName = answers.generatorName;
+      return runGenerator(generatorName, {
+        templateName: getDisplayName(generatorName),
+        env: env
+      });
+    });
+  });
+}
+
+
+

--- a/src/polymer-cli.ts
+++ b/src/polymer-cli.ts
@@ -131,7 +131,7 @@ export class PolymerCli {
     return Array.from(mergedArgs.values());
   }
 
-  run() {
+  run(): Promise<any> {
     logger.debug('running...');
 
     // If the "--version" flag is ever present, just print
@@ -165,9 +165,6 @@ export class PolymerCli {
     let command = this.commands.get(commandName);
     logger.debug('Running command...');
 
-    command.run(commandOptions, config).catch((error) => {
-      console.error('error', error);
-      if (error.stack) console.error(error.stack);
-    });
+    return command.run(commandOptions, config);
   }
 }

--- a/test/commands/init_test.js
+++ b/test/commands/init_test.js
@@ -10,258 +10,190 @@
 'use strict';
 
 const assert = require('chai').assert;
-const mockery = require('mockery');
 const sinon = require('sinon');
+const helpers = require('yeoman-test');
+const PolymerCli = require('../../lib/polymer-cli').PolymerCli;
+const childProcess = require('child_process');
+const inquirer = require('inquirer');
 
-const match = sinon.match;
+var isPlatformWin = /^win/.test(process.platform);
 
 suite('init', () => {
-  let InitCommand;
   let sandbox;
-  let originalPlatform;
-  let execStub;
-  let yeomanEnvStub;
-  let inquirerStub;
-  let elementGeneratorStub;
-  let applicationGeneratorStub;
+  let cli;
+  let initCommand;
 
   setup(() => {
     sandbox = sinon.sandbox.create();
-    originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
-    mockery.enable({useCleanCache: true});
-    mockery.registerAllowables(['../../lib/commands/init']);
-    mockDependencies();
-    //We need to re-import this each time mockery gets set up
-    // so that we have fresh stubs/spies
-    InitCommand = require('../../lib/commands/init').InitCommand
+    cli = new PolymerCli(['init']);
+    initCommand = cli.commands.get('init');
   });
 
   teardown(() => {
     sandbox.restore();
-    Object.defineProperty(process, 'platform', originalPlatform);
-    mockery.disable();
   });
 
-  function stubInquirer(generatorName) {
-    inquirerStub.prompt.returns(Promise.resolve({
-      generatorName: generatorName,
-    }))
+  test('calls ', () => {
+    let registeredGenerators = initCommand.env.getGeneratorsMeta();
+    assert.deepEqual(registeredGenerators, {
+      'polymer-init-element:app': {
+        resolved: 'unknown',
+        namespace: 'polymer-init-element:app',
+      },
+      'polymer-init-application:app': {
+        resolved: 'unknown',
+        namespace: 'polymer-init-application:app',
+      },
+      'polymer-init-shop:app': {
+        resolved: 'unknown',
+        namespace: 'polymer-init-shop:app',
+      },
+      'polymer-init-app-drawer-template:app': {
+        resolved: 'unknown',
+        namespace: 'polymer-init-app-drawer-template:app',
+      },
+    });
+  });
+
+  test('prompts with a list of all registered generators', (done) => {
+    let promptStub = sandbox.stub(inquirer, 'prompt').returns(new Promise(function() {}));
+    cli.run().then(() => {
+      assert.isTrue(promptStub.calledOnce);
+      assert.isTrue(promptStub.calledWith([
+        {
+          "type":"list",
+          "name":"generatorName",
+          "message":"Which starter template would you like to use?",
+          "choices":[
+            {
+              "name":"element: \u001b[2mA blank element template\u001b[22m",
+              "value":"polymer-init-element:app",
+              "short":"element",
+            },
+            {
+              "name":"application: \u001b[2mA blank application template\u001b[22m",
+              "value":"polymer-init-application:app",
+              "short":"application",
+            },
+            {
+              "name":"shop: \u001b[2mThe \"Shop\" Progressive Web App demo\u001b[22m",
+              "value":"polymer-init-shop:app",
+              "short":"shop",
+            },
+            {
+              "name":"app-drawer-template: \u001b[2mA starter application template, with navigation and \"PRPL pattern\" loading\u001b[22m",
+              "value":"polymer-init-app-drawer-template:app",
+              "short":"app-drawer-template",
+            },
+          ],
+        },
+      ]));
+      done();
+    });
+  });
+
+  test('includes user-provided generators in the list when properly installed/registered', () => {
+    let promptStub = sandbox.stub(inquirer, 'prompt').returns(new Promise(function() {}));
+    helpers.registerDependencies(initCommand.env, [[helpers.createDummyGenerator(), 'polymer-init-custom-template:app']]);
+    initCommand.run({});
+
+    assert.isTrue(promptStub.calledOnce);
+    assert.isTrue(promptStub.calledWith([
+      {
+        "type":"list",
+        "name":"generatorName",
+        "message":"Which starter template would you like to use?",
+        "choices":[
+          {
+            "name":"element: \u001b[2mA blank element template\u001b[22m",
+            "value":"polymer-init-element:app",
+            "short":"element",
+          },
+          {
+            "name":"application: \u001b[2mA blank application template\u001b[22m",
+            "value":"polymer-init-application:app",
+            "short":"application",
+          },
+          {
+            "name":"shop: \u001b[2mThe \"Shop\" Progressive Web App demo\u001b[22m",
+            "value":"polymer-init-shop:app",
+            "short":"shop",
+          },
+          {
+            "name":"app-drawer-template: \u001b[2mA starter application template, with navigation and \"PRPL pattern\" loading\u001b[22m",
+            "value":"polymer-init-app-drawer-template:app",
+            "short":"app-drawer-template",
+          },
+          {
+            name: 'custom-template: \u001b[2mno description\u001b[22m',
+            value: 'polymer-init-custom-template:app',
+            short: 'custom-template',
+          },
+        ],
+      },
+    ]));
+  });
+
+  if (isPlatformWin) {
+
+    test('prompts with a rawlist if being used in MinGW shell', () => {
+      let promptStub = sandbox.stub(inquirer, 'prompt').returns(new Promise(function() {}));
+      sandbox.stub(childProcess, 'execSync').withExactArgs('uname -s').returns('mingw');
+      cli.run();
+
+      assert.isTrue(promptStub.calledWith([
+        {
+          "type":"rawlist",
+          "name":"generatorName",
+          "message":"Which starter template would you like to use?",
+          "choices":[
+            {
+              "name":"element: \u001b[2mA blank element template\u001b[22m",
+              "value":"polymer-init-element:app",
+              "short":"element",
+            },
+            {
+              "name":"application: \u001b[2mA blank application template\u001b[22m",
+              "value":"polymer-init-application:app",
+              "short":"application",
+            },
+            {
+              "name":"shop: \u001b[2mThe \"Shop\" Progressive Web App demo\u001b[22m",
+              "value":"polymer-init-shop:app",
+              "short":"shop",
+            },
+            {
+              "name":"app-drawer-template: \u001b[2mA starter application template, with navigation and \"PRPL pattern\" loading\u001b[22m",
+              "value":"polymer-init-app-drawer-template:app",
+              "short":"app-drawer-template",
+            },
+          ],
+        },
+      ]));
+    });
+
   }
 
-  test('registers default template generators', () => {
-    let registeredGens = {};
-    let registerSpy = sandbox.spy(function (gen, name) {
-      registeredGens[name] = gen;
-    });
-    yeomanEnvStub.prototype.registerStub = registerSpy;
-
-    yeomanEnvStub.prototype.getGeneratorsMeta.returns(registeredGens);
-    stubInquirer('polymer-init-element:app');
-
-    return new InitCommand().run({}, {})
-      .then(() => {
-        assert.isTrue(registerSpy.calledWith(
-          match.same(elementGeneratorStub.ElementGenerator),
-          'polymer-init-element:app'
-        ));
-
-        assert.isTrue(registerSpy.calledWith(
-          match.same(applicationGeneratorStub.ApplicationGenerator),
-          'polymer-init-application:app'
-        ));
-
-        assert.isTrue(registerSpy.calledWith(
-          {
-            owner: 'Polymer', repo: 'shop',
-          },
-          'polymer-init-shop:app')
-        );
-
-        assert.isTrue(registerSpy.calledWith(
-          {
-            owner: 'Polymer', repo: 'app-drawer-template',
-          },
-          'polymer-init-app-drawer-template:app'
-        ));
-
-        assert.isTrue(inquirerStub.prompt.calledWithMatch(match(function (value) {
-          assert.sameDeepMembers(
-            value[0].choices,
-            [
-              {
-                name: 'element: A blank element template',
-                value: 'polymer-init-element:app',
-                short: 'element',
-              },
-              {
-                name: 'application: A blank application template',
-                value: 'polymer-init-application:app',
-                short: 'application',
-              },
-              {
-                name: 'shop: The "Shop" Progressive Web App demo',
-                value: 'polymer-init-shop:app',
-                short: 'shop',
-              },
-              {
-                name: 'app-drawer-template: A starter application template, ' +
-                'with navigation and "PRPL pattern" loading',
-                value: 'polymer-init-app-drawer-template:app',
-                short: 'app-drawer-template',
-              },
-            ]
-          );
-          return true;
-        })));
-      });
-  });
-
-  test('prompts with a list of all registered generators', () => {
-    mockPlatform('linux');
-    yeomanEnvStub.prototype.getGeneratorsMeta.returns({
-      'polymer-init-foo:app': {},
-      'polymer-init-bar:app': {},
-    });
-    stubInquirer('polymer-init-foo:app');
-
-    return new InitCommand().run({}, {})
-      .then(() => {
-        assert.isTrue(inquirerStub.prompt.calledWith([
-          {
-            type: 'list',
-            name: 'generatorName',
-            message: 'Which starter template would you like to use?',
-            choices: [
-              {
-                "name": "foo: no description",
-                "value": "polymer-init-foo:app",
-                "short": "foo",
-              },
-              {
-                "name": "bar: no description",
-                "value": "polymer-init-bar:app",
-                "short": "bar",
-              },
-            ],
-          },
-        ]));
-      });
-  });
-
-  test('prompts with a rawlist if being used in MinGW shell', () => {
-    mockPlatform('windows');
-    execStub.execSync.returns('mingw');
-
-    yeomanEnvStub.prototype.getGeneratorsMeta.returns({
-      'polymer-init-foo:app': {},
-      'polymer-init-bar:app': {},
-    });
-    stubInquirer('polymer-init-foo:app');
-
-    return new InitCommand().run({}, {})
-      .then(() => {
-        assert.isTrue(inquirerStub.prompt.calledWith(match((value) => {
-          return value[0].type === 'rawlist';
-        }, 'prompt type must be rawlist')));
-      });
-  });
-
   test('allows a generator to be be specified', () => {
-    yeomanEnvStub.prototype.getGeneratorsMeta.returns({
-      'polymer-init-test:app': {},
-    });
+    let runStub = sandbox.stub(initCommand.env, 'run').returns(Promise.resolve());
+    let promptStub = sandbox.stub(inquirer, 'prompt').returns(new Promise(function() {}));
 
-    let run = new InitCommand().run({name: 'test'}, {});
-
-    return run.then(() => {
-      let runStub = yeomanEnvStub.prototype.run;
-
-      assert.isTrue(runStub.calledWith('polymer-init-test:app'));
-      assert.isTrue(runStub.calledOnce);
-
-      //Make sure we never prompted, we just ran with it
-      assert.isFalse(inquirerStub.prompt.called);
-    })
+    initCommand.run({name: 'shop'});
+    assert.isTrue(runStub.calledOnce);
+    assert.isTrue(runStub.calledWith('polymer-init-shop:app'));
+    //Make sure we never prompted, we just ran with it
+    assert.isFalse(promptStub.called);
   });
 
   test('fails if an unknown generator is requested', (done) => {
-    yeomanEnvStub.prototype.getGeneratorsMeta.returns({
-      'polymer-init-test:app': {},
-    });
+    let unknownGeneratorName = 'UNKNOWN-GENERATOR';
 
-    let run = new InitCommand().run({name: 'fake'}, {});
-
-    run.then(function () {
+    initCommand.run({name: unknownGeneratorName}).then(() => {
       done('The promise should have been rejected');
-    }, function (err) {
-      assert.equal(err, 'Template fake not found');
+    }, (err) => {
+      assert.equal(err, `Template ${unknownGeneratorName} not found`);
       done();
-    }).catch(done);//to catch the assertion error
+    }).catch(done); // to catch the assertion error
   });
-
-  //TODO(ThatJoeMoore): pending as part of #177
-  test('detects and prompts with custom generators');
-
-  function mockPlatform(platform) {
-    Object.defineProperty(process, 'platform', {
-      value: platform,
-    });
-  }
-
-  function mockDependencies() {
-    execStub = registerMock('child_process', {
-      execSync: sandbox.stub(),
-    });
-
-    registerMock('fs', {
-      readFileSync: sandbox.stub(),
-    });
-
-    registerMock('chalk', {
-      dim: sandbox.stub().returnsArg(0),
-    });
-
-    //This fails with arrow functions
-    //  (arrow functions don't have an accessible prototype)
-    yeomanEnvStub = registerMock('yeoman-environment', function() {});
-    yeomanEnvStub.prototype.registerStub = sandbox.stub();
-    yeomanEnvStub.prototype.lookup = sandbox.stub().yields();
-    yeomanEnvStub.prototype.run = sandbox.stub().yields();
-    yeomanEnvStub.prototype.getGeneratorsMeta = sandbox.stub();
-
-    registerMock('findup', {
-      sync: sandbox.stub(),
-    });
-
-    inquirerStub = registerMock('inquirer', {
-      prompt: sandbox.stub().returns(Promise.resolve()),
-    });
-
-    registerMock('../init/github', {
-      createGithubGenerator: sandbox.stub().returnsArg(0),
-    });
-
-    registerMock('plylog', {
-      getLogger: () => {
-        return {
-          info: sandbox.spy(),
-          debug: sandbox.spy(),
-          warn: sandbox.spy(),
-        }
-      },
-    });
-
-    elementGeneratorStub = registerMock(
-      '../init/element/element', {ElementGenerator: {}}
-    );
-    applicationGeneratorStub = registerMock(
-      '../init/application/application', {ApplicationGenerator: {}}
-    );
-  }
-
-  function registerMock(name, obj) {
-    mockery.registerMock(name, obj);
-    return obj;
-  }
 
 });


### PR DESCRIPTION
There was considerable configuration/boilerplate brought into the `init` command tests, as a workaround to how self-contained and complex the command was. This refactoring exposes the yeoman environment as a property of the command, allowing us to inspect yeoman, its generators, and its prompts. As a result we can now remove the mockery dependency that was added for this.

/cc @justinfagnani 