### PR TITLE
v0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## v0.16.0
+
+- build: fail immediately if polymer.json is invalid
+- build: Add missing support for `sourceGlobs` & `includeDependencies` in polymer.json 
+- polymer-build@v0.4.1 (fixes ignored `staticFileGlobs` bug)
+
+
+## v0.15.0
+
+- replace app-drawer-template with starter-kit
+
+
 ## v0.14.0
 
 - replace unneccesary gulp dependency with vinyl-fs

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "polymer-cli",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "A commandline tool for Polymer projects",
   "main": "lib/polymer-cli.js",
   "engines": {


### PR DESCRIPTION
- build: fail immediately if polymer.json is invalid
- build: Add missing support for `sourceGlobs` & `includeDependencies` in polymer.json 
- polymer-build@v0.4.1 (fixes ignored `staticFileGlobs` bug)

/cc @justinfagnani @robdodson 