### PR TITLE
Fix generator names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Added an `install` command, which can install "variants" of Bower dependencies. TODO(justinfagnani): document variants.
 - Added support for v7.x of Node.js, dropped support for v5.x. Please move to an [actively maintained version of Node.js](https://github.com/nodejs/LTS) for the best experience.
 - Upgrade [web-component-tester 6.0](https://github.com/Polymer/web-component-tester/blob/master/CHANGELOG.md) which brings a number of breaking changes to the `test` command.
+- `init`: Fix duplicate names for sub-generators in a directory
 
 ## v0.17.0
 

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -37,7 +37,8 @@ export class InitCommand implements Command {
 
     const templateName = options['name'];
     if (templateName) {
-      const generatorName = `polymer-init-${templateName}:app`;
+      const subgen = (templateName.indexOf(':') !== -1) ? '' : ':app';
+      const generatorName = `polymer-init-${templateName}${subgen}`;
       logger.debug('template name provided', {
         generator: generatorName,
         template: templateName,

--- a/src/init/init.ts
+++ b/src/init/init.ts
@@ -136,9 +136,9 @@ function getGeneratorMeta(
 
 /**
  * Extract the meaningful name from the full Yeoman generator name.
- * Strip the standard generator prefixes ("generator-" and "polymer-init-"),
- * and extract the remainder of the name (the first part of the string
- * before any colons).
+ * Strip the standard generator prefixes ("generator-", "polymer-init-",
+ * and "polymer-starter-kit-"), and extract the remainder of the name
+ * (the first part of the string before any colons).
  *
  * Examples:
  *
@@ -150,16 +150,18 @@ function getGeneratorMeta(
  *   'foo-bar:ccc'                        === 'foo-bar'
  */
 function getDisplayName(generatorName: string) {
-  // Breakdown of regular expression to extract name (group 3 in pattern):
+  // Breakdown of regular expression to extract name (group 4 in pattern):
   //
-  //  Pattern           | Meaning
-  //  -------------------------------------------------------------------
-  //  (generator-)?     | Group 1; Match "generator-"; Optional
-  //  (polymer-init-)?  | Group 2; Match "polymer-init-"; Optional
-  //  ([^:]+)           | Group 3; Match one or more characters != ':'
-  //  (:.*)?            | Group 4; Match ':' followed by anything; Optional
-  return generatorName.replace(/(generator-)?(polymer-init-)?([^:]+)(:.*)?/g,
-                               '$3');
+  // Pattern                 | Meaning
+  // -------------------------------------------------------------------
+  // (generator-)?           | Grp 1; Match "generator-"; Optional
+  // (polymer-init)?         | Grp 2; Match "polymer-init-"; Optional
+  // (polymer-starter-kit-)? | Grp 3; Match "polymer-starter-kit-"; Optional
+  // ([^:]+)                 | Grp 4; Match one or more characters != ":"
+  // (:.*)?                  | Grp 5; Match ":" followed by anything; Optional
+  return generatorName.replace(
+      /(generator-)?(polymer-init-)?(polymer-starter-kit-)?([^:]+)(:.*)?/g,
+      '$4');
 }
 
 /**

--- a/test/unit/init/init_test.js
+++ b/test/unit/init/init_test.js
@@ -138,20 +138,20 @@ suite('init', () => {
     setup(() => {
       let generators = {};
 
-      for (let g of GENERATORS) {
-        if (!g.resolved) {
+      for (let generator of GENERATORS) {
+        if (!generator.resolved) {
           let tmpDir = temp.mkdirSync();
           let packageJsonPath = `${tmpDir}/package.json`;
           fs.writeFileSync(packageJsonPath, JSON.stringify({
-            description: g.description,
-            name: g.metaName,
+            description: generator.description,
+            name: generator.metaName,
           }));
-          g.resolved = tmpDir;
+          generator.resolved = tmpDir;
         }
 
-        generators[g.generatorName] = {
-          resolved: g.resolved,
-          namespace: g.generatorName,
+        generators[generator.generatorName] = {
+          resolved: generator.resolved,
+          namespace: generator.generatorName,
         };
       }
 
@@ -187,12 +187,12 @@ suite('init', () => {
         let choices = promptStub.firstCall.args[0][0].choices;
         assert.equal(choices.length, GENERATORS.length);
 
-        for (let c of choices) {
-          let g = GENERATORS.find(x => x.generatorName === c.value);
-          assert.isDefined(g, `generator not found: ${c.value}`);
-          assert.oneOf(stripAnsi(c.name), [g.shortName, `${g.shortName} - ${g.description}`]);
-          assert.equal(c.value, g.generatorName);
-          assert.equal(c.short, g.shortName);
+        for (let choice of choices) {
+          let generator = GENERATORS.find(generator => generator.generatorName === choice.value);
+          assert.isDefined(generator, `generator not found: ${choice.value}`);
+          assert.oneOf(stripAnsi(choice.name), [generator.shortName, `${generator.shortName} - ${generator.description}`]);
+          assert.equal(choice.value, generator.generatorName);
+          assert.equal(choice.short, generator.shortName);
         }
       });
     });

--- a/test/unit/init/init_test.js
+++ b/test/unit/init/init_test.js
@@ -15,6 +15,7 @@ const helpers = require('yeoman-test');
 const childProcess = require('child_process');
 const inquirer = require('inquirer');
 const YeomanEnvironment = require('yeoman-environment');
+const path = require('path');
 
 const polymerInit = require('../../../lib/init/init');
 
@@ -95,6 +96,10 @@ suite('init', () => {
           resolved: 'unknown',
           namespace: 'polymer-init-element:app',
         },
+        'polymer-init-my-test-app:app': {
+          resolved: path.resolve(__dirname, 'package.json'),
+          namespace: 'polymer-init-my-test-app:app',
+        },
       });
     });
 
@@ -124,10 +129,15 @@ suite('init', () => {
         assert.equal(error.message, 'Template TEST not found');
       }).then(() => {
         let choices = promptStub.firstCall.args[0][0].choices;
-        assert.equal(choices.length, 1);
+        assert.equal(choices.length, 2);
         assert.equal(stripAnsi(choices[0].name), 'element - A blank element template');
         assert.equal(choices[0].value, 'polymer-init-element:app');
         assert.equal(choices[0].short, 'element');
+
+        // custom generator's name and description parsed from package.json
+        assert.equal(stripAnsi(choices[1].name), 'my-test-app - dummy description');
+        assert.equal(choices[1].value, 'polymer-init-my-test-app:app');
+        assert.equal(choices[1].short, 'my-test-app');
       });
     });
 

--- a/test/unit/init/package.json
+++ b/test/unit/init/package.json
@@ -1,4 +1,0 @@
-{
-  "name": "polymer-init-my-test-app",
-  "description": "dummy description"
-}

--- a/test/unit/init/package.json
+++ b/test/unit/init/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "polymer-init-my-test-app",
+  "description": "dummy description"
+}


### PR DESCRIPTION
<!--
  Thanks for the PR!

  If this change has a user visible change (including
  bug fixes, new features, etc) please describe the change in
  CHANGELOG.md.

  If the change is an entirely package-internal reshuffling/refactoring
  should the change not be described in the CHANGELOG.

  Consider also updating the README.

  More info: http://keepachangelog.com/en/0.3.0/
 -->

 - [x] CHANGELOG.md has been updated

The generator name was parsed from the directory name (`./generator-polymer-init-foo/` --> `"foo"`), and this name was given to all sub-generators in the directory, regardless of their individual `package.json` config for `name`, which made them indistinguishable without descriptions. Technically, Yeoman generators are supposed to be named based on their `package.json` config [[1]](http://yeoman.io/authoring/).

### Example

```
generator-polymer-init-my-app
├── generators
│   ├── foo
│   │   ├── index.js
│   │   ├── package.json   # name: 'polymer-init-foo-el', description: 'My foo element'
│   │   └── templates
│   │      └── _element_test.html
│   └── bar
│       ├── index.js
│       ├── package.json   # name: 'polymer-init-bar-el', description: 'My bar element'
│       └── templates
│          └── _element_test.html
└── package.json # description: 'My test app'
```

*Before*
```
$ polymer init
? Which starter template would you like to use? 
  element - A blank element template 
  application - A blank application template 
  shop - The "Shop" Progressive Web App demo 
  starter-kit - A starter application template, with navigation and "PRPL pattern" loading 
❯ my-app - My foo element
  my-app - My bar element
```

*After*
```
$ polymer init
? Which starter template would you like to use? 
  element - A blank element template 
  application - A blank application template 
  shop - The "Shop" Progressive Web App demo 
  starter-kit - A starter application template, with navigation and "PRPL pattern" loading 
❯ foo-el - My foo element
  bar-el - My bar element
```
