### PR TITLE
Move last of the old commands to load their dependencies at runtime

### DIFF
--- a/src/commands/lint.ts
+++ b/src/commands/lint.ts
@@ -10,12 +10,9 @@
 
 import * as commandLineArgs from 'command-line-args';
 import * as logging from 'plylog';
-
 import {Command} from './command';
 
 let logger = logging.getLogger('cli.lint');
-const polylint = require('polylint/lib/cli');
-
 
 export class LintCommand implements Command {
   name = 'lint';
@@ -57,6 +54,9 @@ export class LintCommand implements Command {
   ];
 
   run(options, config): Promise<any> {
+    // Defer dependency loading until this specific command is run
+    const polylint = require('polylint/lib/cli');
+
     if (config.inputs.length === 0) {
       let argsCli = commandLineArgs(this.args);
 

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -8,10 +8,7 @@
  * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
  */
 
-import {startServer, args as polyserveArgs} from 'polyserve';
-import {ServerOptions} from 'polyserve/lib/start_server';
 import {Command} from './command';
-import {Environment} from '../environment/environment';
 import * as logging from 'plylog';
 
 let logger = logging.getLogger('cli.serve');
@@ -69,6 +66,11 @@ export class ServeCommand implements Command {
   ];
 
   run(options, config): Promise<any> {
+    // Defer dependency loading until this specific command is run
+    const polyserve = require('polyserve');
+    const ServerOptions = require('polyserve/lib/start_server').ServerOptions;
+    const Environment = require('../environment/environment').Environment;
+
     let openPath;
     if (config.entrypoint && config.shell) {
       let rootLength = (config.root && config.root.length) || 0;
@@ -97,7 +99,7 @@ export class ServeCommand implements Command {
       return env.serve(serverOptions);
     }
 
-    logger.debug('serving via startServer()...');
-    return startServer(serverOptions);
+    logger.debug('serving via polyserve.startServer()...');
+    return polyserve.startServer(serverOptions);
   }
 }

--- a/src/commands/test.ts
+++ b/src/commands/test.ts
@@ -108,7 +108,7 @@ export class TestCommand implements Command {
 
   run(options, config): Promise<void> {
     // Defer dependency loading until this specific command is run
-    let wct = require('web-component-tester');
+    const wct = require('web-component-tester');
 
     return new Promise<void>((resolve, reject) => {
       wct.cli.run(process.env, process.argv.slice(3), process.stdout,

--- a/src/polymer-cli.ts
+++ b/src/polymer-cli.ts
@@ -21,8 +21,6 @@ import {ServeCommand} from './commands/serve';
 import {TestCommand} from './commands/test';
 import {Command} from './commands/command';
 import {ProjectConfig, ProjectConfigOptions} from './project-config';
-import {Environment} from './environment/environment';
-import {buildEnvironment} from './environments/environments';
 
 
 const logger = logging.getLogger('cli.main');


### PR DESCRIPTION
This moves the last of the commands  (besides init, which is complex enough to get its own PR) to use lazy dependency loading. We weren't able to move these previously because they were needed on load for our CLI argument definitions.

This (/w init fixed as well) drops our startup time from the original `~1.6s` down to `~0.2s`. booyah!

/cc @justinfagnani 