### PR TITLE
replace unneccesary gulp dependency with vinyl-fs

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "findup": "^0.1.5",
     "fs-extra": "^0.30.0",
     "github": "^1.1.0",
-    "gulp": "^3.9.1",
     "gulp-if": "^2.0.0",
     "gunzip-maybe": "^1.3.1",
     "html-minifier": "^3.0.1",
@@ -50,6 +49,7 @@
     "uglify-js": "^2.7.0",
     "update-notifier": "^1.0.0",
     "vinyl": "^1.1.1",
+    "vinyl-fs": "^2.4.3",
     "web-component-tester": "^4.2.0",
     "yeoman-environment": "^1.5.2",
     "yeoman-generator": "^0.23.3"
@@ -57,6 +57,7 @@
   "devDependencies": {
     "chai": "^3.5.0",
     "depcheck": "^0.6.3",
+    "gulp": "^3.9.1",
     "gulp-eslint": "^2.0.0",
     "gulp-mocha": "^2.2.0",
     "gulp-tslint": "^5.0.0",

--- a/src/build/build.ts
+++ b/src/build/build.ts
@@ -10,7 +10,7 @@
 
 import clone = require('clone');
 import * as fs from 'fs';
-import * as gulp from 'gulp';
+import {dest} from 'vinyl-fs';
 import * as gulpif from 'gulp-if';
 import * as gutil from 'gulp-util';
 import mergeStream = require('merge-stream');
@@ -102,12 +102,12 @@ export function build(options: BuildOptions, config: ProjectConfig): Promise<any
             polymerProject.analyzer)
         )
       )
-      .pipe(gulp.dest('build/unbundled'));
+      .pipe(dest('build/unbundled'));
 
     let bundledPhase = forkStream(buildStream)
       .once('data', () => { logger.info('Generating build/bundled...'); })
       .pipe(polymerProject.bundler)
-      .pipe(gulp.dest('build/bundled'));
+      .pipe(dest('build/bundled'));
 
     let swPrecacheConfig = path.resolve(polymerProject.root, options.swPrecacheConfig || 'sw-precache-config.js');
     let loadSWConfig = parsePreCacheConfig(swPrecacheConfig);


### PR DESCRIPTION
With the new build pipeline, gulp is unneccesary as a regular dependency. Instead, we can use vinyl-fs directly and greatly reduce our dependency graph. (internally, `gulp.dest` is just a direct reference to `vinyl-fs.dest`)

See http://npm.anvaka.com/#/view/2d/gulp (212) vs. http://npm.anvaka.com/#/view/2d/vinyl-fs (89)

/cc @justinfagnani 