### PR TITLE
Add .gitignore to init templates

### DIFF
--- a/src/init/application/templates/.gitignore
+++ b/src/init/application/templates/.gitignore
@@ -1,0 +1,1 @@
+bower_components/

--- a/src/init/element/templates/.gitignore
+++ b/src/init/element/templates/.gitignore
@@ -1,0 +1,1 @@
+bower_components/


### PR DESCRIPTION
To make sure the user does not accidentally commit the `bower_components` folder when pushing a new element/application to git.