### PR TITLE
add custom typescript declaration for merge-stream

### DIFF
--- a/custom_typings/merge-stream.d.ts
+++ b/custom_typings/merge-stream.d.ts
@@ -4,7 +4,7 @@ declare module "merge-stream" {
     interface MergedStream extends NodeJS.ReadWriteStream {
       add: (source: NodeJS.ReadableStream) => MergedStream;
     }
-	}
+  }
 
   function mergeStream<T extends NodeJS.ReadableStream>(...streams: T[]): mergeStream.MergedStream;
   export = mergeStream;

--- a/custom_typings/merge-stream.d.ts
+++ b/custom_typings/merge-stream.d.ts
@@ -1,0 +1,12 @@
+declare module "merge-stream" {
+
+  module mergeStream {
+    interface MergedStream extends NodeJS.ReadWriteStream {
+      add: (source: NodeJS.ReadableStream) => MergedStream;
+    }
+	}
+
+  function mergeStream<T extends NodeJS.ReadableStream>(...streams: T[]): mergeStream.MergedStream;
+  export = mergeStream;
+
+}

--- a/src/build/build.ts
+++ b/src/build/build.ts
@@ -15,6 +15,7 @@ import * as gulpif from 'gulp-if';
 import * as path from 'path';
 import {PassThrough, Readable} from 'stream';
 import * as logging from 'plylog';
+import * as mergeStream from 'merge-stream';
 import {PolymerProject, addServiceWorker, forkStream, DepsIndex, SWConfig} from 'polymer-build';
 
 import {JSOptimizeStream, CSSOptimizeStream, HTMLOptimizeStream} from './optimize-streams';
@@ -23,11 +24,6 @@ import {ProjectConfig} from '../project-config';
 import {PrefetchTransform} from './prefetch';
 import {waitFor} from './streams';
 import {parsePreCacheConfig} from './sw-precache';
-
-// TODO(fks) 09-22-2016: Latest npm type declaration resolves to a non-module
-// entity. Upgrade to proper JS import once compatible .d.ts file is released,
-// or consider writing a custom declaration in the `custom_typings/` folder.
-import mergeStream = require('merge-stream');
 
 let logger = logging.getLogger('cli.build.build');
 


### PR DESCRIPTION
After merging I was still getting errors from `merge-stream` for not having a type declaration, so I bit the bullet and added one. After this polymer-cli should be building without errors.

/cc @rictic @justinfagnani 