### PR TITLE
Update command-line-* suite of dependencies, refactor to accomodate

### DIFF
--- a/custom_typings/command-line-args.d.ts
+++ b/custom_typings/command-line-args.d.ts
@@ -1,7 +1,4 @@
 declare module 'command-line-args' {
-  function commandLineArgs(args: commandLineArgs.ArgDescriptor[])
-      : commandLineArgs.CLI;
-
   module commandLineArgs {
     interface ArgDescriptor {
       name: string;
@@ -13,17 +10,9 @@ declare module 'command-line-args' {
       defaultOption?: boolean;
       group?: string;
     }
-    interface UsageOpts {
-      title?: string;
-      header?: string;
-      description?: string;
-      groups?: any;
-    }
-    interface CLI {
-      parse(): any;
-      getUsage(opts: UsageOpts): string;
-    }
   }
+
+  function commandLineArgs(groups: commandLineArgs.ArgDescriptor[], args?: string[]): any;
 
   export = commandLineArgs;
 }

--- a/custom_typings/command-line-commands.d.ts
+++ b/custom_typings/command-line-commands.d.ts
@@ -1,26 +1,13 @@
 declare module 'command-line-commands' {
   module commandLineCommands {
-    interface CommandDescriptor {
-      name: string;
-      definitions?: any[];
-      description?: string;
-      defaultOption?: boolean;
-    }
-
-    interface Command {
-      name: string;
-      options: {[name: string]: string|{[name: string]: string}};
-    }
-
-    interface CLI {
-      commands: CommandDescriptor[];
-      parse(args?: string[]): Command;
-      getUsage(): string;
+    interface ParsedCommand {
+      command: string;
+      argv: string[];
     }
   }
 
-  function commandLineCommands(args: commandLineCommands.CommandDescriptor[])
-      : commandLineCommands.CLI;
+  function commandLineCommands(commands: string[], argv?: string[])
+      : commandLineCommands.ParsedCommand;
 
   export = commandLineCommands;
 }

--- a/custom_typings/command-line-usage.d.ts
+++ b/custom_typings/command-line-usage.d.ts
@@ -1,0 +1,24 @@
+declare module 'command-line-usage' {
+  module commandLineUsage {
+    interface ArgDescriptor {
+      name: string;
+      alias?: string;
+      description?: string;
+      defaultValue?: any;
+      type?: Object;
+      multiple?: boolean;
+      defaultOption?: boolean;
+      group?: string;
+    }
+    interface UsageGroup {
+      header?: string;
+      content?: any;
+      optionList?: ArgDescriptor[];
+      raw?: boolean;
+    }
+  }
+
+  function commandLineUsage(groups: commandLineUsage.UsageGroup[]): string;
+
+  export = commandLineUsage;
+}

--- a/package.json
+++ b/package.json
@@ -25,8 +25,9 @@
   "dependencies": {
     "chalk": "^1.1.3",
     "clone": "^1.0.2",
-    "command-line-args": "^2.1.6",
-    "command-line-commands": "^0.1.2",
+    "command-line-args": "^3.0.0",
+    "command-line-commands": "^1.0.3",
+    "command-line-usage": "^3.0.1",
     "css-slam": "^1.1.0",
     "dom5": "^1.3.1",
     "findup": "^0.1.5",

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -9,8 +9,6 @@
  */
 
 import {ArgDescriptor} from 'command-line-args';
-import {CLI} from 'command-line-commands';
-
 import {BuildOptions} from '../build/build';
 import {Command} from './command';
 import * as logging from 'plylog';

--- a/test/commands/cli_test.js
+++ b/test/commands/cli_test.js
@@ -27,7 +27,7 @@ suite('The general CLI', () => {
     let helpCommandSpy = sinon.spy(helpCommand, 'run');
     cli.run();
     assert.isOk(helpCommandSpy.calledOnce);
-    assert.deepEqual(helpCommandSpy.firstCall.args, [{}, defaultConfig]);
+    assert.deepEqual(helpCommandSpy.firstCall.args, [{command: null}, defaultConfig]);
   });
 
   test('displays general help when no command is called with the --help flag', () => {
@@ -36,7 +36,7 @@ suite('The general CLI', () => {
     let helpCommandSpy = sinon.spy(helpCommand, 'run');
     cli.run();
     assert.isOk(helpCommandSpy.calledOnce);
-    assert.deepEqual(helpCommandSpy.firstCall.args, [{}, defaultConfig]);
+    assert.deepEqual(helpCommandSpy.firstCall.args, [{command: null}, defaultConfig]);
   });
 
   test('displays general help when unknown command is called', () => {
@@ -45,7 +45,7 @@ suite('The general CLI', () => {
     let helpCommandSpy = sinon.spy(helpCommand, 'run');
     cli.run();
     assert.isOk(helpCommandSpy.calledOnce);
-    assert.deepEqual(helpCommandSpy.firstCall.args, [{}, defaultConfig]);
+    assert.deepEqual(helpCommandSpy.firstCall.args, [{command: 'THIS_IS_SOME_UNKNOWN_COMMAND'}, defaultConfig]);
   });
 
   test('displays command help when called with the --help flag', () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -51,6 +51,7 @@
     "src/project-config.ts",
     "custom_typings/command-line-args.d.ts",
     "custom_typings/command-line-commands.d.ts",
+    "custom_typings/command-line-usage.d.ts",
     "custom_typings/dom5.d.ts",
     "custom_typings/fs-extra.d.ts",
     "custom_typings/github.d.ts",


### PR DESCRIPTION
The command-line-* suite of libraries went through a major redesign for v1.0. This PR uses the new suite of tools, all updated to their latest versions.

/cc @justinfagnani

 