### PR TITLE
Refactor init command tests and make the cli commands more testable

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
     "gulp-tslint": "^5.0.0",
     "gulp-typescript": "^2.13.4",
     "gulp-typings": "^1.3.6",
-    "mockery": "^1.7.0",
     "run-sequence": "^1.2.0",
     "sinon": "^1.17.4",
     "tslint": "^3.10.2",

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -15,7 +15,7 @@ import {BuildOptions} from '../build/build';
 import {Command} from './command';
 import * as logging from 'plylog';
 
-let logger = logging.getLogger('cli.build');
+let logger = logging.getLogger('cli.command.build');
 
 
 export class BuildCommand implements Command {

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -13,7 +13,7 @@ import {CLI} from 'command-line-commands';
 import * as commandLineArgs from 'command-line-args';
 import * as logging from 'plylog';
 
-let logger = logging.getLogger('cli.help');
+let logger = logging.getLogger('cli.command.help');
 
 
 import {globalArguments} from '../args';

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -9,30 +9,10 @@
  */
 
 import {Command} from './command';
-import {execSync} from 'child_process';
 import {ArgDescriptor} from 'command-line-args';
-import * as fs from 'fs';
 import * as logging from 'plylog';
-import * as chalk from 'chalk';
-import {ApplicationGenerator} from '../init/application/application';
-import {ElementGenerator} from '../init/element/element';
-import * as YeomanEnvironment from 'yeoman-environment';
-import * as findup from 'findup';
 
-let logger = logging.getLogger('cli.init');
-
-const templateDescriptions = {
-  'element': 'A blank element template',
-  'application': 'A blank application template',
-  'app-drawer-template': 'A starter application template, with navigation and "PRPL pattern" loading',
-  'shop': 'The "Shop" Progressive Web App demo',
-};
-
-interface GeneratorDescription {
-  name: string;
-  value: string;
-  short: string;
-}
+let logger = logging.getLogger('cli.command.init');
 
 export class InitCommand implements Command {
   name = 'init';
@@ -49,128 +29,21 @@ export class InitCommand implements Command {
   ];
 
   run(options, config): Promise<any> {
-    // Defer dependency loading until this specific command is run
-    const inquirer = require('inquirer');
-    const YeomanEnvironment = require('yeoman-environment');
+    // Defer dependency loading until needed
+    const polymerInit = require('../init/init');
 
-    return new Promise((resolve, reject) => {
-      logger.debug('creating yeoman environment...');
-
-      let env = new YeomanEnvironment();
-
-      registerDefaultGenerators(env);
-
-      env.lookup(() => {
-        let generators = env.getGeneratorsMeta();
-
-        let runGenerator = (generatorName: string, templateName?: string) => {
-          let generator = generators[generatorName];
-          if (generator) {
-            logger.info(`Running template ${templateName || generatorName}`);
-            logger.debug(`Running generator ${generatorName}`);
-            env.run(generatorName, {}, () => resolve());
-          } else {
-            logger.warn(`Template ${options.name} not found`);
-            reject(`Template ${options.name} not found`);
-          }
-        };
-
-        if (options.name) {
-          let generatorName = `polymer-init-${options.name}:app`;
-          runGenerator(generatorName, options.name);
-        } else {
-          let polymerInitGenerators = Object.keys(generators)
-              .filter((k) => k.startsWith('polymer-init')
-                  && k !== 'polymer-init:app');
-          let choices = polymerInitGenerators.map((generatorName: string) => {
-            let generator = generators[generatorName];
-            return getGeneratorDescription(generator, generatorName);
-          });
-          // Some windows emulators (mingw) don't handle arrows correctly
-          // https://github.com/SBoudrias/Inquirer.js/issues/266
-          // Fall back to rawlist and use number input
-          // Credit to https://gist.github.com/geddski/c42feb364f3c671d22b6390d82b8af8f
-          let isMinGW = checkIsMinGW();
-          let prompt = {
-            type: isMinGW ? 'rawlist' : 'list',
-            name: 'generatorName',
-            message: 'Which starter template would you like to use?',
-            choices: choices,
-          };
-          inquirer.prompt([prompt]).then((answers) => {
-            let generatorName = answers.generatorName;
-            runGenerator(generatorName, getDisplayName(generatorName));
-          });
-        }
+    if (options.name) {
+      let templateName = options.name;
+      let generatorName = `polymer-init-${templateName}:app`;
+      logger.debug('template name provided', {
+        generator: generatorName,
+        template: templateName,
       });
-    });
-  }
-}
-
-function registerDefaultGenerators(env: YeomanEnvironment): void {
-  const createGithubGenerator =
-    require('../init/github').createGithubGenerator;
-  env.registerStub(ElementGenerator, 'polymer-init-element:app');
-  env.registerStub(ApplicationGenerator, 'polymer-init-application:app');
-  let shopGenerator = createGithubGenerator({
-    owner: 'Polymer',
-    repo: 'shop',
-  });
-  env.registerStub(shopGenerator, 'polymer-init-shop:app');
-  let appDrawerGenerator = createGithubGenerator({
-    owner: 'Polymer',
-    repo: 'app-drawer-template',
-  });
-  env.registerStub(appDrawerGenerator,
-    'polymer-init-app-drawer-template:app');
-}
-
-function checkIsMinGW(): boolean {
-  let isWindows = /^win/.test(process.platform);
-  if (isWindows) {
-    // uname might not exist if using cmd or powershell,
-    // which would throw an exception
-    try {
-      let uname = execSync('uname -s').toString();
-      return !!/^mingw/i.test(uname);
-    } catch (e) {
+      return polymerInit.runGenerator(generatorName, options);
     }
+
+    logger.debug('no template name provided, prompting user...');
+    return polymerInit.promptGeneratorSelection();
   }
-  return false;
-}
-
-function getGeneratorDescription(generator: YeomanEnvironment.GeneratorMeta, generatorName: string): GeneratorDescription {
-  let description = 'no description';
-  let name = getDisplayName(generatorName);
-
-  if (templateDescriptions.hasOwnProperty(name)) {
-    description = templateDescriptions[name];
-  } else if (generator.resolved && generator.resolved !== 'unknown') {
-    try {
-      let metapath = findup.sync(generator.resolved, 'package.json');
-      let meta = JSON.parse(fs.readFileSync(metapath, 'utf8'));
-      description = meta.description;
-    } catch (err) {
-      if (err.message === 'not found') {
-        logger.debug('no package.json found for generator');
-      } else {
-        logger.debug('problem reading/parsing package.json for generator', { err: err.message });
-      }
-    }
-  }
-
-  return {
-    name: `${name}: ${chalk.dim(description)}`,
-    value: generatorName,
-    // inquirer is broken and doesn't print descriptions :(
-    // keeping this so things work when it does
-    short: name,
-  };
-}
-
-function getDisplayName(generatorName: string) {
-  let nameEnd = generatorName.indexOf(':');
-  if (nameEnd === -1) nameEnd = generatorName.length;
-  return generatorName.substring('polymer-init-'.length, nameEnd);
 }
 

--- a/src/commands/lint.ts
+++ b/src/commands/lint.ts
@@ -12,6 +12,7 @@ import * as commandLineArgs from 'command-line-args';
 import * as logging from 'plylog';
 import {Command} from './command';
 
+
 let logger = logging.getLogger('cli.lint');
 
 export class LintCommand implements Command {

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -11,7 +11,7 @@
 import {Command} from './command';
 import * as logging from 'plylog';
 
-let logger = logging.getLogger('cli.serve');
+let logger = logging.getLogger('cli.command.serve');
 
 
 export class ServeCommand implements Command {

--- a/src/init/init.ts
+++ b/src/init/init.ts
@@ -1,0 +1,218 @@
+/**
+ * @license
+ * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ */
+
+import {execSync} from 'child_process';
+import * as fs from 'fs';
+import * as logging from 'plylog';
+import * as chalk from 'chalk';
+import * as findup from 'findup';
+import {ApplicationGenerator} from '../init/application/application';
+import {ElementGenerator} from '../init/element/element';
+import * as YeomanEnvironment from 'yeoman-environment';
+import * as inquirer from 'inquirer';
+import {createGithubGenerator} from '../init/github';
+
+let logger = logging.getLogger('init');
+
+interface GeneratorDescription {
+  name: string;
+  value: string;
+  short: string;
+}
+
+const templateDescriptions = {
+  'element': 'A blank element template',
+  'application': 'A blank application template',
+  'app-drawer-template': 'A starter application template, with navigation and "PRPL pattern" loading',
+  'shop': 'The "Shop" Progressive Web App demo',
+};
+
+let shopGenerator = createGithubGenerator({
+  owner: 'Polymer',
+  repo: 'shop',
+});
+
+let appDrawerGenerator = createGithubGenerator({
+  owner: 'Polymer',
+  repo: 'app-drawer-template',
+});
+
+/**
+ * Check if the current shell environment is MinGW. MinGW can't handle some
+ * yeoman features, so we can use this check to downgrade gracefully.
+ */
+function checkIsMinGW(): boolean {
+  let isWindows = /^win/.test(process.platform);
+  if (!isWindows) {
+    return false;
+  }
+
+  // uname might not exist if using cmd or powershell,
+  // which would throw an exception
+  try {
+    let uname = execSync('uname -s').toString();
+    return !!/^mingw/i.test(uname);
+  } catch (err) {
+    logger.debug('`uname -s` failed to execute correctly', {err: err.message});
+    return false;
+  }
+}
+
+/**
+ * Get a description for the given generator. If this is an external generator,
+ * read the description from its package.json.
+ */
+function getGeneratorDescription(generator: YeomanEnvironment.GeneratorMeta, generatorName: string): GeneratorDescription {
+  let name = getDisplayName(generatorName);
+  let description = 'no description';
+
+  if (templateDescriptions.hasOwnProperty(name)) {
+    description = templateDescriptions[name];
+  } else if (generator.resolved && generator.resolved !== 'unknown') {
+    try {
+      let metapath = findup.sync(generator.resolved, 'package.json');
+      let meta = JSON.parse(fs.readFileSync(metapath, 'utf8'));
+      description = meta.description;
+    } catch (err) {
+      if (err.message === 'not found') {
+        logger.debug('no package.json found for generator');
+      } else {
+        logger.debug('problem reading/parsing package.json for generator', {
+          generator: generatorName,
+          err: err.message,
+        });
+      }
+    }
+  }
+
+  return {
+    name: `${name}: ${chalk.dim(description)}`,
+    value: generatorName,
+    // inquirer is broken and doesn't print descriptions :(
+    // keeping this so things work when it does
+    short: name,
+  };
+}
+
+/**
+ * Extract the meaningful name from the full yeoman generator name
+ */
+function getDisplayName(generatorName: string) {
+  let nameEnd = generatorName.indexOf(':');
+  if (nameEnd === -1) {
+    nameEnd = generatorName.length;
+  }
+  return generatorName.substring('polymer-init-'.length, nameEnd);
+}
+
+/**
+ * Create & populate a Yeoman environment.
+ */
+function createYeomanEnvironment(): Promise<any> {
+  return new Promise((resolve, reject) => {
+    let env = new YeomanEnvironment();
+    env.registerStub(ElementGenerator, 'polymer-init-element:app');
+    env.registerStub(ApplicationGenerator, 'polymer-init-application:app');
+    env.registerStub(shopGenerator, 'polymer-init-shop:app');
+    env.registerStub(appDrawerGenerator, 'polymer-init-app-drawer-template:app');
+    env.lookup((err) => {
+      if (err) {
+        reject(err);
+        return;
+      }
+      resolve(env);
+    });
+  });
+}
+
+/**
+ * Create the prompt used for selecting which template to run. Generate
+ * the list of available generators by filtering relevent ones out from
+ * the environment list.
+ */
+function createSelectPrompt(env): Promise<any> {
+  let generators = env.getGeneratorsMeta();
+  let polymerInitGenerators = Object.keys(generators).filter((k) => {
+    return k.startsWith('polymer-init') && k !== 'polymer-init:app';
+  });
+  let choices = polymerInitGenerators.map((generatorName: string) => {
+    let generator = generators[generatorName];
+    return getGeneratorDescription(generator, generatorName);
+  });
+
+  // Some windows emulators (mingw) don't handle arrows correctly
+  // https://github.com/SBoudrias/Inquirer.js/issues/266
+  // Fall back to rawlist and use number input
+  // Credit to https://gist.github.com/geddski/c42feb364f3c671d22b6390d82b8af8f
+  let isMinGW = checkIsMinGW();
+
+  return {
+    type: isMinGW ? 'rawlist' : 'list',
+    name: 'generatorName',
+    message: 'Which starter template would you like to use?',
+    choices: choices,
+  };
+}
+
+/**
+ * Run the given generator. If no Yeoman environment is provided, a new one
+ * will be created. If the generator does not exist in the environment, an
+ * error will be thrown.
+ */
+export function runGenerator(generatorName, options): Promise<any> {
+  options = options || {};
+  let templateName = options.templateName || generatorName;
+
+  return new Promise((resolve, reject) => {
+    resolve(options.env || createYeomanEnvironment());
+  }).then(function(env) {
+    logger.info(`Running template ${templateName}...`);
+    logger.debug(`Running generator ${generatorName}...`);
+    let generators = env.getGeneratorsMeta();
+    let generator = generators[generatorName];
+
+    if (!generator) {
+      logger.error(`Template ${templateName} not found`);
+      throw new Error(`Template ${templateName} not found`);
+    }
+
+    return new Promise((resolve, reject) => {
+      env.run(generatorName, {}, (err) => {
+        if (err) {
+          reject(err);
+          return;
+        }
+        resolve();
+      });
+    });
+  });
+}
+
+/**
+ * Prompt the user to select a generator. When the user
+ * selects a generator, run it.
+ */
+export function promptGeneratorSelection(options): Promise<any> {
+  options = options || {};
+  let env;
+
+  return new Promise((resolve, reject) => {
+    resolve(options.env || createYeomanEnvironment());
+  }).then(function(_env) {
+    env = _env;
+    return inquirer.prompt([createSelectPrompt(env)]);
+  }).then(function(answers) {
+    let generatorName = answers.generatorName;
+    return runGenerator(generatorName, {
+      templateName: getDisplayName(generatorName),
+      env: env
+    });
+  });
+}

--- a/test/commands/init_test.js
+++ b/test/commands/init_test.js
@@ -10,258 +10,36 @@
 'use strict';
 
 const assert = require('chai').assert;
-const mockery = require('mockery');
 const sinon = require('sinon');
-
-const match = sinon.match;
+const PolymerCli = require('../../lib/polymer-cli').PolymerCli;
+const polymerInit = require('../../lib/init/init');
 
 suite('init', () => {
-  let InitCommand;
   let sandbox;
-  let originalPlatform;
-  let execStub;
-  let yeomanEnvStub;
-  let inquirerStub;
-  let elementGeneratorStub;
-  let applicationGeneratorStub;
 
   setup(() => {
     sandbox = sinon.sandbox.create();
-    originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
-    mockery.enable({useCleanCache: true});
-    mockery.registerAllowables(['../../lib/commands/init']);
-    mockDependencies();
-    //We need to re-import this each time mockery gets set up
-    // so that we have fresh stubs/spies
-    InitCommand = require('../../lib/commands/init').InitCommand
   });
 
   teardown(() => {
     sandbox.restore();
-    Object.defineProperty(process, 'platform', originalPlatform);
-    mockery.disable();
   });
 
-  function stubInquirer(generatorName) {
-    inquirerStub.prompt.returns(Promise.resolve({
-      generatorName: generatorName,
-    }))
-  }
-
-  test('registers default template generators', () => {
-    let registeredGens = {};
-    let registerSpy = sandbox.spy(function (gen, name) {
-      registeredGens[name] = gen;
-    });
-    yeomanEnvStub.prototype.registerStub = registerSpy;
-
-    yeomanEnvStub.prototype.getGeneratorsMeta.returns(registeredGens);
-    stubInquirer('polymer-init-element:app');
-
-    return new InitCommand().run({}, {})
-      .then(() => {
-        assert.isTrue(registerSpy.calledWith(
-          match.same(elementGeneratorStub.ElementGenerator),
-          'polymer-init-element:app'
-        ));
-
-        assert.isTrue(registerSpy.calledWith(
-          match.same(applicationGeneratorStub.ApplicationGenerator),
-          'polymer-init-application:app'
-        ));
-
-        assert.isTrue(registerSpy.calledWith(
-          {
-            owner: 'Polymer', repo: 'shop',
-          },
-          'polymer-init-shop:app')
-        );
-
-        assert.isTrue(registerSpy.calledWith(
-          {
-            owner: 'Polymer', repo: 'app-drawer-template',
-          },
-          'polymer-init-app-drawer-template:app'
-        ));
-
-        assert.isTrue(inquirerStub.prompt.calledWithMatch(match(function (value) {
-          assert.sameDeepMembers(
-            value[0].choices,
-            [
-              {
-                name: 'element: A blank element template',
-                value: 'polymer-init-element:app',
-                short: 'element',
-              },
-              {
-                name: 'application: A blank application template',
-                value: 'polymer-init-application:app',
-                short: 'application',
-              },
-              {
-                name: 'shop: The "Shop" Progressive Web App demo',
-                value: 'polymer-init-shop:app',
-                short: 'shop',
-              },
-              {
-                name: 'app-drawer-template: A starter application template, ' +
-                'with navigation and "PRPL pattern" loading',
-                value: 'polymer-init-app-drawer-template:app',
-                short: 'app-drawer-template',
-              },
-            ]
-          );
-          return true;
-        })));
-      });
+  test('runs the given generator when name argument is provided', () => {
+    let runGeneratorStub = sandbox.stub(polymerInit, 'runGenerator').returns(Promise.resolve());
+    let cli = new PolymerCli(['init', 'shop'], null);
+    cli.run();
+    assert.isOk(runGeneratorStub.calledOnce);
+    assert.isOk(runGeneratorStub.calledWith(`polymer-init-shop:app`, {
+      name: 'shop',
+    }));
   });
 
-  test('prompts with a list of all registered generators', () => {
-    mockPlatform('linux');
-    yeomanEnvStub.prototype.getGeneratorsMeta.returns({
-      'polymer-init-foo:app': {},
-      'polymer-init-bar:app': {},
-    });
-    stubInquirer('polymer-init-foo:app');
-
-    return new InitCommand().run({}, {})
-      .then(() => {
-        assert.isTrue(inquirerStub.prompt.calledWith([
-          {
-            type: 'list',
-            name: 'generatorName',
-            message: 'Which starter template would you like to use?',
-            choices: [
-              {
-                "name": "foo: no description",
-                "value": "polymer-init-foo:app",
-                "short": "foo",
-              },
-              {
-                "name": "bar: no description",
-                "value": "polymer-init-bar:app",
-                "short": "bar",
-              },
-            ],
-          },
-        ]));
-      });
+  test('prompts the user to select a generator when no argument is provided', () => {
+    let promptSelectionStub = sandbox.stub(polymerInit, 'promptGeneratorSelection').returns(Promise.resolve());
+    let cli = new PolymerCli(['init'], null);
+    cli.run();
+    assert.isOk(promptSelectionStub.calledOnce);
   });
-
-  test('prompts with a rawlist if being used in MinGW shell', () => {
-    mockPlatform('windows');
-    execStub.execSync.returns('mingw');
-
-    yeomanEnvStub.prototype.getGeneratorsMeta.returns({
-      'polymer-init-foo:app': {},
-      'polymer-init-bar:app': {},
-    });
-    stubInquirer('polymer-init-foo:app');
-
-    return new InitCommand().run({}, {})
-      .then(() => {
-        assert.isTrue(inquirerStub.prompt.calledWith(match((value) => {
-          return value[0].type === 'rawlist';
-        }, 'prompt type must be rawlist')));
-      });
-  });
-
-  test('allows a generator to be be specified', () => {
-    yeomanEnvStub.prototype.getGeneratorsMeta.returns({
-      'polymer-init-test:app': {},
-    });
-
-    let run = new InitCommand().run({name: 'test'}, {});
-
-    return run.then(() => {
-      let runStub = yeomanEnvStub.prototype.run;
-
-      assert.isTrue(runStub.calledWith('polymer-init-test:app'));
-      assert.isTrue(runStub.calledOnce);
-
-      //Make sure we never prompted, we just ran with it
-      assert.isFalse(inquirerStub.prompt.called);
-    })
-  });
-
-  test('fails if an unknown generator is requested', (done) => {
-    yeomanEnvStub.prototype.getGeneratorsMeta.returns({
-      'polymer-init-test:app': {},
-    });
-
-    let run = new InitCommand().run({name: 'fake'}, {});
-
-    run.then(function () {
-      done('The promise should have been rejected');
-    }, function (err) {
-      assert.equal(err, 'Template fake not found');
-      done();
-    }).catch(done);//to catch the assertion error
-  });
-
-  //TODO(ThatJoeMoore): pending as part of #177
-  test('detects and prompts with custom generators');
-
-  function mockPlatform(platform) {
-    Object.defineProperty(process, 'platform', {
-      value: platform,
-    });
-  }
-
-  function mockDependencies() {
-    execStub = registerMock('child_process', {
-      execSync: sandbox.stub(),
-    });
-
-    registerMock('fs', {
-      readFileSync: sandbox.stub(),
-    });
-
-    registerMock('chalk', {
-      dim: sandbox.stub().returnsArg(0),
-    });
-
-    //This fails with arrow functions
-    //  (arrow functions don't have an accessible prototype)
-    yeomanEnvStub = registerMock('yeoman-environment', function() {});
-    yeomanEnvStub.prototype.registerStub = sandbox.stub();
-    yeomanEnvStub.prototype.lookup = sandbox.stub().yields();
-    yeomanEnvStub.prototype.run = sandbox.stub().yields();
-    yeomanEnvStub.prototype.getGeneratorsMeta = sandbox.stub();
-
-    registerMock('findup', {
-      sync: sandbox.stub(),
-    });
-
-    inquirerStub = registerMock('inquirer', {
-      prompt: sandbox.stub().returns(Promise.resolve()),
-    });
-
-    registerMock('../init/github', {
-      createGithubGenerator: sandbox.stub().returnsArg(0),
-    });
-
-    registerMock('plylog', {
-      getLogger: () => {
-        return {
-          info: sandbox.spy(),
-          debug: sandbox.spy(),
-          warn: sandbox.spy(),
-        }
-      },
-    });
-
-    elementGeneratorStub = registerMock(
-      '../init/element/element', {ElementGenerator: {}}
-    );
-    applicationGeneratorStub = registerMock(
-      '../init/application/application', {ApplicationGenerator: {}}
-    );
-  }
-
-  function registerMock(name, obj) {
-    mockery.registerMock(name, obj);
-    return obj;
-  }
 
 });

--- a/test/init/init_test.js
+++ b/test/init/init_test.js
@@ -1,0 +1,160 @@
+/**
+ * @license
+ * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ */
+'use strict';
+
+const assert = require('chai').assert;
+const sinon = require('sinon');
+const helpers = require('yeoman-test');
+const childProcess = require('child_process');
+const inquirer = require('inquirer');
+const YeomanEnvironment = require('yeoman-environment');
+
+const polymerInit = require('../../lib/init/init');
+
+var isPlatformWin = /^win/.test(process.platform);
+
+function stripAnsi(str) {
+  let ansiRegex = /[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g;
+  return str.replace(ansiRegex, '');
+}
+
+suite('init', () => {
+  let sandbox;
+
+  function createFakeEnv() {
+    return {
+      getGeneratorsMeta: sandbox.stub(),
+      run: sandbox.stub().yields(),
+    };
+  }
+
+  setup(() => {
+    sandbox = sinon.sandbox.create();
+  });
+
+  teardown(() => {
+    sandbox.restore();
+  });
+
+  suite('runGenerator', () => {
+
+    test('runs the given generator', () => {
+      const GENERATOR_NAME = 'TEST-GENERATOR';
+      let yeomanEnv = createFakeEnv();
+      yeomanEnv.getGeneratorsMeta.returns({
+        [GENERATOR_NAME]: GENERATOR_NAME,
+      });
+
+      return polymerInit.runGenerator(GENERATOR_NAME, {env: yeomanEnv}).then(() => {
+        assert.isOk(yeomanEnv.run.calledWith(GENERATOR_NAME));
+      });
+    });
+
+    test('fails if an unknown generator is requested', () => {
+      const UNKNOWN_GENERATOR_NAME = 'UNKNOWN-GENERATOR';
+      let yeomanEnv = createFakeEnv();
+      yeomanEnv.getGeneratorsMeta.returns({
+        'TEST-GENERATOR': 'TEST-GENERATOR',
+      });
+
+      return polymerInit.runGenerator(UNKNOWN_GENERATOR_NAME, {env: yeomanEnv}).then(() => {
+        throw new Error('The promise should have been rejected before it got here');
+      }, (err) => {
+        assert.equal(err.message, `Template ${UNKNOWN_GENERATOR_NAME} not found`);
+      });
+    });
+
+  });
+
+  suite('promptGeneratorSelection', () => {
+
+    let yeomanEnvMock;
+
+    setup(() => {
+      yeomanEnvMock = createFakeEnv();
+      yeomanEnvMock.getGeneratorsMeta.returns({
+        'polymer-init-element:app': {
+          resolved: 'unknown',
+          namespace: 'polymer-init-element:app',
+        },
+      });
+    });
+
+    test('prompts with a list to get generatorName property from user', () => {
+      let promptStub = sandbox.stub(inquirer, 'prompt').returns(Promise.resolve({generatorName: 'TEST'}));
+      return polymerInit.promptGeneratorSelection({env: yeomanEnvMock}).catch((err) => {
+        assert.equal(err.message, 'Template TEST not found');
+      }).then(() => {
+        assert.isTrue(promptStub.calledOnce);
+        assert.equal(promptStub.firstCall.args[0][0].type, 'list');
+        assert.equal(promptStub.firstCall.args[0][0].name, 'generatorName');
+        assert.equal(promptStub.firstCall.args[0][0].message,  'Which starter template would you like to use?');
+      });
+    });
+
+    test('prompts with a list of all registered generators', () => {
+      let promptStub = sandbox.stub(inquirer, 'prompt').returns(Promise.resolve({generatorName: 'TEST'}));
+      return polymerInit.promptGeneratorSelection({env: yeomanEnvMock}).catch((err) => {
+        assert.equal(err.message, 'Template TEST not found');
+      }).then(() => {
+        let choices = promptStub.firstCall.args[0][0].choices;
+        assert.equal(choices.length, 1);
+        assert.equal(stripAnsi(choices[0].name), 'element: A blank element template');
+        assert.equal(choices[0].value, 'polymer-init-element:app');
+        assert.equal(choices[0].short, 'element');
+      });
+    });
+
+    test('includes user-provided generators in the list when properly installed/registered', () => {
+      let yeomanEnv = new YeomanEnvironment();
+      let promptStub = sandbox.stub(inquirer, 'prompt').returns(Promise.resolve({generatorName: 'TEST'}));
+      helpers.registerDependencies(yeomanEnv, [[helpers.createDummyGenerator(), 'polymer-init-custom-template:app']]);
+      return polymerInit.promptGeneratorSelection({env: yeomanEnv}).catch((err) => {
+        assert.equal(err.message, 'Template TEST not found');
+      }).then(() => {
+        assert.isTrue(promptStub.calledOnce);
+        let choices = promptStub.firstCall.args[0][0].choices;
+        let customGeneratorChoice = choices[choices.length-1];
+        assert.equal(stripAnsi(customGeneratorChoice.name), 'custom-template: no description');
+        assert.equal(customGeneratorChoice.value, 'polymer-init-custom-template:app');
+        assert.equal(customGeneratorChoice.short, 'custom-template');
+      });
+    });
+
+    test('prompts the user with a list', () => {
+      let promptStub = sandbox.stub(inquirer, 'prompt').returns(Promise.resolve({generatorName: 'TEST'}));
+
+      return polymerInit.promptGeneratorSelection({env: yeomanEnvMock}).catch((err) => {
+        assert.equal(err.message, 'Template TEST not found');
+      }).then(() => {
+        assert.isTrue(promptStub.calledOnce);
+        assert.equal(promptStub.firstCall.args[0][0].type, 'list');
+      });
+    });
+
+    if (isPlatformWin) {
+
+      test('prompts with a rawlist if being used in MinGW shell', () => {
+        let promptStub = sandbox.stub(inquirer, 'prompt').returns(Promise.resolve({generatorName: 'TEST'}));
+        sandbox.stub(childProcess, 'execSync').withArgs('uname -s').returns('mingw');
+
+        return polymerInit.promptGeneratorSelection({env: yeomanEnvMock}).catch((err) => {
+          assert.equal(err.message, 'Template TEST not found');
+        }).then(() => {
+          assert.isTrue(promptStub.calledOnce);
+          assert.equal(promptStub.firstCall.args[0][0].type, 'rawlist');
+        });
+      });
+
+    }
+
+  });
+
+});


### PR DESCRIPTION
> *Whoops, looks like you can't reopen the original PR once closed. See https://github.com/Polymer/polymer-cli/pull/246 for past discussion (most of it outdated)*

There was considerable configuration/boilerplate brought into the `init` command tests, as a workaround to how self-contained and complex the command was. This refactoring pulls the main init logic out of the command itself, which has several benefits to our architecture:

- Removes the mockery dependency that was added for testing the original code 
- Reduces startup time considerably by delaying yeoman loading until the init command is run
- Keeps the command small and singular in focus

/cc @justinfagnani 