### PR TITLE
import fixups, and adding missing licence headers

### DIFF
--- a/src/args.ts
+++ b/src/args.ts
@@ -12,7 +12,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {ArgDescriptor} from './commands/command';
+import {ArgDescriptor} from 'command-line-args';
 import {Environment} from './environment/environment';
 import {buildEnvironment} from './environments/environments';
 

--- a/src/build/optimize-streams.ts
+++ b/src/build/optimize-streams.ts
@@ -1,3 +1,17 @@
+/**
+ * @license
+ * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
 import {css as cssSlam} from 'css-slam';
 import {minify as htmlMinify, Options as HTMLMinifierOptions} from 'html-minifier';
 import * as logging from 'plylog';

--- a/src/commands/analyze.ts
+++ b/src/commands/analyze.ts
@@ -13,7 +13,8 @@
  */
 
 import * as logging from 'plylog';
-import {Command, CommandOptions, ProjectConfig} from './command';
+import {ProjectConfig} from 'polymer-project-config';
+import {Command, CommandOptions} from './command';
 
 const logger = logging.getLogger('cli.command.analyze');
 

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -19,7 +19,8 @@ import * as logging from 'plylog';
 // be loaded and parsed.
 import {BuildOptions} from '../build/build';
 
-import {Command, CommandOptions, ProjectConfig} from './command';
+import {ProjectConfig} from 'polymer-project-config';
+import {Command, CommandOptions} from './command';
 
 let logger = logging.getLogger('cli.command.build');
 

--- a/src/commands/command.ts
+++ b/src/commands/command.ts
@@ -1,7 +1,19 @@
-import {ArgDescriptor} from 'command-line-args';
+/**
+ * @license
+ * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
 
+import {ArgDescriptor} from 'command-line-args';
 import {ProjectConfig} from 'polymer-project-config';
-export {ProjectConfig} from 'polymer-project-config';
 
 export type CommandOptions = {
   [name: string]: any
@@ -13,5 +25,3 @@ export interface Command {
   args: ArgDescriptor[];
   run(options: CommandOptions, config: ProjectConfig): Promise<any>;
 }
-
-export {ArgDescriptor} from 'command-line-args';

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -16,7 +16,8 @@ import * as chalk from 'chalk';
 import * as commandLineUsage from 'command-line-usage';
 import * as logging from 'plylog';
 import {globalArguments} from '../args';
-import {Command, CommandOptions, ProjectConfig} from './command';
+import {ProjectConfig} from 'polymer-project-config';
+import {Command, CommandOptions} from './command';
 
 let logger = logging.getLogger('cli.command.help');
 

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -14,8 +14,8 @@
 
 import {ArgDescriptor} from 'command-line-args';
 import * as logging from 'plylog';
-
-import {Command, CommandOptions, ProjectConfig} from './command';
+import {ProjectConfig} from 'polymer-project-config';
+import {Command, CommandOptions} from './command';
 
 let logger = logging.getLogger('cli.command.init');
 

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -12,7 +12,8 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {Command, CommandOptions, ProjectConfig} from './command';
+import {ProjectConfig} from 'polymer-project-config';
+import {Command, CommandOptions} from './command';
 
 export class InstallCommand implements Command {
   name = 'install';

--- a/src/commands/lint.ts
+++ b/src/commands/lint.ts
@@ -14,7 +14,8 @@
 
 import * as commandLineArgs from 'command-line-args';
 import * as logging from 'plylog';
-import {Command, CommandOptions, ProjectConfig} from './command';
+import {ProjectConfig} from 'polymer-project-config';
+import {Command, CommandOptions} from './command';
 
 const logger = logging.getLogger('cli.lint');
 

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -18,10 +18,9 @@ import {args as polyserveArgs} from 'polyserve/lib/args';
 // the JS output, triggering  the entire build library & its dependencies to
 // be loaded and parsed.
 import {ServerOptions} from 'polyserve/lib/start_server';
-
 import {Environment} from '../environment/environment';
-
-import {Command, CommandOptions, ProjectConfig} from './command';
+import {ProjectConfig} from 'polymer-project-config';
+import {Command, CommandOptions} from './command';
 
 let logger = logging.getLogger('cli.command.serve');
 

--- a/src/commands/test.ts
+++ b/src/commands/test.ts
@@ -12,7 +12,8 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {Command, CommandOptions, ProjectConfig} from './command';
+import {ProjectConfig} from 'polymer-project-config';
+import {Command, CommandOptions} from './command';
 
 export class TestCommand implements Command {
   name = 'test';


### PR DESCRIPTION
Looks like these weird imports were just copy-pasted around the different commands.
/cc @rictic @justinfagnani 