### PR TITLE
Add a npm-shinkwrap.json file

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,8 +8,8 @@ install:
   - ps: Install-Product node $env:nodejs_version
   # Get npm 3
   - npm install -g npm
-  # install modules
-  - npm install
+  # install modules. Use --force to workaround permissions issues on Windows
+  - npm install --force
 
 # Post-install test scripts.
 test_script:

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,0 +1,3762 @@
+{
+  "name": "polymer-cli",
+  "version": "0.18.0-alpha.8",
+  "dependencies": {
+    "@types/babel-core": {
+      "version": "6.7.14"
+    },
+    "@types/babel-template": {
+      "version": "6.7.14"
+    },
+    "@types/babel-traverse": {
+      "version": "6.7.15"
+    },
+    "@types/babel-types": {
+      "version": "6.7.14"
+    },
+    "@types/babylon": {
+      "version": "6.7.15"
+    },
+    "@types/bluebird": {
+      "version": "3.0.37"
+    },
+    "@types/body-parser": {
+      "version": "0.0.33"
+    },
+    "@types/chai": {
+      "version": "3.4.34"
+    },
+    "@types/chalk": {
+      "version": "0.4.31"
+    },
+    "@types/clean-css": {
+      "version": "3.4.30"
+    },
+    "@types/clone": {
+      "version": "0.1.30"
+    },
+    "@types/content-type": {
+      "version": "1.0.33"
+    },
+    "@types/del": {
+      "version": "2.2.31"
+    },
+    "@types/doctrine": {
+      "version": "0.0.1"
+    },
+    "@types/escodegen": {
+      "version": "0.0.2"
+    },
+    "@types/estraverse": {
+      "version": "0.0.2"
+    },
+    "@types/estree": {
+      "version": "0.0.34"
+    },
+    "@types/express": {
+      "version": "4.0.34"
+    },
+    "@types/express-serve-static-core": {
+      "version": "4.0.40"
+    },
+    "@types/findup-sync": {
+      "version": "0.3.29"
+    },
+    "@types/form-data": {
+      "version": "0.0.33"
+    },
+    "@types/freeport": {
+      "version": "1.0.20",
+      "optional": true
+    },
+    "@types/fs-extra": {
+      "version": "0.0.35"
+    },
+    "@types/glob": {
+      "version": "5.0.30"
+    },
+    "@types/glob-stream": {
+      "version": "3.1.30"
+    },
+    "@types/grunt": {
+      "version": "0.4.20"
+    },
+    "@types/gulp": {
+      "version": "3.8.32"
+    },
+    "@types/gulp-if": {
+      "version": "0.0.30"
+    },
+    "@types/html-minifier": {
+      "version": "1.1.30"
+    },
+    "@types/inquirer": {
+      "version": "0.0.32"
+    },
+    "@types/lodash": {
+      "version": "4.14.45"
+    },
+    "@types/merge-stream": {
+      "version": "1.0.28"
+    },
+    "@types/mime": {
+      "version": "0.0.29"
+    },
+    "@types/minimatch": {
+      "version": "2.0.29"
+    },
+    "@types/mocha": {
+      "version": "2.2.35"
+    },
+    "@types/multer": {
+      "version": "0.0.32"
+    },
+    "@types/mz": {
+      "version": "0.0.29"
+    },
+    "@types/node": {
+      "version": "0.0.2"
+    },
+    "@types/nomnom": {
+      "version": "0.0.28"
+    },
+    "@types/opn": {
+      "version": "3.0.28"
+    },
+    "@types/orchestrator": {
+      "version": "0.0.30"
+    },
+    "@types/parse5": {
+      "version": "2.2.34"
+    },
+    "@types/pem": {
+      "version": "1.8.1"
+    },
+    "@types/q": {
+      "version": "0.0.32"
+    },
+    "@types/relateurl": {
+      "version": "0.2.28"
+    },
+    "@types/request": {
+      "version": "0.0.36"
+    },
+    "@types/rx": {
+      "version": "4.1.1"
+    },
+    "@types/rx-core": {
+      "version": "4.0.0"
+    },
+    "@types/rx-core-binding": {
+      "version": "4.0.0"
+    },
+    "@types/rx-lite": {
+      "version": "4.0.0"
+    },
+    "@types/rx-lite-aggregates": {
+      "version": "4.0.0"
+    },
+    "@types/rx-lite-async": {
+      "version": "4.0.0"
+    },
+    "@types/rx-lite-backpressure": {
+      "version": "4.0.0"
+    },
+    "@types/rx-lite-coincidence": {
+      "version": "4.0.0"
+    },
+    "@types/rx-lite-experimental": {
+      "version": "4.0.0"
+    },
+    "@types/rx-lite-joinpatterns": {
+      "version": "4.0.0"
+    },
+    "@types/rx-lite-testing": {
+      "version": "4.0.0"
+    },
+    "@types/rx-lite-time": {
+      "version": "4.0.0"
+    },
+    "@types/rx-lite-virtualtime": {
+      "version": "4.0.0"
+    },
+    "@types/semver": {
+      "version": "5.3.30"
+    },
+    "@types/serve-static": {
+      "version": "1.7.31"
+    },
+    "@types/sinon": {
+      "version": "1.16.34"
+    },
+    "@types/sinon-chai": {
+      "version": "2.7.27"
+    },
+    "@types/socket.io": {
+      "version": "1.4.27"
+    },
+    "@types/source-map": {
+      "version": "0.5.0"
+    },
+    "@types/spdy": {
+      "version": "3.4.1"
+    },
+    "@types/temp": {
+      "version": "0.8.29"
+    },
+    "@types/through": {
+      "version": "0.0.28"
+    },
+    "@types/ua-parser-js": {
+      "version": "0.7.30"
+    },
+    "@types/uglify-js": {
+      "version": "2.6.28"
+    },
+    "@types/vinyl": {
+      "version": "2.0.0"
+    },
+    "@types/vinyl-fs": {
+      "version": "0.0.28"
+    },
+    "@types/which": {
+      "version": "1.0.28",
+      "optional": true
+    },
+    "@types/yeoman-generator": {
+      "version": "0.0.30"
+    },
+    "abbrev": {
+      "version": "1.0.9"
+    },
+    "accepts": {
+      "version": "1.3.3"
+    },
+    "accessibility-developer-tools": {
+      "version": "2.11.0"
+    },
+    "acorn": {
+      "version": "4.0.4"
+    },
+    "acorn-jsx": {
+      "version": "3.0.1",
+      "dependencies": {
+        "acorn": {
+          "version": "3.3.0"
+        }
+      }
+    },
+    "adm-zip": {
+      "version": "0.4.7",
+      "optional": true
+    },
+    "after": {
+      "version": "0.8.2"
+    },
+    "agent-base": {
+      "version": "2.0.1",
+      "dependencies": {
+        "semver": {
+          "version": "5.0.3"
+        }
+      }
+    },
+    "align-text": {
+      "version": "0.1.4"
+    },
+    "amdefine": {
+      "version": "1.0.1"
+    },
+    "ansi-align": {
+      "version": "1.1.0"
+    },
+    "ansi-escape-sequences": {
+      "version": "3.0.0"
+    },
+    "ansi-escapes": {
+      "version": "1.4.0"
+    },
+    "ansi-regex": {
+      "version": "2.0.0"
+    },
+    "ansi-styles": {
+      "version": "2.2.1"
+    },
+    "any-promise": {
+      "version": "1.3.0"
+    },
+    "append-field": {
+      "version": "0.1.0"
+    },
+    "archive-type": {
+      "version": "3.2.0"
+    },
+    "archiver": {
+      "version": "1.1.0",
+      "dependencies": {
+        "async": {
+          "version": "2.0.1"
+        },
+        "glob": {
+          "version": "7.1.1"
+        },
+        "lodash": {
+          "version": "4.17.4"
+        }
+      }
+    },
+    "archiver-utils": {
+      "version": "1.3.0",
+      "dependencies": {
+        "glob": {
+          "version": "7.1.1"
+        },
+        "lodash": {
+          "version": "4.17.4"
+        }
+      }
+    },
+    "arr-diff": {
+      "version": "2.0.0"
+    },
+    "arr-flatten": {
+      "version": "1.0.1"
+    },
+    "array-back": {
+      "version": "1.0.4"
+    },
+    "array-differ": {
+      "version": "1.0.0"
+    },
+    "array-find-index": {
+      "version": "1.0.2"
+    },
+    "array-flatten": {
+      "version": "1.1.1"
+    },
+    "array-union": {
+      "version": "1.0.2"
+    },
+    "array-uniq": {
+      "version": "1.0.3"
+    },
+    "array-unique": {
+      "version": "0.2.1"
+    },
+    "arraybuffer.slice": {
+      "version": "0.0.6"
+    },
+    "arrify": {
+      "version": "1.0.1"
+    },
+    "asap": {
+      "version": "2.0.5"
+    },
+    "asn1": {
+      "version": "0.2.3"
+    },
+    "assert-plus": {
+      "version": "0.2.0"
+    },
+    "assertion-error": {
+      "version": "1.0.2"
+    },
+    "ast-query": {
+      "version": "2.0.0",
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.4"
+        }
+      }
+    },
+    "async": {
+      "version": "1.5.2"
+    },
+    "asynckit": {
+      "version": "0.4.0"
+    },
+    "aws-sign2": {
+      "version": "0.6.0"
+    },
+    "aws4": {
+      "version": "1.5.0"
+    },
+    "babel-code-frame": {
+      "version": "6.20.0",
+      "dependencies": {
+        "esutils": {
+          "version": "2.0.2"
+        }
+      }
+    },
+    "babel-core": {
+      "version": "6.21.0",
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.4"
+        }
+      }
+    },
+    "babel-generator": {
+      "version": "6.21.0",
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.4"
+        }
+      }
+    },
+    "babel-helper-call-delegate": {
+      "version": "6.18.0"
+    },
+    "babel-helper-define-map": {
+      "version": "6.18.0",
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.4"
+        }
+      }
+    },
+    "babel-helper-function-name": {
+      "version": "6.18.0"
+    },
+    "babel-helper-get-function-arity": {
+      "version": "6.18.0"
+    },
+    "babel-helper-hoist-variables": {
+      "version": "6.18.0"
+    },
+    "babel-helper-optimise-call-expression": {
+      "version": "6.18.0"
+    },
+    "babel-helper-regex": {
+      "version": "6.18.0",
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.4"
+        }
+      }
+    },
+    "babel-helper-replace-supers": {
+      "version": "6.18.0"
+    },
+    "babel-helpers": {
+      "version": "6.16.0"
+    },
+    "babel-messages": {
+      "version": "6.8.0"
+    },
+    "babel-plugin-transform-es2015-arrow-functions": {
+      "version": "6.8.0"
+    },
+    "babel-plugin-transform-es2015-block-scoped-functions": {
+      "version": "6.8.0"
+    },
+    "babel-plugin-transform-es2015-block-scoping": {
+      "version": "6.21.0",
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.4"
+        }
+      }
+    },
+    "babel-plugin-transform-es2015-classes": {
+      "version": "6.18.0"
+    },
+    "babel-plugin-transform-es2015-computed-properties": {
+      "version": "6.8.0"
+    },
+    "babel-plugin-transform-es2015-destructuring": {
+      "version": "6.19.0"
+    },
+    "babel-plugin-transform-es2015-duplicate-keys": {
+      "version": "6.8.0"
+    },
+    "babel-plugin-transform-es2015-for-of": {
+      "version": "6.18.0"
+    },
+    "babel-plugin-transform-es2015-function-name": {
+      "version": "6.9.0"
+    },
+    "babel-plugin-transform-es2015-literals": {
+      "version": "6.8.0"
+    },
+    "babel-plugin-transform-es2015-object-super": {
+      "version": "6.8.0"
+    },
+    "babel-plugin-transform-es2015-parameters": {
+      "version": "6.21.0"
+    },
+    "babel-plugin-transform-es2015-shorthand-properties": {
+      "version": "6.18.0"
+    },
+    "babel-plugin-transform-es2015-spread": {
+      "version": "6.8.0"
+    },
+    "babel-plugin-transform-es2015-sticky-regex": {
+      "version": "6.8.0"
+    },
+    "babel-plugin-transform-es2015-template-literals": {
+      "version": "6.8.0"
+    },
+    "babel-plugin-transform-es2015-typeof-symbol": {
+      "version": "6.18.0"
+    },
+    "babel-plugin-transform-es2015-unicode-regex": {
+      "version": "6.11.0"
+    },
+    "babel-plugin-transform-regenerator": {
+      "version": "6.21.0"
+    },
+    "babel-polyfill": {
+      "version": "6.20.0"
+    },
+    "babel-register": {
+      "version": "6.18.0",
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.4"
+        }
+      }
+    },
+    "babel-runtime": {
+      "version": "6.20.0"
+    },
+    "babel-template": {
+      "version": "6.16.0",
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.4"
+        }
+      }
+    },
+    "babel-traverse": {
+      "version": "6.21.0",
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.4"
+        }
+      }
+    },
+    "babel-types": {
+      "version": "6.21.0",
+      "dependencies": {
+        "esutils": {
+          "version": "2.0.2"
+        },
+        "lodash": {
+          "version": "4.17.4"
+        }
+      }
+    },
+    "babylon": {
+      "version": "6.14.1"
+    },
+    "backo2": {
+      "version": "1.0.2"
+    },
+    "backoff": {
+      "version": "2.5.0",
+      "optional": true
+    },
+    "balanced-match": {
+      "version": "0.4.2"
+    },
+    "base64-arraybuffer": {
+      "version": "0.1.5"
+    },
+    "base64-js": {
+      "version": "1.1.2",
+      "optional": true
+    },
+    "base64id": {
+      "version": "1.0.0"
+    },
+    "bcrypt-pbkdf": {
+      "version": "1.0.0",
+      "optional": true
+    },
+    "beeper": {
+      "version": "1.1.1"
+    },
+    "better-assert": {
+      "version": "1.0.2"
+    },
+    "binaryextensions": {
+      "version": "1.0.1"
+    },
+    "bl": {
+      "version": "1.2.0"
+    },
+    "blob": {
+      "version": "0.0.4"
+    },
+    "body-parser": {
+      "version": "1.15.2",
+      "dependencies": {
+        "debug": {
+          "version": "2.2.0"
+        },
+        "depd": {
+          "version": "1.1.0"
+        },
+        "ms": {
+          "version": "0.7.1"
+        },
+        "qs": {
+          "version": "6.2.0"
+        }
+      }
+    },
+    "boolbase": {
+      "version": "1.0.0"
+    },
+    "boom": {
+      "version": "2.10.1"
+    },
+    "bower": {
+      "version": "1.8.0"
+    },
+    "bower-json": {
+      "version": "0.8.1"
+    },
+    "bower-logger": {
+      "version": "0.2.2"
+    },
+    "boxen": {
+      "version": "0.6.0",
+      "dependencies": {
+        "camelcase": {
+          "version": "2.1.1"
+        }
+      }
+    },
+    "brace-expansion": {
+      "version": "1.1.6"
+    },
+    "braces": {
+      "version": "1.8.5"
+    },
+    "browser-stdout": {
+      "version": "1.3.0"
+    },
+    "browserify-zlib": {
+      "version": "0.1.4"
+    },
+    "browserstack": {
+      "version": "1.5.0",
+      "optional": true
+    },
+    "buffer-crc32": {
+      "version": "0.2.13"
+    },
+    "buffer-shims": {
+      "version": "1.0.0"
+    },
+    "buffer-to-vinyl": {
+      "version": "1.1.0",
+      "dependencies": {
+        "uuid": {
+          "version": "2.0.3"
+        }
+      }
+    },
+    "builtin-modules": {
+      "version": "1.1.1"
+    },
+    "bunyan": {
+      "version": "1.8.5",
+      "optional": true,
+      "dependencies": {
+        "dtrace-provider": {
+          "version": "0.8.0",
+          "optional": true
+        }
+      }
+    },
+    "busboy": {
+      "version": "0.2.13",
+      "dependencies": {
+        "readable-stream": {
+          "version": "1.1.14"
+        }
+      }
+    },
+    "bytes": {
+      "version": "2.4.0"
+    },
+    "callsite": {
+      "version": "1.0.0"
+    },
+    "camel-case": {
+      "version": "3.0.0"
+    },
+    "camelcase": {
+      "version": "1.2.1"
+    },
+    "camelcase-keys": {
+      "version": "2.1.0",
+      "dependencies": {
+        "camelcase": {
+          "version": "2.1.1"
+        }
+      }
+    },
+    "capture-stack-trace": {
+      "version": "1.0.0"
+    },
+    "caseless": {
+      "version": "0.11.0"
+    },
+    "caw": {
+      "version": "1.2.0",
+      "dependencies": {
+        "object-assign": {
+          "version": "3.0.0"
+        }
+      }
+    },
+    "center-align": {
+      "version": "0.1.3"
+    },
+    "chai": {
+      "version": "3.5.0"
+    },
+    "chalk": {
+      "version": "1.1.3"
+    },
+    "cheerio": {
+      "version": "0.19.0"
+    },
+    "class-extend": {
+      "version": "0.1.2",
+      "dependencies": {
+        "object-assign": {
+          "version": "2.1.1"
+        }
+      }
+    },
+    "clean-css": {
+      "version": "3.4.23",
+      "dependencies": {
+        "commander": {
+          "version": "2.8.1"
+        },
+        "source-map": {
+          "version": "0.4.4"
+        }
+      }
+    },
+    "cleankill": {
+      "version": "1.0.3"
+    },
+    "cli-boxes": {
+      "version": "1.0.0"
+    },
+    "cli-cursor": {
+      "version": "1.0.2"
+    },
+    "cli-table": {
+      "version": "0.3.1",
+      "dependencies": {
+        "colors": {
+          "version": "1.0.3"
+        }
+      }
+    },
+    "cli-width": {
+      "version": "2.1.0"
+    },
+    "cliui": {
+      "version": "2.1.0",
+      "dependencies": {
+        "wordwrap": {
+          "version": "0.0.2"
+        }
+      }
+    },
+    "clone": {
+      "version": "1.0.2"
+    },
+    "clone-stats": {
+      "version": "0.0.1"
+    },
+    "co": {
+      "version": "3.1.0"
+    },
+    "code-point-at": {
+      "version": "1.1.0"
+    },
+    "collect-all": {
+      "version": "0.2.1",
+      "dependencies": {
+        "stream-via": {
+          "version": "0.1.1"
+        }
+      }
+    },
+    "collect-json": {
+      "version": "1.0.8",
+      "dependencies": {
+        "collect-all": {
+          "version": "1.0.2"
+        }
+      }
+    },
+    "colors": {
+      "version": "1.1.2"
+    },
+    "column-layout": {
+      "version": "2.1.4",
+      "dependencies": {
+        "ansi-escape-sequences": {
+          "version": "2.2.2"
+        },
+        "command-line-args": {
+          "version": "2.1.6"
+        },
+        "command-line-usage": {
+          "version": "2.0.5"
+        },
+        "wordwrapjs": {
+          "version": "1.2.1"
+        }
+      }
+    },
+    "combined-stream": {
+      "version": "1.0.5"
+    },
+    "command-line-args": {
+      "version": "3.0.5"
+    },
+    "command-line-commands": {
+      "version": "1.0.4"
+    },
+    "command-line-usage": {
+      "version": "3.0.8"
+    },
+    "commander": {
+      "version": "2.9.0"
+    },
+    "commondir": {
+      "version": "1.0.1"
+    },
+    "component-bind": {
+      "version": "1.0.0"
+    },
+    "component-emitter": {
+      "version": "1.1.2"
+    },
+    "component-inherit": {
+      "version": "0.0.3"
+    },
+    "compress-commons": {
+      "version": "1.1.0"
+    },
+    "concat-map": {
+      "version": "0.0.1"
+    },
+    "concat-stream": {
+      "version": "1.6.0"
+    },
+    "configstore": {
+      "version": "2.1.0",
+      "dependencies": {
+        "uuid": {
+          "version": "2.0.3"
+        }
+      }
+    },
+    "content-disposition": {
+      "version": "0.5.1"
+    },
+    "content-type": {
+      "version": "1.0.2"
+    },
+    "convert-source-map": {
+      "version": "1.3.0"
+    },
+    "cookie": {
+      "version": "0.3.1"
+    },
+    "cookie-signature": {
+      "version": "1.0.6"
+    },
+    "core-js": {
+      "version": "2.4.1"
+    },
+    "core-util-is": {
+      "version": "1.0.2"
+    },
+    "crc": {
+      "version": "3.2.1"
+    },
+    "crc32-stream": {
+      "version": "1.0.0"
+    },
+    "create-error-class": {
+      "version": "3.0.2"
+    },
+    "cross-spawn": {
+      "version": "3.0.1"
+    },
+    "cryptiles": {
+      "version": "2.0.5"
+    },
+    "css-select": {
+      "version": "1.0.0"
+    },
+    "css-slam": {
+      "version": "1.2.1",
+      "dependencies": {
+        "@types/node": {
+          "version": "4.0.30"
+        },
+        "@types/parse5": {
+          "version": "0.0.31",
+          "dependencies": {
+            "@types/node": {
+              "version": "6.0.56"
+            }
+          }
+        },
+        "dom5": {
+          "version": "1.3.6"
+        },
+        "parse5": {
+          "version": "1.5.1"
+        }
+      }
+    },
+    "css-what": {
+      "version": "1.0.0"
+    },
+    "cssbeautify": {
+      "version": "0.3.1"
+    },
+    "csv": {
+      "version": "0.4.6",
+      "optional": true
+    },
+    "csv-generate": {
+      "version": "0.0.6",
+      "optional": true
+    },
+    "csv-parse": {
+      "version": "1.1.7",
+      "optional": true
+    },
+    "csv-stringify": {
+      "version": "0.0.8",
+      "optional": true
+    },
+    "ctype": {
+      "version": "0.5.3"
+    },
+    "currently-unhandled": {
+      "version": "0.4.1"
+    },
+    "cycle": {
+      "version": "1.0.3"
+    },
+    "d": {
+      "version": "0.1.1"
+    },
+    "dargs": {
+      "version": "4.1.0"
+    },
+    "dashdash": {
+      "version": "1.14.1",
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0"
+        }
+      }
+    },
+    "dateformat": {
+      "version": "1.0.12"
+    },
+    "debug": {
+      "version": "2.6.0",
+      "dependencies": {
+        "ms": {
+          "version": "0.7.2"
+        }
+      }
+    },
+    "decamelize": {
+      "version": "1.2.0"
+    },
+    "decompress": {
+      "version": "3.0.0"
+    },
+    "decompress-tar": {
+      "version": "3.1.0",
+      "dependencies": {
+        "clone": {
+          "version": "0.2.0"
+        },
+        "object-assign": {
+          "version": "2.1.1"
+        },
+        "readable-stream": {
+          "version": "1.0.34"
+        },
+        "through2": {
+          "version": "0.6.5"
+        },
+        "vinyl": {
+          "version": "0.4.6"
+        }
+      }
+    },
+    "decompress-tarbz2": {
+      "version": "3.1.0",
+      "dependencies": {
+        "clone": {
+          "version": "0.2.0"
+        },
+        "object-assign": {
+          "version": "2.1.1"
+        },
+        "readable-stream": {
+          "version": "1.0.34"
+        },
+        "through2": {
+          "version": "0.6.5"
+        },
+        "vinyl": {
+          "version": "0.4.6"
+        }
+      }
+    },
+    "decompress-targz": {
+      "version": "3.1.0",
+      "dependencies": {
+        "clone": {
+          "version": "0.2.0"
+        },
+        "object-assign": {
+          "version": "2.1.1"
+        },
+        "readable-stream": {
+          "version": "1.0.34"
+        },
+        "through2": {
+          "version": "0.6.5"
+        },
+        "vinyl": {
+          "version": "0.4.6"
+        }
+      }
+    },
+    "decompress-unzip": {
+      "version": "3.4.0",
+      "dependencies": {
+        "through2": {
+          "version": "2.0.3"
+        }
+      }
+    },
+    "deep-eql": {
+      "version": "0.1.3",
+      "dependencies": {
+        "type-detect": {
+          "version": "0.1.1"
+        }
+      }
+    },
+    "deep-extend": {
+      "version": "0.4.1"
+    },
+    "deep-is": {
+      "version": "0.1.3"
+    },
+    "del": {
+      "version": "2.2.2",
+      "dependencies": {
+        "glob": {
+          "version": "7.1.1"
+        },
+        "globby": {
+          "version": "5.0.0"
+        }
+      }
+    },
+    "delayed-stream": {
+      "version": "1.0.0"
+    },
+    "depd": {
+      "version": "1.0.1"
+    },
+    "destroy": {
+      "version": "1.0.3"
+    },
+    "detect-conflict": {
+      "version": "1.0.1"
+    },
+    "detect-file": {
+      "version": "0.1.0"
+    },
+    "detect-indent": {
+      "version": "4.0.0"
+    },
+    "detect-newline": {
+      "version": "1.0.3"
+    },
+    "dicer": {
+      "version": "0.2.5",
+      "dependencies": {
+        "readable-stream": {
+          "version": "1.1.14"
+        }
+      }
+    },
+    "diff": {
+      "version": "2.2.3"
+    },
+    "doctrine": {
+      "version": "0.7.2"
+    },
+    "dom-serializer": {
+      "version": "0.1.0"
+    },
+    "dom-urls": {
+      "version": "1.1.0",
+      "dependencies": {
+        "urijs": {
+          "version": "1.18.4"
+        }
+      }
+    },
+    "dom5": {
+      "version": "2.0.1",
+      "dependencies": {
+        "@types/node": {
+          "version": "4.0.30"
+        }
+      }
+    },
+    "domelementtype": {
+      "version": "1.1.3"
+    },
+    "domhandler": {
+      "version": "2.3.0"
+    },
+    "domutils": {
+      "version": "1.4.3"
+    },
+    "dot-prop": {
+      "version": "3.0.0"
+    },
+    "download": {
+      "version": "4.4.3"
+    },
+    "dtrace-provider": {
+      "version": "0.6.0",
+      "optional": true
+    },
+    "duplexer2": {
+      "version": "0.1.4"
+    },
+    "duplexify": {
+      "version": "3.5.0"
+    },
+    "each-async": {
+      "version": "1.1.1"
+    },
+    "ecc-jsbn": {
+      "version": "0.1.1",
+      "optional": true
+    },
+    "editions": {
+      "version": "1.3.3"
+    },
+    "ee-first": {
+      "version": "1.1.0"
+    },
+    "ejs": {
+      "version": "2.5.5"
+    },
+    "encodeurl": {
+      "version": "1.0.1"
+    },
+    "end-of-stream": {
+      "version": "1.0.0",
+      "dependencies": {
+        "once": {
+          "version": "1.3.3"
+        }
+      }
+    },
+    "ends-with": {
+      "version": "0.2.0"
+    },
+    "engine.io": {
+      "version": "1.8.2",
+      "dependencies": {
+        "debug": {
+          "version": "2.3.3"
+        },
+        "ms": {
+          "version": "0.7.2"
+        }
+      }
+    },
+    "engine.io-client": {
+      "version": "1.8.2",
+      "dependencies": {
+        "component-emitter": {
+          "version": "1.2.1"
+        },
+        "debug": {
+          "version": "2.3.3"
+        },
+        "ms": {
+          "version": "0.7.2"
+        }
+      }
+    },
+    "engine.io-parser": {
+      "version": "1.3.2"
+    },
+    "entities": {
+      "version": "1.1.1"
+    },
+    "error": {
+      "version": "7.0.2"
+    },
+    "error-ex": {
+      "version": "1.3.0"
+    },
+    "es5-ext": {
+      "version": "0.10.12"
+    },
+    "es6-iterator": {
+      "version": "2.0.0"
+    },
+    "es6-promise": {
+      "version": "2.3.0"
+    },
+    "es6-set": {
+      "version": "0.1.4"
+    },
+    "es6-symbol": {
+      "version": "3.1.0"
+    },
+    "escape-html": {
+      "version": "1.0.1"
+    },
+    "escape-regexp-component": {
+      "version": "1.0.2",
+      "optional": true
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5"
+    },
+    "escodegen": {
+      "version": "1.8.1",
+      "dependencies": {
+        "estraverse": {
+          "version": "1.9.3"
+        },
+        "esutils": {
+          "version": "2.0.2"
+        },
+        "source-map": {
+          "version": "0.2.0",
+          "optional": true
+        }
+      }
+    },
+    "escodegen-wallaby": {
+      "version": "1.6.8",
+      "dependencies": {
+        "estraverse": {
+          "version": "1.9.3"
+        },
+        "esutils": {
+          "version": "2.0.2"
+        },
+        "source-map": {
+          "version": "0.2.0",
+          "optional": true
+        }
+      }
+    },
+    "espree": {
+      "version": "3.3.2"
+    },
+    "esprima": {
+      "version": "2.7.3"
+    },
+    "estraverse": {
+      "version": "3.1.0"
+    },
+    "esutils": {
+      "version": "1.1.6"
+    },
+    "etag": {
+      "version": "1.5.1"
+    },
+    "event-emitter": {
+      "version": "0.3.4"
+    },
+    "eventemitter3": {
+      "version": "1.2.0"
+    },
+    "exit-hook": {
+      "version": "1.1.1"
+    },
+    "expand-brackets": {
+      "version": "0.1.5"
+    },
+    "expand-range": {
+      "version": "1.8.2"
+    },
+    "expand-tilde": {
+      "version": "1.2.2"
+    },
+    "express": {
+      "version": "4.14.0",
+      "dependencies": {
+        "debug": {
+          "version": "2.2.0"
+        },
+        "depd": {
+          "version": "1.1.0"
+        },
+        "destroy": {
+          "version": "1.0.4"
+        },
+        "escape-html": {
+          "version": "1.0.3"
+        },
+        "etag": {
+          "version": "1.7.0"
+        },
+        "fresh": {
+          "version": "0.3.0"
+        },
+        "ms": {
+          "version": "0.7.1"
+        },
+        "qs": {
+          "version": "6.2.0"
+        },
+        "range-parser": {
+          "version": "1.2.0"
+        },
+        "send": {
+          "version": "0.14.1"
+        }
+      }
+    },
+    "ext-list": {
+      "version": "2.2.0",
+      "dependencies": {
+        "got": {
+          "version": "2.9.2"
+        },
+        "object-assign": {
+          "version": "2.1.1"
+        },
+        "read-all-stream": {
+          "version": "2.2.0"
+        },
+        "timed-out": {
+          "version": "2.0.0"
+        }
+      }
+    },
+    "ext-name": {
+      "version": "3.0.0"
+    },
+    "extend": {
+      "version": "3.0.0"
+    },
+    "extend-shallow": {
+      "version": "2.0.1"
+    },
+    "external-editor": {
+      "version": "1.1.1"
+    },
+    "extglob": {
+      "version": "0.3.2"
+    },
+    "extsprintf": {
+      "version": "1.0.2"
+    },
+    "eyes": {
+      "version": "0.1.8"
+    },
+    "fancy-log": {
+      "version": "1.3.0"
+    },
+    "fast-levenshtein": {
+      "version": "2.0.6"
+    },
+    "fd-slicer": {
+      "version": "1.0.1"
+    },
+    "feature-detect-es6": {
+      "version": "1.3.1"
+    },
+    "figures": {
+      "version": "1.7.0"
+    },
+    "file-type": {
+      "version": "3.9.0"
+    },
+    "filename-regex": {
+      "version": "2.0.0"
+    },
+    "filename-reserved-regex": {
+      "version": "1.0.0"
+    },
+    "filenamify": {
+      "version": "1.2.1"
+    },
+    "fill-range": {
+      "version": "2.2.3"
+    },
+    "filled-array": {
+      "version": "1.1.0"
+    },
+    "finalhandler": {
+      "version": "0.5.0",
+      "dependencies": {
+        "debug": {
+          "version": "2.2.0"
+        },
+        "escape-html": {
+          "version": "1.0.3"
+        },
+        "ms": {
+          "version": "0.7.1"
+        }
+      }
+    },
+    "find-port": {
+      "version": "1.0.1",
+      "dependencies": {
+        "async": {
+          "version": "0.2.10"
+        }
+      }
+    },
+    "find-replace": {
+      "version": "1.0.2"
+    },
+    "find-up": {
+      "version": "1.1.2"
+    },
+    "findup-sync": {
+      "version": "0.4.3"
+    },
+    "first-chunk-stream": {
+      "version": "1.0.0"
+    },
+    "follow-redirects": {
+      "version": "0.0.7"
+    },
+    "for-in": {
+      "version": "0.1.6"
+    },
+    "for-own": {
+      "version": "0.1.4"
+    },
+    "forever-agent": {
+      "version": "0.6.1"
+    },
+    "fork-stream": {
+      "version": "0.0.4"
+    },
+    "form-data": {
+      "version": "2.1.2"
+    },
+    "formatio": {
+      "version": "1.1.1"
+    },
+    "formidable": {
+      "version": "1.0.17",
+      "optional": true
+    },
+    "forwarded": {
+      "version": "0.1.0"
+    },
+    "freeport": {
+      "version": "1.0.5",
+      "optional": true
+    },
+    "fresh": {
+      "version": "0.2.4"
+    },
+    "fs-exists-sync": {
+      "version": "0.1.0"
+    },
+    "fs-extra": {
+      "version": "1.0.0"
+    },
+    "fs.realpath": {
+      "version": "1.0.0"
+    },
+    "generate-function": {
+      "version": "2.0.0"
+    },
+    "generate-object-property": {
+      "version": "1.2.0"
+    },
+    "get-proxy": {
+      "version": "1.1.0"
+    },
+    "get-stdin": {
+      "version": "4.0.1"
+    },
+    "getpass": {
+      "version": "0.1.6",
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0"
+        }
+      }
+    },
+    "gh-got": {
+      "version": "2.4.0"
+    },
+    "github": {
+      "version": "7.2.1"
+    },
+    "github-username": {
+      "version": "2.1.0"
+    },
+    "glob": {
+      "version": "5.0.15"
+    },
+    "glob-base": {
+      "version": "0.3.0",
+      "dependencies": {
+        "glob-parent": {
+          "version": "2.0.0"
+        }
+      }
+    },
+    "glob-parent": {
+      "version": "3.1.0",
+      "dependencies": {
+        "is-extglob": {
+          "version": "2.1.1"
+        },
+        "is-glob": {
+          "version": "3.1.0"
+        }
+      }
+    },
+    "glob-stream": {
+      "version": "5.3.5",
+      "dependencies": {
+        "readable-stream": {
+          "version": "1.0.34"
+        },
+        "through2": {
+          "version": "0.6.5"
+        }
+      }
+    },
+    "global-modules": {
+      "version": "0.2.3"
+    },
+    "global-prefix": {
+      "version": "0.1.5"
+    },
+    "globals": {
+      "version": "9.14.0"
+    },
+    "globby": {
+      "version": "4.1.0",
+      "dependencies": {
+        "glob": {
+          "version": "6.0.4"
+        }
+      }
+    },
+    "glogg": {
+      "version": "1.0.0"
+    },
+    "got": {
+      "version": "5.7.1"
+    },
+    "graceful-fs": {
+      "version": "4.1.11"
+    },
+    "graceful-readlink": {
+      "version": "1.0.1"
+    },
+    "grouped-queue": {
+      "version": "0.3.3",
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.4"
+        }
+      }
+    },
+    "growl": {
+      "version": "1.9.2"
+    },
+    "gruntfile-editor": {
+      "version": "1.2.1",
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.4"
+        }
+      }
+    },
+    "gulp-decompress": {
+      "version": "1.2.0"
+    },
+    "gulp-if": {
+      "version": "2.0.2",
+      "dependencies": {
+        "through2": {
+          "version": "2.0.3"
+        }
+      }
+    },
+    "gulp-match": {
+      "version": "1.0.3"
+    },
+    "gulp-rename": {
+      "version": "1.2.2"
+    },
+    "gulp-sourcemaps": {
+      "version": "1.6.0",
+      "dependencies": {
+        "through2": {
+          "version": "2.0.3"
+        }
+      }
+    },
+    "gulp-util": {
+      "version": "3.0.8",
+      "dependencies": {
+        "dateformat": {
+          "version": "2.0.0"
+        },
+        "duplexer2": {
+          "version": "0.0.2",
+          "dependencies": {
+            "readable-stream": {
+              "version": "1.1.14"
+            }
+          }
+        },
+        "multipipe": {
+          "version": "0.1.2"
+        },
+        "object-assign": {
+          "version": "3.0.0"
+        },
+        "through2": {
+          "version": "2.0.3"
+        },
+        "vinyl": {
+          "version": "0.5.3"
+        }
+      }
+    },
+    "gulplog": {
+      "version": "1.0.0"
+    },
+    "gunzip-maybe": {
+      "version": "1.3.1"
+    },
+    "handle-thing": {
+      "version": "1.2.5"
+    },
+    "har-validator": {
+      "version": "2.0.6"
+    },
+    "has-ansi": {
+      "version": "2.0.0"
+    },
+    "has-binary": {
+      "version": "0.1.7"
+    },
+    "has-color": {
+      "version": "0.1.7"
+    },
+    "has-cors": {
+      "version": "1.1.0"
+    },
+    "has-flag": {
+      "version": "1.0.0"
+    },
+    "has-gulplog": {
+      "version": "0.1.0"
+    },
+    "hawk": {
+      "version": "3.1.3"
+    },
+    "he": {
+      "version": "1.1.0"
+    },
+    "hoek": {
+      "version": "2.16.3"
+    },
+    "home-or-tmp": {
+      "version": "2.0.0"
+    },
+    "homedir-polyfill": {
+      "version": "1.0.1"
+    },
+    "hosted-git-info": {
+      "version": "2.1.5"
+    },
+    "hpack.js": {
+      "version": "2.1.6"
+    },
+    "html-minifier": {
+      "version": "3.2.3"
+    },
+    "html-wiring": {
+      "version": "1.2.0"
+    },
+    "htmlparser2": {
+      "version": "3.8.3",
+      "dependencies": {
+        "domutils": {
+          "version": "1.5.1"
+        },
+        "entities": {
+          "version": "1.0.0"
+        },
+        "readable-stream": {
+          "version": "1.1.14"
+        }
+      }
+    },
+    "http-deceiver": {
+      "version": "1.2.7"
+    },
+    "http-errors": {
+      "version": "1.5.1"
+    },
+    "http-proxy": {
+      "version": "1.16.2"
+    },
+    "http-proxy-middleware": {
+      "version": "0.17.3",
+      "dependencies": {
+        "is-extglob": {
+          "version": "2.1.1"
+        },
+        "is-glob": {
+          "version": "3.1.0"
+        },
+        "lodash": {
+          "version": "4.17.4"
+        }
+      }
+    },
+    "http-signature": {
+      "version": "1.1.1"
+    },
+    "https-proxy-agent": {
+      "version": "1.0.0"
+    },
+    "hydrolysis": {
+      "version": "1.24.1",
+      "dependencies": {
+        "@types/node": {
+          "version": "4.0.30"
+        },
+        "@types/parse5": {
+          "version": "0.0.31",
+          "dependencies": {
+            "@types/node": {
+              "version": "6.0.56"
+            }
+          }
+        },
+        "dom5": {
+          "version": "1.3.6"
+        },
+        "parse5": {
+          "version": "1.5.1"
+        }
+      }
+    },
+    "iconv-lite": {
+      "version": "0.4.13"
+    },
+    "imurmurhash": {
+      "version": "0.1.4"
+    },
+    "indent-string": {
+      "version": "2.1.0"
+    },
+    "indexof": {
+      "version": "0.0.1"
+    },
+    "infinity-agent": {
+      "version": "2.0.3"
+    },
+    "inflight": {
+      "version": "1.0.6"
+    },
+    "inherits": {
+      "version": "2.0.3"
+    },
+    "ini": {
+      "version": "1.3.4"
+    },
+    "inquirer": {
+      "version": "1.2.3",
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.4"
+        }
+      }
+    },
+    "interpret": {
+      "version": "1.0.1"
+    },
+    "intersect": {
+      "version": "1.0.1"
+    },
+    "invariant": {
+      "version": "2.2.2"
+    },
+    "ipaddr.js": {
+      "version": "1.1.1"
+    },
+    "is-absolute": {
+      "version": "0.1.7"
+    },
+    "is-arrayish": {
+      "version": "0.2.1"
+    },
+    "is-buffer": {
+      "version": "1.1.4"
+    },
+    "is-builtin-module": {
+      "version": "1.0.0"
+    },
+    "is-bzip2": {
+      "version": "1.0.0"
+    },
+    "is-deflate": {
+      "version": "1.0.0"
+    },
+    "is-dotfile": {
+      "version": "1.0.2"
+    },
+    "is-equal-shallow": {
+      "version": "0.1.3"
+    },
+    "is-extendable": {
+      "version": "0.1.1"
+    },
+    "is-extglob": {
+      "version": "1.0.0"
+    },
+    "is-finite": {
+      "version": "1.0.2"
+    },
+    "is-fullwidth-code-point": {
+      "version": "1.0.0"
+    },
+    "is-glob": {
+      "version": "2.0.1"
+    },
+    "is-gzip": {
+      "version": "1.0.0"
+    },
+    "is-my-json-valid": {
+      "version": "2.15.0"
+    },
+    "is-natural-number": {
+      "version": "2.1.1"
+    },
+    "is-npm": {
+      "version": "1.0.0"
+    },
+    "is-number": {
+      "version": "2.1.0"
+    },
+    "is-obj": {
+      "version": "1.0.1"
+    },
+    "is-path-cwd": {
+      "version": "1.0.0"
+    },
+    "is-path-in-cwd": {
+      "version": "1.0.0"
+    },
+    "is-path-inside": {
+      "version": "1.0.0"
+    },
+    "is-plain-obj": {
+      "version": "1.1.0"
+    },
+    "is-posix-bracket": {
+      "version": "0.1.1"
+    },
+    "is-primitive": {
+      "version": "2.0.0"
+    },
+    "is-promise": {
+      "version": "2.1.0"
+    },
+    "is-property": {
+      "version": "1.0.2"
+    },
+    "is-redirect": {
+      "version": "1.0.0"
+    },
+    "is-relative": {
+      "version": "0.1.3"
+    },
+    "is-retry-allowed": {
+      "version": "1.1.0"
+    },
+    "is-stream": {
+      "version": "1.1.0"
+    },
+    "is-tar": {
+      "version": "1.0.0"
+    },
+    "is-typedarray": {
+      "version": "1.0.0"
+    },
+    "is-url": {
+      "version": "1.2.2"
+    },
+    "is-utf8": {
+      "version": "0.2.1"
+    },
+    "is-valid-glob": {
+      "version": "0.3.0"
+    },
+    "is-windows": {
+      "version": "0.2.0"
+    },
+    "is-zip": {
+      "version": "1.0.0"
+    },
+    "isarray": {
+      "version": "0.0.1"
+    },
+    "isexe": {
+      "version": "1.1.2"
+    },
+    "isobject": {
+      "version": "2.1.0",
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0"
+        }
+      }
+    },
+    "isstream": {
+      "version": "0.1.2"
+    },
+    "istextorbinary": {
+      "version": "1.0.2"
+    },
+    "jodid25519": {
+      "version": "1.0.2",
+      "optional": true
+    },
+    "js-tokens": {
+      "version": "2.0.0"
+    },
+    "jsbn": {
+      "version": "0.1.0",
+      "optional": true
+    },
+    "jsesc": {
+      "version": "1.3.0"
+    },
+    "json-schema": {
+      "version": "0.2.3"
+    },
+    "json-stable-stringify": {
+      "version": "1.0.1"
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1"
+    },
+    "json3": {
+      "version": "3.3.2"
+    },
+    "json5": {
+      "version": "0.5.1"
+    },
+    "jsonfile": {
+      "version": "2.4.0"
+    },
+    "jsonify": {
+      "version": "0.0.0"
+    },
+    "jsonpointer": {
+      "version": "4.0.1"
+    },
+    "jsonschema": {
+      "version": "1.1.1"
+    },
+    "jsprim": {
+      "version": "1.3.1"
+    },
+    "keep-alive-agent": {
+      "version": "0.0.1",
+      "optional": true
+    },
+    "kind-of": {
+      "version": "3.1.0"
+    },
+    "klaw": {
+      "version": "1.3.1"
+    },
+    "latest-version": {
+      "version": "2.0.0"
+    },
+    "launchpad": {
+      "version": "0.5.4",
+      "optional": true,
+      "dependencies": {
+        "async": {
+          "version": "2.0.1",
+          "optional": true
+        },
+        "lodash": {
+          "version": "4.17.4",
+          "optional": true
+        },
+        "underscore": {
+          "version": "1.8.3",
+          "optional": true
+        }
+      }
+    },
+    "lazy-cache": {
+      "version": "1.0.4"
+    },
+    "lazy-req": {
+      "version": "1.1.0"
+    },
+    "lazystream": {
+      "version": "1.0.0"
+    },
+    "levn": {
+      "version": "0.3.0"
+    },
+    "load-json-file": {
+      "version": "1.1.0"
+    },
+    "lodash": {
+      "version": "3.10.1"
+    },
+    "lodash._baseassign": {
+      "version": "3.2.0"
+    },
+    "lodash._basecopy": {
+      "version": "3.0.1"
+    },
+    "lodash._basecreate": {
+      "version": "3.0.3"
+    },
+    "lodash._basetostring": {
+      "version": "3.0.1"
+    },
+    "lodash._basevalues": {
+      "version": "3.0.0"
+    },
+    "lodash._getnative": {
+      "version": "3.9.1"
+    },
+    "lodash._isiterateecall": {
+      "version": "3.0.9"
+    },
+    "lodash._reescape": {
+      "version": "3.0.0"
+    },
+    "lodash._reevaluate": {
+      "version": "3.0.0"
+    },
+    "lodash._reinterpolate": {
+      "version": "3.0.0"
+    },
+    "lodash._root": {
+      "version": "3.0.1"
+    },
+    "lodash.create": {
+      "version": "3.1.1"
+    },
+    "lodash.defaults": {
+      "version": "4.2.0"
+    },
+    "lodash.escape": {
+      "version": "3.2.0"
+    },
+    "lodash.isarguments": {
+      "version": "3.1.0"
+    },
+    "lodash.isarray": {
+      "version": "3.0.4"
+    },
+    "lodash.isequal": {
+      "version": "4.4.0"
+    },
+    "lodash.keys": {
+      "version": "3.1.2"
+    },
+    "lodash.restparam": {
+      "version": "3.6.1"
+    },
+    "lodash.template": {
+      "version": "3.6.2"
+    },
+    "lodash.templatesettings": {
+      "version": "3.1.1"
+    },
+    "log-symbols": {
+      "version": "1.0.2"
+    },
+    "lolex": {
+      "version": "1.3.2"
+    },
+    "longest": {
+      "version": "1.0.1"
+    },
+    "loose-envify": {
+      "version": "1.3.0"
+    },
+    "loud-rejection": {
+      "version": "1.6.0"
+    },
+    "lower-case": {
+      "version": "1.1.3"
+    },
+    "lowercase-keys": {
+      "version": "1.0.0"
+    },
+    "lru-cache": {
+      "version": "4.0.2"
+    },
+    "map-obj": {
+      "version": "1.0.1"
+    },
+    "media-typer": {
+      "version": "0.3.0"
+    },
+    "mem-fs": {
+      "version": "1.1.3",
+      "dependencies": {
+        "through2": {
+          "version": "2.0.3"
+        }
+      }
+    },
+    "mem-fs-editor": {
+      "version": "2.3.0",
+      "dependencies": {
+        "glob": {
+          "version": "7.1.1"
+        },
+        "through2": {
+          "version": "2.0.3"
+        }
+      }
+    },
+    "meow": {
+      "version": "3.7.0"
+    },
+    "merge-descriptors": {
+      "version": "1.0.1"
+    },
+    "merge-stream": {
+      "version": "1.0.1"
+    },
+    "methods": {
+      "version": "1.1.2"
+    },
+    "micromatch": {
+      "version": "2.3.11"
+    },
+    "mime": {
+      "version": "1.3.4"
+    },
+    "mime-db": {
+      "version": "1.25.0"
+    },
+    "mime-types": {
+      "version": "2.1.13"
+    },
+    "minimalistic-assert": {
+      "version": "1.0.0"
+    },
+    "minimatch": {
+      "version": "3.0.3"
+    },
+    "minimatch-all": {
+      "version": "1.1.0"
+    },
+    "minimist": {
+      "version": "1.2.0"
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.8"
+        }
+      }
+    },
+    "mocha": {
+      "version": "3.2.0",
+      "dependencies": {
+        "debug": {
+          "version": "2.2.0"
+        },
+        "diff": {
+          "version": "1.4.0"
+        },
+        "glob": {
+          "version": "7.0.5"
+        },
+        "ms": {
+          "version": "0.7.1"
+        },
+        "supports-color": {
+          "version": "3.1.2"
+        }
+      }
+    },
+    "moment": {
+      "version": "2.17.1",
+      "optional": true
+    },
+    "ms": {
+      "version": "0.7.0"
+    },
+    "multer": {
+      "version": "1.2.1",
+      "dependencies": {
+        "object-assign": {
+          "version": "3.0.0"
+        }
+      }
+    },
+    "multimatch": {
+      "version": "2.1.0"
+    },
+    "multipipe": {
+      "version": "1.0.2"
+    },
+    "mute-stream": {
+      "version": "0.0.6"
+    },
+    "mv": {
+      "version": "2.1.1",
+      "optional": true,
+      "dependencies": {
+        "glob": {
+          "version": "6.0.4",
+          "optional": true
+        },
+        "rimraf": {
+          "version": "2.4.5",
+          "optional": true
+        }
+      }
+    },
+    "mz": {
+      "version": "2.6.0"
+    },
+    "nan": {
+      "version": "2.5.0",
+      "optional": true
+    },
+    "ncname": {
+      "version": "1.0.0"
+    },
+    "ncp": {
+      "version": "2.0.0",
+      "optional": true
+    },
+    "negotiator": {
+      "version": "0.6.1"
+    },
+    "nested-error-stacks": {
+      "version": "1.0.2"
+    },
+    "netrc": {
+      "version": "0.1.4"
+    },
+    "no-case": {
+      "version": "2.3.0"
+    },
+    "node-status-codes": {
+      "version": "1.0.0"
+    },
+    "node-uuid": {
+      "version": "1.4.7"
+    },
+    "nodegit-promise": {
+      "version": "4.0.0"
+    },
+    "nomnom": {
+      "version": "1.8.1",
+      "dependencies": {
+        "ansi-styles": {
+          "version": "1.0.0"
+        },
+        "chalk": {
+          "version": "0.4.0"
+        },
+        "strip-ansi": {
+          "version": "0.1.1"
+        }
+      }
+    },
+    "nopt": {
+      "version": "3.0.6"
+    },
+    "normalize-package-data": {
+      "version": "2.3.5",
+      "dependencies": {
+        "semver": {
+          "version": "5.3.0"
+        }
+      }
+    },
+    "normalize-path": {
+      "version": "2.0.1"
+    },
+    "nth-check": {
+      "version": "1.0.1"
+    },
+    "number-is-nan": {
+      "version": "1.0.1"
+    },
+    "oauth-sign": {
+      "version": "0.8.2"
+    },
+    "object-assign": {
+      "version": "4.1.0"
+    },
+    "object-component": {
+      "version": "0.0.3"
+    },
+    "object-get": {
+      "version": "2.1.0"
+    },
+    "object-keys": {
+      "version": "0.4.0"
+    },
+    "object-tools": {
+      "version": "2.0.6",
+      "dependencies": {
+        "test-value": {
+          "version": "1.1.0"
+        }
+      }
+    },
+    "object.omit": {
+      "version": "2.0.1"
+    },
+    "obuf": {
+      "version": "1.1.1"
+    },
+    "on-finished": {
+      "version": "2.3.0",
+      "dependencies": {
+        "ee-first": {
+          "version": "1.1.1"
+        }
+      }
+    },
+    "once": {
+      "version": "1.4.0"
+    },
+    "onetime": {
+      "version": "1.1.0"
+    },
+    "opn": {
+      "version": "3.0.3"
+    },
+    "optimist": {
+      "version": "0.6.1",
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.8"
+        }
+      }
+    },
+    "optionator": {
+      "version": "0.8.2",
+      "dependencies": {
+        "wordwrap": {
+          "version": "1.0.0"
+        }
+      }
+    },
+    "options": {
+      "version": "0.0.6"
+    },
+    "ordered-read-streams": {
+      "version": "0.3.0"
+    },
+    "os-homedir": {
+      "version": "1.0.2"
+    },
+    "os-shim": {
+      "version": "0.1.3"
+    },
+    "os-tmpdir": {
+      "version": "1.0.2"
+    },
+    "osenv": {
+      "version": "0.1.4"
+    },
+    "package-json": {
+      "version": "2.4.0",
+      "dependencies": {
+        "semver": {
+          "version": "5.3.0"
+        }
+      }
+    },
+    "pako": {
+      "version": "0.2.9"
+    },
+    "param-case": {
+      "version": "2.1.0"
+    },
+    "parse-glob": {
+      "version": "3.0.4"
+    },
+    "parse-json": {
+      "version": "2.2.0"
+    },
+    "parse-passwd": {
+      "version": "1.0.0"
+    },
+    "parse5": {
+      "version": "2.2.3"
+    },
+    "parsejson": {
+      "version": "0.0.3"
+    },
+    "parseqs": {
+      "version": "0.0.5"
+    },
+    "parseuri": {
+      "version": "0.0.5"
+    },
+    "parseurl": {
+      "version": "1.3.1"
+    },
+    "path-dirname": {
+      "version": "1.0.2"
+    },
+    "path-exists": {
+      "version": "2.1.0"
+    },
+    "path-is-absolute": {
+      "version": "1.0.1"
+    },
+    "path-is-inside": {
+      "version": "1.0.2"
+    },
+    "path-posix": {
+      "version": "1.0.0"
+    },
+    "path-to-regexp": {
+      "version": "0.1.7"
+    },
+    "path-type": {
+      "version": "1.1.0"
+    },
+    "peek-stream": {
+      "version": "1.1.1",
+      "dependencies": {
+        "readable-stream": {
+          "version": "1.0.34"
+        },
+        "through2": {
+          "version": "0.5.1"
+        },
+        "xtend": {
+          "version": "3.0.0"
+        }
+      }
+    },
+    "pem": {
+      "version": "1.9.4"
+    },
+    "pend": {
+      "version": "1.2.0"
+    },
+    "performance-now": {
+      "version": "0.2.0"
+    },
+    "pify": {
+      "version": "2.3.0"
+    },
+    "pinkie": {
+      "version": "2.0.4"
+    },
+    "pinkie-promise": {
+      "version": "2.0.1"
+    },
+    "plist": {
+      "version": "2.0.1",
+      "optional": true
+    },
+    "plylog": {
+      "version": "0.4.0"
+    },
+    "polylint": {
+      "version": "2.10.1",
+      "dependencies": {
+        "@types/node": {
+          "version": "4.0.30"
+        },
+        "@types/parse5": {
+          "version": "0.0.31",
+          "dependencies": {
+            "@types/node": {
+              "version": "6.0.56"
+            }
+          }
+        },
+        "ansi-escape-sequences": {
+          "version": "2.2.2"
+        },
+        "command-line-args": {
+          "version": "2.1.6"
+        },
+        "command-line-usage": {
+          "version": "2.0.5"
+        },
+        "dom5": {
+          "version": "1.3.6"
+        },
+        "parse5": {
+          "version": "1.5.1"
+        },
+        "wordwrapjs": {
+          "version": "1.2.1"
+        }
+      }
+    },
+    "polymer-analyzer": {
+      "version": "2.0.0-alpha.20",
+      "dependencies": {
+        "@types/node": {
+          "version": "4.0.30"
+        },
+        "clone": {
+          "version": "2.1.0"
+        }
+      }
+    },
+    "polymer-build": {
+      "version": "0.6.0-alpha.3",
+      "dependencies": {
+        "@types/vinyl": {
+          "version": "1.2.30"
+        }
+      }
+    },
+    "polymer-project-config": {
+      "version": "1.1.0",
+      "dependencies": {
+        "@types/node": {
+          "version": "6.0.56"
+        }
+      }
+    },
+    "polyserve": {
+      "version": "0.16.0-prerelease.9",
+      "dependencies": {
+        "@types/node": {
+          "version": "4.0.30"
+        },
+        "debug": {
+          "version": "2.2.0"
+        },
+        "depd": {
+          "version": "1.1.0"
+        },
+        "destroy": {
+          "version": "1.0.4"
+        },
+        "escape-html": {
+          "version": "1.0.3"
+        },
+        "etag": {
+          "version": "1.7.0"
+        },
+        "fresh": {
+          "version": "0.3.0"
+        },
+        "ms": {
+          "version": "0.7.1"
+        },
+        "range-parser": {
+          "version": "1.2.0"
+        },
+        "send": {
+          "version": "0.14.1"
+        }
+      }
+    },
+    "precond": {
+      "version": "0.2.3",
+      "optional": true
+    },
+    "prelude-ls": {
+      "version": "1.1.2"
+    },
+    "prepend-http": {
+      "version": "1.0.4"
+    },
+    "preserve": {
+      "version": "0.2.0"
+    },
+    "pretty-bytes": {
+      "version": "3.0.1"
+    },
+    "private": {
+      "version": "0.1.6"
+    },
+    "process-nextick-args": {
+      "version": "1.0.7"
+    },
+    "progress": {
+      "version": "1.1.8"
+    },
+    "promisify-node": {
+      "version": "0.4.0"
+    },
+    "proxy-addr": {
+      "version": "1.1.2"
+    },
+    "pseudomap": {
+      "version": "1.0.2"
+    },
+    "pump": {
+      "version": "1.0.2",
+      "dependencies": {
+        "end-of-stream": {
+          "version": "1.1.0",
+          "dependencies": {
+            "once": {
+              "version": "1.3.3"
+            }
+          }
+        }
+      }
+    },
+    "pumpify": {
+      "version": "1.3.5"
+    },
+    "punycode": {
+      "version": "1.4.1"
+    },
+    "q": {
+      "version": "1.4.1"
+    },
+    "qs": {
+      "version": "6.3.0"
+    },
+    "randomatic": {
+      "version": "1.1.6"
+    },
+    "range-parser": {
+      "version": "1.0.3"
+    },
+    "raw-body": {
+      "version": "2.1.7"
+    },
+    "rc": {
+      "version": "1.1.6"
+    },
+    "read-all-stream": {
+      "version": "3.1.0"
+    },
+    "read-chunk": {
+      "version": "1.0.1"
+    },
+    "read-pkg": {
+      "version": "1.1.0"
+    },
+    "read-pkg-up": {
+      "version": "1.0.1"
+    },
+    "readable-stream": {
+      "version": "2.2.2",
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0"
+        }
+      }
+    },
+    "rechoir": {
+      "version": "0.6.2"
+    },
+    "redent": {
+      "version": "1.0.0",
+      "dependencies": {
+        "strip-indent": {
+          "version": "1.0.1"
+        }
+      }
+    },
+    "reduce-flatten": {
+      "version": "1.0.1"
+    },
+    "regenerate": {
+      "version": "1.3.2"
+    },
+    "regenerator-runtime": {
+      "version": "0.10.1"
+    },
+    "regenerator-transform": {
+      "version": "0.9.8"
+    },
+    "regex-cache": {
+      "version": "0.4.3"
+    },
+    "regexpu-core": {
+      "version": "2.0.0"
+    },
+    "registry-auth-token": {
+      "version": "3.1.0"
+    },
+    "registry-url": {
+      "version": "3.1.0"
+    },
+    "regjsgen": {
+      "version": "0.2.0"
+    },
+    "regjsparser": {
+      "version": "0.1.5",
+      "dependencies": {
+        "jsesc": {
+          "version": "0.5.0"
+        }
+      }
+    },
+    "relateurl": {
+      "version": "0.2.7"
+    },
+    "repeat-element": {
+      "version": "1.1.2"
+    },
+    "repeat-string": {
+      "version": "1.6.1"
+    },
+    "repeating": {
+      "version": "2.0.1"
+    },
+    "replace-ext": {
+      "version": "0.0.1"
+    },
+    "request": {
+      "version": "2.79.0"
+    },
+    "requires-port": {
+      "version": "1.0.0"
+    },
+    "resolve": {
+      "version": "1.2.0"
+    },
+    "resolve-dir": {
+      "version": "0.1.1"
+    },
+    "restify": {
+      "version": "4.3.0",
+      "optional": true,
+      "dependencies": {
+        "asn1": {
+          "version": "0.1.11",
+          "optional": true
+        },
+        "assert-plus": {
+          "version": "0.1.5"
+        },
+        "extsprintf": {
+          "version": "1.3.0",
+          "optional": true
+        },
+        "http-signature": {
+          "version": "0.11.0",
+          "optional": true
+        },
+        "verror": {
+          "version": "1.9.0",
+          "optional": true,
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "optional": true
+            }
+          }
+        }
+      }
+    },
+    "restore-cursor": {
+      "version": "1.0.1"
+    },
+    "right-align": {
+      "version": "0.1.3"
+    },
+    "rimraf": {
+      "version": "2.5.4",
+      "dependencies": {
+        "glob": {
+          "version": "7.1.1"
+        }
+      }
+    },
+    "run-async": {
+      "version": "2.3.0"
+    },
+    "rx": {
+      "version": "4.1.0"
+    },
+    "safe-json-stringify": {
+      "version": "1.0.3",
+      "optional": true
+    },
+    "samsam": {
+      "version": "1.1.2"
+    },
+    "sauce-connect-launcher": {
+      "version": "1.1.1",
+      "optional": true,
+      "dependencies": {
+        "async": {
+          "version": "2.1.4",
+          "optional": true
+        },
+        "lodash": {
+          "version": "4.17.4"
+        }
+      }
+    },
+    "seek-bzip": {
+      "version": "1.0.5",
+      "dependencies": {
+        "commander": {
+          "version": "2.8.1"
+        }
+      }
+    },
+    "select-hose": {
+      "version": "2.0.0"
+    },
+    "selenium-standalone": {
+      "version": "5.9.0",
+      "optional": true,
+      "dependencies": {
+        "asn1": {
+          "version": "0.1.11",
+          "optional": true
+        },
+        "assert-plus": {
+          "version": "0.1.5",
+          "optional": true
+        },
+        "async": {
+          "version": "1.2.1",
+          "optional": true
+        },
+        "aws-sign2": {
+          "version": "0.5.0",
+          "optional": true
+        },
+        "bl": {
+          "version": "0.9.5",
+          "optional": true
+        },
+        "boom": {
+          "version": "0.4.2"
+        },
+        "caseless": {
+          "version": "0.8.0",
+          "optional": true
+        },
+        "combined-stream": {
+          "version": "0.0.7"
+        },
+        "commander": {
+          "version": "2.6.0",
+          "optional": true
+        },
+        "cryptiles": {
+          "version": "0.2.2",
+          "optional": true
+        },
+        "delayed-stream": {
+          "version": "0.0.5"
+        },
+        "forever-agent": {
+          "version": "0.5.2",
+          "optional": true
+        },
+        "form-data": {
+          "version": "0.2.0",
+          "optional": true,
+          "dependencies": {
+            "async": {
+              "version": "0.9.2",
+              "optional": true
+            },
+            "mime-types": {
+              "version": "2.0.14",
+              "optional": true
+            }
+          }
+        },
+        "hawk": {
+          "version": "1.1.1",
+          "optional": true
+        },
+        "hoek": {
+          "version": "0.9.1"
+        },
+        "http-signature": {
+          "version": "0.10.1",
+          "optional": true
+        },
+        "lodash": {
+          "version": "3.9.3",
+          "optional": true
+        },
+        "mime-db": {
+          "version": "1.12.0",
+          "optional": true
+        },
+        "mime-types": {
+          "version": "1.0.2",
+          "optional": true
+        },
+        "minimist": {
+          "version": "1.1.0",
+          "optional": true
+        },
+        "mkdirp": {
+          "version": "0.5.0",
+          "optional": true,
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.8",
+              "optional": true
+            }
+          }
+        },
+        "oauth-sign": {
+          "version": "0.5.0",
+          "optional": true
+        },
+        "qs": {
+          "version": "2.3.3",
+          "optional": true
+        },
+        "readable-stream": {
+          "version": "1.0.34",
+          "optional": true
+        },
+        "request": {
+          "version": "2.51.0",
+          "optional": true
+        },
+        "sntp": {
+          "version": "0.2.4",
+          "optional": true
+        },
+        "which": {
+          "version": "1.1.1",
+          "optional": true
+        }
+      }
+    },
+    "semver": {
+      "version": "4.3.6"
+    },
+    "semver-diff": {
+      "version": "2.1.0",
+      "dependencies": {
+        "semver": {
+          "version": "5.3.0"
+        }
+      }
+    },
+    "send": {
+      "version": "0.11.1",
+      "dependencies": {
+        "debug": {
+          "version": "2.1.3"
+        },
+        "mime": {
+          "version": "1.2.11"
+        },
+        "on-finished": {
+          "version": "2.2.1"
+        }
+      }
+    },
+    "serve-static": {
+      "version": "1.11.1",
+      "dependencies": {
+        "debug": {
+          "version": "2.2.0"
+        },
+        "depd": {
+          "version": "1.1.0"
+        },
+        "destroy": {
+          "version": "1.0.4"
+        },
+        "escape-html": {
+          "version": "1.0.3"
+        },
+        "etag": {
+          "version": "1.7.0"
+        },
+        "fresh": {
+          "version": "0.3.0"
+        },
+        "ms": {
+          "version": "0.7.1"
+        },
+        "range-parser": {
+          "version": "1.2.0"
+        },
+        "send": {
+          "version": "0.14.1"
+        }
+      }
+    },
+    "server-destroy": {
+      "version": "1.0.1"
+    },
+    "serviceworker-cache-polyfill": {
+      "version": "4.0.0"
+    },
+    "set-immediate-shim": {
+      "version": "1.0.1"
+    },
+    "setprototypeof": {
+      "version": "1.0.2"
+    },
+    "shady-css-parser": {
+      "version": "0.0.8"
+    },
+    "shelljs": {
+      "version": "0.7.5",
+      "dependencies": {
+        "glob": {
+          "version": "7.1.1"
+        }
+      }
+    },
+    "signal-exit": {
+      "version": "3.0.2"
+    },
+    "sinon": {
+      "version": "1.17.7"
+    },
+    "sinon-chai": {
+      "version": "2.8.0"
+    },
+    "slash": {
+      "version": "1.0.0"
+    },
+    "slide": {
+      "version": "1.1.6"
+    },
+    "sntp": {
+      "version": "1.0.9"
+    },
+    "socket.io": {
+      "version": "1.7.2",
+      "dependencies": {
+        "debug": {
+          "version": "2.3.3"
+        },
+        "ms": {
+          "version": "0.7.2"
+        }
+      }
+    },
+    "socket.io-adapter": {
+      "version": "0.5.0",
+      "dependencies": {
+        "debug": {
+          "version": "2.3.3"
+        },
+        "ms": {
+          "version": "0.7.2"
+        }
+      }
+    },
+    "socket.io-client": {
+      "version": "1.7.2",
+      "dependencies": {
+        "component-emitter": {
+          "version": "1.2.1"
+        },
+        "debug": {
+          "version": "2.3.3"
+        },
+        "ms": {
+          "version": "0.7.2"
+        }
+      }
+    },
+    "socket.io-parser": {
+      "version": "2.3.1",
+      "dependencies": {
+        "debug": {
+          "version": "2.2.0"
+        },
+        "ms": {
+          "version": "0.7.1"
+        }
+      }
+    },
+    "sort-keys": {
+      "version": "1.1.2"
+    },
+    "sort-keys-length": {
+      "version": "1.0.1"
+    },
+    "source-map": {
+      "version": "0.5.6"
+    },
+    "source-map-support": {
+      "version": "0.4.8"
+    },
+    "sparkles": {
+      "version": "1.0.0"
+    },
+    "spawn-sync": {
+      "version": "1.0.15"
+    },
+    "spdx-correct": {
+      "version": "1.0.2"
+    },
+    "spdx-expression-parse": {
+      "version": "1.0.4"
+    },
+    "spdx-license-ids": {
+      "version": "1.2.2"
+    },
+    "spdy": {
+      "version": "3.4.4"
+    },
+    "spdy-transport": {
+      "version": "2.0.18"
+    },
+    "split": {
+      "version": "1.0.0"
+    },
+    "sprintf-js": {
+      "version": "1.0.3"
+    },
+    "sshpk": {
+      "version": "1.10.1",
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0"
+        }
+      }
+    },
+    "stack-trace": {
+      "version": "0.0.9"
+    },
+    "stacky": {
+      "version": "1.3.1"
+    },
+    "stat-mode": {
+      "version": "0.2.2"
+    },
+    "statuses": {
+      "version": "1.3.1"
+    },
+    "stream-combiner2": {
+      "version": "1.1.1"
+    },
+    "stream-connect": {
+      "version": "1.0.2"
+    },
+    "stream-consume": {
+      "version": "0.1.0"
+    },
+    "stream-shift": {
+      "version": "1.0.0"
+    },
+    "stream-transform": {
+      "version": "0.1.1",
+      "optional": true
+    },
+    "stream-via": {
+      "version": "1.0.3"
+    },
+    "streamsearch": {
+      "version": "0.1.2"
+    },
+    "string_decoder": {
+      "version": "0.10.31"
+    },
+    "string-template": {
+      "version": "0.2.1"
+    },
+    "string-width": {
+      "version": "1.0.2"
+    },
+    "stringstream": {
+      "version": "0.0.5"
+    },
+    "strip-ansi": {
+      "version": "3.0.1"
+    },
+    "strip-bom": {
+      "version": "2.0.0"
+    },
+    "strip-bom-stream": {
+      "version": "1.0.0"
+    },
+    "strip-dirs": {
+      "version": "1.1.1"
+    },
+    "strip-indent": {
+      "version": "2.0.0"
+    },
+    "strip-json-comments": {
+      "version": "1.0.4"
+    },
+    "strip-outer": {
+      "version": "1.0.0"
+    },
+    "sum-up": {
+      "version": "1.0.3"
+    },
+    "supports-color": {
+      "version": "2.0.0"
+    },
+    "sw-precache": {
+      "version": "4.2.3",
+      "dependencies": {
+        "es6-promise": {
+          "version": "4.0.5"
+        },
+        "glob": {
+          "version": "7.1.1"
+        },
+        "lodash.template": {
+          "version": "4.4.0"
+        },
+        "lodash.templatesettings": {
+          "version": "4.1.0"
+        }
+      }
+    },
+    "sw-toolbox": {
+      "version": "3.4.0",
+      "dependencies": {
+        "path-to-regexp": {
+          "version": "1.7.0"
+        }
+      }
+    },
+    "table-layout": {
+      "version": "0.3.0"
+    },
+    "tar-fs": {
+      "version": "1.15.0"
+    },
+    "tar-stream": {
+      "version": "1.5.2",
+      "dependencies": {
+        "end-of-stream": {
+          "version": "1.1.0"
+        },
+        "once": {
+          "version": "1.3.3"
+        }
+      }
+    },
+    "temp": {
+      "version": "0.8.3",
+      "dependencies": {
+        "rimraf": {
+          "version": "2.2.8"
+        }
+      }
+    },
+    "ternary-stream": {
+      "version": "2.0.1",
+      "dependencies": {
+        "through2": {
+          "version": "2.0.3"
+        }
+      }
+    },
+    "test-value": {
+      "version": "2.1.0"
+    },
+    "text-table": {
+      "version": "0.2.0"
+    },
+    "textextensions": {
+      "version": "1.0.2"
+    },
+    "thenify": {
+      "version": "3.2.1"
+    },
+    "thenify-all": {
+      "version": "1.6.0"
+    },
+    "through": {
+      "version": "2.3.8"
+    },
+    "through2": {
+      "version": "0.4.2",
+      "dependencies": {
+        "readable-stream": {
+          "version": "1.0.34"
+        },
+        "xtend": {
+          "version": "2.1.2"
+        }
+      }
+    },
+    "through2-filter": {
+      "version": "2.0.0",
+      "dependencies": {
+        "through2": {
+          "version": "2.0.3"
+        }
+      }
+    },
+    "time-stamp": {
+      "version": "1.0.1"
+    },
+    "timed-out": {
+      "version": "3.1.3"
+    },
+    "tmp": {
+      "version": "0.0.29"
+    },
+    "to-absolute-glob": {
+      "version": "0.1.1"
+    },
+    "to-array": {
+      "version": "0.1.4"
+    },
+    "to-fast-properties": {
+      "version": "1.0.2"
+    },
+    "tough-cookie": {
+      "version": "2.3.2"
+    },
+    "traverse": {
+      "version": "0.6.6"
+    },
+    "trim-newlines": {
+      "version": "1.0.0"
+    },
+    "trim-repeated": {
+      "version": "1.0.0"
+    },
+    "tunnel-agent": {
+      "version": "0.4.3"
+    },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "optional": true
+    },
+    "type-check": {
+      "version": "0.3.2"
+    },
+    "type-detect": {
+      "version": "1.0.0"
+    },
+    "type-is": {
+      "version": "1.6.14"
+    },
+    "typedarray": {
+      "version": "0.0.6"
+    },
+    "typical": {
+      "version": "2.6.0"
+    },
+    "ua-parser-js": {
+      "version": "0.7.12"
+    },
+    "uglify-js": {
+      "version": "2.7.5",
+      "dependencies": {
+        "async": {
+          "version": "0.2.10"
+        },
+        "yargs": {
+          "version": "3.10.0"
+        }
+      }
+    },
+    "uglify-to-browserify": {
+      "version": "1.0.2"
+    },
+    "ultron": {
+      "version": "1.0.2"
+    },
+    "underscore": {
+      "version": "1.6.0"
+    },
+    "underscore.string": {
+      "version": "3.3.4"
+    },
+    "unique-stream": {
+      "version": "2.2.1"
+    },
+    "unpipe": {
+      "version": "1.0.0"
+    },
+    "untildify": {
+      "version": "2.1.0"
+    },
+    "unzip-response": {
+      "version": "1.0.2"
+    },
+    "update-notifier": {
+      "version": "1.0.3"
+    },
+    "upper-case": {
+      "version": "1.1.3"
+    },
+    "urijs": {
+      "version": "1.16.1",
+      "optional": true
+    },
+    "url-parse-lax": {
+      "version": "1.0.0"
+    },
+    "user-home": {
+      "version": "2.0.0"
+    },
+    "util": {
+      "version": "0.10.3",
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.1"
+        }
+      }
+    },
+    "util-deprecate": {
+      "version": "1.0.2"
+    },
+    "utils-merge": {
+      "version": "1.0.0"
+    },
+    "uuid": {
+      "version": "3.0.1"
+    },
+    "vali-date": {
+      "version": "1.0.0"
+    },
+    "validate-npm-package-license": {
+      "version": "3.0.1"
+    },
+    "vargs": {
+      "version": "0.1.0"
+    },
+    "vary": {
+      "version": "1.1.0"
+    },
+    "vasync": {
+      "version": "1.6.3",
+      "optional": true,
+      "dependencies": {
+        "extsprintf": {
+          "version": "1.2.0",
+          "optional": true
+        },
+        "verror": {
+          "version": "1.6.0",
+          "optional": true
+        }
+      }
+    },
+    "verror": {
+      "version": "1.3.6"
+    },
+    "vinyl": {
+      "version": "1.2.0"
+    },
+    "vinyl-assign": {
+      "version": "1.2.1"
+    },
+    "vinyl-file": {
+      "version": "2.0.0",
+      "dependencies": {
+        "first-chunk-stream": {
+          "version": "2.0.0"
+        },
+        "strip-bom-stream": {
+          "version": "2.0.0"
+        }
+      }
+    },
+    "vinyl-fs": {
+      "version": "2.4.4",
+      "dependencies": {
+        "through2": {
+          "version": "2.0.3"
+        }
+      }
+    },
+    "vulcanize": {
+      "version": "1.15.2",
+      "dependencies": {
+        "@types/node": {
+          "version": "4.0.30"
+        },
+        "@types/parse5": {
+          "version": "0.0.31",
+          "dependencies": {
+            "@types/node": {
+              "version": "6.0.56"
+            }
+          }
+        },
+        "dom5": {
+          "version": "1.3.6"
+        },
+        "parse5": {
+          "version": "1.5.1"
+        }
+      }
+    },
+    "ware": {
+      "version": "1.3.0"
+    },
+    "wbuf": {
+      "version": "1.7.2"
+    },
+    "wct-local": {
+      "version": "2.0.13",
+      "optional": true,
+      "dependencies": {
+        "@types/node": {
+          "version": "6.0.56",
+          "optional": true
+        }
+      }
+    },
+    "wct-sauce": {
+      "version": "2.0.0-pre.1",
+      "optional": true,
+      "dependencies": {
+        "uuid": {
+          "version": "2.0.3",
+          "optional": true
+        }
+      }
+    },
+    "wd": {
+      "version": "1.1.1",
+      "dependencies": {
+        "async": {
+          "version": "2.0.1",
+          "dependencies": {
+            "lodash": {
+              "version": "4.17.4"
+            }
+          }
+        },
+        "bl": {
+          "version": "1.1.2"
+        },
+        "form-data": {
+          "version": "2.0.0"
+        },
+        "isarray": {
+          "version": "1.0.0"
+        },
+        "lodash": {
+          "version": "4.16.2"
+        },
+        "qs": {
+          "version": "6.2.0"
+        },
+        "readable-stream": {
+          "version": "2.0.6"
+        },
+        "request": {
+          "version": "2.75.0"
+        }
+      }
+    },
+    "web-component-tester": {
+      "version": "6.0.0-prerelease.4",
+      "dependencies": {
+        "@types/node": {
+          "version": "4.0.30"
+        },
+        "findup-sync": {
+          "version": "0.2.1",
+          "dependencies": {
+            "glob": {
+              "version": "4.3.5"
+            }
+          }
+        },
+        "minimatch": {
+          "version": "2.0.10"
+        },
+        "semver": {
+          "version": "5.3.0"
+        }
+      }
+    },
+    "which": {
+      "version": "1.2.12"
+    },
+    "widest-line": {
+      "version": "1.0.0"
+    },
+    "window-size": {
+      "version": "0.1.0"
+    },
+    "winston": {
+      "version": "2.3.0",
+      "dependencies": {
+        "async": {
+          "version": "1.0.0"
+        },
+        "colors": {
+          "version": "1.0.3"
+        }
+      }
+    },
+    "wordwrap": {
+      "version": "0.0.3"
+    },
+    "wordwrapjs": {
+      "version": "2.0.0"
+    },
+    "wrap-fn": {
+      "version": "0.1.5"
+    },
+    "wrappy": {
+      "version": "1.0.2"
+    },
+    "write-file-atomic": {
+      "version": "1.2.0"
+    },
+    "ws": {
+      "version": "1.1.1"
+    },
+    "wtf-8": {
+      "version": "1.0.0"
+    },
+    "xdg-basedir": {
+      "version": "2.0.0"
+    },
+    "xml-char-classes": {
+      "version": "1.0.0"
+    },
+    "xmlbuilder": {
+      "version": "8.2.2",
+      "optional": true
+    },
+    "xmldom": {
+      "version": "0.1.27",
+      "optional": true
+    },
+    "xmlhttprequest-ssl": {
+      "version": "1.5.3"
+    },
+    "xtend": {
+      "version": "4.0.1"
+    },
+    "yallist": {
+      "version": "2.0.0"
+    },
+    "yauzl": {
+      "version": "2.7.0"
+    },
+    "yeast": {
+      "version": "0.1.2"
+    },
+    "yeoman-assert": {
+      "version": "2.2.2"
+    },
+    "yeoman-environment": {
+      "version": "1.6.6",
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.4"
+        }
+      }
+    },
+    "yeoman-generator": {
+      "version": "0.23.4",
+      "dependencies": {
+        "glob": {
+          "version": "7.1.1"
+        },
+        "lodash": {
+          "version": "4.17.4"
+        },
+        "through2": {
+          "version": "2.0.3"
+        }
+      }
+    },
+    "yeoman-test": {
+      "version": "1.6.0",
+      "dependencies": {
+        "async": {
+          "version": "2.0.1"
+        },
+        "cross-spawn": {
+          "version": "4.0.2"
+        },
+        "glob": {
+          "version": "7.1.1"
+        },
+        "istextorbinary": {
+          "version": "2.1.0"
+        },
+        "lodash": {
+          "version": "4.17.4"
+        },
+        "through2": {
+          "version": "2.0.3"
+        },
+        "yeoman-generator": {
+          "version": "0.24.1"
+        }
+      }
+    },
+    "yeoman-welcome": {
+      "version": "1.0.1"
+    },
+    "zip-stream": {
+      "version": "1.1.0",
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.4"
+        }
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -77,7 +77,6 @@
     "yeoman-generator": "^0.23.3"
   },
   "devDependencies": {
-    "bower": "^1.7.9",
     "chai": "^3.5.0",
     "clang-format": "=1.0.45",
     "depcheck": "^0.6.3",


### PR DESCRIPTION
This should get us more repeatable tests and bug reports, and reduces npm install times by ~15%.

`np` will regenerate the shrinkwrap for every release if one already exists, so this gets things started.