### PR TITLE
assign element using `var` instead of `let`

### DIFF
--- a/src/init/application/templates/test/_element/_element_test.html
+++ b/src/init/application/templates/test/_element/_element_test.html
@@ -22,7 +22,7 @@
       suite('<%= elementName %>', function() {
 
         test('instantiating the element works', function() {
-          let element = fixture('basic');
+          var element = fixture('basic');
           assert.equal(element.is, '<%= elementName %>');
         });
 

--- a/src/init/element/templates/test/_element_test.html
+++ b/src/init/element/templates/test/_element_test.html
@@ -22,7 +22,7 @@
       suite('<%= name %>', function() {
 
         test('instantiating the element works', function() {
-          let element = fixture('basic');
+          var element = fixture('basic');
           assert.equal(element.is, '<%= name %>');
         });
 


### PR DESCRIPTION
`let` makes non ecma script 6 compliant browsers ignore the test (tested using Safari Version 9.1.1)