### PR TITLE
Fix runtime error on `polymer init`

### DIFF
--- a/src/init/init.ts
+++ b/src/init/init.ts
@@ -177,7 +177,7 @@ export async function runGenerator(generatorName: string, options: {[name: strin
   options = options || {};
   const templateName = options['templateName'] || generatorName;
 
-  const env: YeomanEnvironment = await options['env'] || createYeomanEnvironment();
+  const env: YeomanEnvironment = await options['env'] || await createYeomanEnvironment();
 
   logger.info(`Running template ${templateName}...`);
   logger.debug(`Running generator ${generatorName}...`);
@@ -206,7 +206,7 @@ export async function runGenerator(generatorName: string, options: {[name: strin
  */
 export async function promptGeneratorSelection(options: {[name: string]: any}): Promise<void> {
   options = options || {};
-  const env = await options['env'] || createYeomanEnvironment();
+  const env = await options['env'] || await createYeomanEnvironment();
   // TODO(justinfagnani): the typings for inquirer appear wrong
   const answers = await (prompt([createSelectPrompt(env)]) as any);
   const generatorName = answers['generatorName'];

--- a/src/init/init.ts
+++ b/src/init/init.ts
@@ -177,7 +177,7 @@ export async function runGenerator(generatorName: string, options: {[name: strin
   options = options || {};
   const templateName = options['templateName'] || generatorName;
 
-  const env: YeomanEnvironment = await options['env'] || await createYeomanEnvironment();
+  const env: YeomanEnvironment = await (options['env'] || createYeomanEnvironment());
 
   logger.info(`Running template ${templateName}...`);
   logger.debug(`Running generator ${generatorName}...`);
@@ -206,7 +206,7 @@ export async function runGenerator(generatorName: string, options: {[name: strin
  */
 export async function promptGeneratorSelection(options: {[name: string]: any}): Promise<void> {
   options = options || {};
-  const env = await options['env'] || await createYeomanEnvironment();
+  const env = await (options['env'] || createYeomanEnvironment());
   // TODO(justinfagnani): the typings for inquirer appear wrong
   const answers = await (prompt([createSelectPrompt(env)]) as any);
   const generatorName = answers['generatorName'];


### PR DESCRIPTION
<!--
  Thanks for the PR!

  If this change has a user visible change (including
  bug fixes, new features, etc) please describe the change in
  CHANGELOG.md.

  If the change is an entirely package-internal reshuffling/refactoring
  should the change not be described in the CHANGELOG.

  Consider also updating the README.

  More info: http://keepachangelog.com/en/0.3.0/
 -->

 - [ ] CHANGELOG.md has been updated

`createYeomanEnvironment()` returns a promise, but a couple callers weren't updated to await it, resulting in a runtime error when they tried to access methods not available on a promise.