### PR TITLE
Accept relative roots in project config.

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
   },
   "devDependencies": {
     "chai": "^3.5.0",
+    "del": "^2.2.0",
     "depcheck": "^0.6.3",
     "gulp-eslint": "^2.0.0",
     "gulp-mocha": "^2.2.0",

--- a/src/build/build.ts
+++ b/src/build/build.ts
@@ -59,7 +59,7 @@ export interface BuildOptions extends OptimizeOptions {
 export function build(options?: BuildOptions, config?: ProjectConfig): Promise<any> {
   return new Promise<any>((buildResolve, _) => {
     options = options || {};
-    let root = config.root;
+    let root = path.resolve(config.root);
     let entrypoint = config.entrypoint;
     let shell = config.shell;
     let fragments = config.fragments;

--- a/test/build/build_test.js
+++ b/test/build/build_test.js
@@ -1,0 +1,70 @@
+/**
+ * @license
+ * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ */
+
+'use strict';
+
+const path = require('path');
+const os = require('os');
+const fs = require('fs');
+const del = require('del');
+
+const build = require('../../lib/build/build');
+
+const makeDir = (_path) => fs.mkdirSync(path.resolve(_path));
+const rmDir = (_path) => del.sync([path.resolve(_path)]);
+const makeFile = (filename, contents, root) => fs.writeFileSync(
+    path.resolve(root || '/tmp/root', filename), contents);
+
+const framework = root => makeFile('framework.html', `
+<div id="framework"></div>
+`, root);
+
+const entrypointA = root => makeFile('entrypointA.html', `
+<link rel="import" href="framework.html">
+<div id="entrypointA"></div>
+`, root);
+
+suite('Build', () => {
+  let savedCwd;
+
+  setup(() => {
+    savedCwd = process.cwd();
+    process.chdir(os.tmpdir());
+  });
+
+  teardown(() => {
+    process.chdir(savedCwd);
+  });
+
+  suite('relative roots', () => {
+    const root = 'relative';
+
+    setup(() => {
+      makeDir(root);
+    });
+
+    teardown(() => {
+      rmDir(root);
+    });
+
+    test('are supported', () => {
+      const root = 'relative';
+
+      framework(root);
+      entrypointA(root);
+
+      return build.build({}, {
+        root: root,
+        entrypoint: path.resolve(root, 'entrypointA.html'),
+        fragments: [],
+      });
+    });
+  });
+});


### PR DESCRIPTION
Most file paths in the project config are resolved to their absolute
paths by the time they are passed to `build`. For some reason, this is
not true for `root`. This change resolves the configured `root` to its
absolute path, so that [a later check](https://github.com/Polymer/polymer-cli/blob/master/src/build/url-from-path.ts#L43-L45) comparing root to other file paths
will succeed when appropriate.