### PR TITLE
Remove application-specific info from the README

### DIFF
--- a/src/init/element/templates/README.md
+++ b/src/init/element/templates/README.md
@@ -6,27 +6,16 @@
 
 First, make sure you have the [Polymer CLI](https://www.npmjs.com/package/polymer-cli) installed. Then run `polymer serve` to serve your application locally.
 
-## Viewing Your Application
+## Viewing Your Element
 
 ```
 $ polymer serve
 ```
 
-## Building Your Application
+You can then view the documentation and demo through this URL:
 
 ```
-$ polymer build
-```
-
-This will create a `build/` folder with `bundled/` and `unbundled/` sub-folders
-containing a bundled (Vulcanized) and unbundled builds, both run through HTML,
-CSS, and JS optimizers.
-
-You can serve the built versions by giving `polymer serve` a folder to serve
-from:
-
-```
-$ polymer serve build/bundled
+http://localhost:8080/components/<%= name%>/
 ```
 
 ## Running Tests
@@ -35,4 +24,4 @@ $ polymer serve build/bundled
 $ polymer test
 ```
 
-Your application is already set up to be tested via [web-component-tester](https://github.com/Polymer/web-component-tester). Run `polymer test` to run your application's test suite locally.
+Your element is already set up to be tested via [web-component-tester](https://github.com/Polymer/web-component-tester). Run `polymer test` to run your application's test suite locally.


### PR DESCRIPTION
The text is misleading for working with elements. Not only is 'Application' confusing, but  `polymer build` doesn't work for them out of the box with this setup.