### PR TITLE
cleanup gulp tasks & npm scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ before_script:
   - npm install
   - npm run build
 script:
-  - npm run test
+  - npm test

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -25,20 +25,16 @@ const tsProject = typescript.createProject('tsconfig.json');
 
 gulp.task('lint', ['tslint', 'eslint', 'depcheck']);
 
-gulp.task('build', () => {
+gulp.task('clean', (done) => {
+  fs.remove(path.join(__dirname, 'lib'), done);
+});
+
+gulp.task('build', ['clean'], () => {
   let tsReporter = typescript.reporter.defaultReporter();
   return mergeStream(
       tsProject.src().pipe(tsProject(tsReporter)),
       gulp.src(['src/**/*', '!src/**/*.ts'])
     ).pipe(gulp.dest('lib'));
-});
-
-gulp.task('clean', (done) => {
-  fs.remove(path.join(__dirname, 'lib'), done);
-});
-
-gulp.task('build-all', (done) => {
-  runSeq('clean', 'lint', 'build', done);
 });
 
 gulp.task('test', ['build'], () =>

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
   "scripts": {
     "lint": "gulp lint",
     "build": "gulp build",
-    "test": "gulp test",
-    "prepublish": "gulp build-all && gulp test"
+    "test": "gulp lint test",
+    "prepublish": "npm run build && npm test"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
- 'init' & 'typings' are going away in #411
- remove 'build-all', now just use 'test'

/cc @justinfagnani @rictic 