### PR TITLE
add back env.lookup() error handling

### DIFF
--- a/custom_typings/yeoman-environment.d.ts
+++ b/custom_typings/yeoman-environment.d.ts
@@ -4,7 +4,7 @@ declare module 'yeoman-environment' {
     registerStub(generator: any, namespace: string);
     run(target: string, options: any, done: Function);
     getGeneratorsMeta(): YeomanEnvironment.GeneratorMeta[];
-    lookup(callback: () => void);
+    lookup(callback: (error?: Error) => void);
   }
 
   namespace YeomanEnvironment {

--- a/src/init/init.ts
+++ b/src/init/init.ts
@@ -124,7 +124,11 @@ function createYeomanEnvironment(): Promise<any> {
     env.registerStub(ApplicationGenerator, 'polymer-init-application:app');
     env.registerStub(shopGenerator, 'polymer-init-shop:app');
     env.registerStub(pskGenerator, 'polymer-init-starter-kit:app');
-    env.lookup(() => {
+    env.lookup((error?: Error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
       resolve(env);
     });
   });


### PR DESCRIPTION
I looked into adding a test but because we call lookup() in the same function scope where we create the Env object it's not easy. Since this error [never actually happens](http://yeoman.io/environment/resolver.js.html#line49) I'm okay with leaving this untested for now, unless anyone feels strongly against.

/cc @justinfagnani @rictic