### PR TITLE
Add `--compile` flag to babelify your build

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "author": "The Polymer Project Authors",
   "license": "BSD-3-Clause",
   "dependencies": {
+    "@types/babel-core": "^6.7.14",
     "@types/chalk": "^0.4.31",
     "@types/del": "^2.2.31",
     "@types/findup-sync": "^0.3.29",
@@ -39,6 +40,8 @@
     "@types/vinyl": "^2.0.0",
     "@types/vinyl-fs": "0.0.28",
     "@types/yeoman-generator": "0.0.30",
+    "babel-core": "^6.17.0",
+    "babel-preset-es2015": "^6.18.0",
     "bower": "1.8.0",
     "bower-json": "^0.8.1",
     "bower-logger": "^0.2.2",

--- a/src/build/optimize-streams.ts
+++ b/src/build/optimize-streams.ts
@@ -12,12 +12,14 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
+import {transform as babelTransform, TransformOptions as BabelTransformOptions} from 'babel-core';
 import {css as cssSlam} from 'css-slam';
 import {minify as htmlMinify, Options as HTMLMinifierOptions} from 'html-minifier';
 import * as logging from 'plylog';
 import {Transform} from 'stream';
 import {minify as uglify, MinifyOptions as UglifyOptions} from 'uglify-js';
 
+const babelPresetES2015 = require('babel-preset-es2015');
 
 // TODO(fks) 09-22-2016: Latest npm type declaration resolves to a non-module
 // entity. Upgrade to proper JS import once compatible .d.ts file is released,
@@ -86,6 +88,26 @@ export class JSOptimizeStream extends GenericOptimizeStream {
   }
 }
 
+
+/**
+ * JSBabelStream transpiles Javascript down to work in older browsers, rewriting
+ * newer ECMAScript features to only use language features available in major
+ * browsers. If no options are given to the constructor, JSBabelStream will use
+ * a default "ES6 -> ES5" preset (configuration).
+ */
+const defaultBabelConfig = {
+  presets: [babelPresetES2015]
+};
+export class JSBabelStream extends GenericOptimizeStream {
+  constructor(options: BabelTransformOptions) {
+    let transform = (contents: string, options: BabelTransformOptions) => {
+      const bob = babelTransform(contents, options).code!;
+      return bob;
+    };
+    let config = options || defaultBabelConfig;
+    super('.js', transform, config);
+  }
+}
 
 /**
  * CSSOptimizeStream optimizes CSS files that pass through it (via css-slam).

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -39,6 +39,12 @@ export class BuildCommand implements Command {
           'requests needed to serve your application.'
     },
     {
+      name: 'compile',
+      type: Boolean,
+      description: 'Path to an sw-precache configuration to be ' +
+          'used for service worker generation.'
+    },
+    {
       name: 'sw-precache-config',
       defaultValue: 'sw-precache-config.js',
       description: 'Path to an sw-precache configuration to be ' +
@@ -64,6 +70,7 @@ export class BuildCommand implements Command {
     const build = require('../build/build').build;
 
     let buildOptions: BuildOptions = {
+      compile: options['compile'],
       swPrecacheConfig: options['sw-precache-config'],
       prefetchDepedencies: options['add-prefetch'],
       bundle: options['bundle'],


### PR DESCRIPTION
I figured out how to load and use presets within the CLI (not super obvious). This lets users already using babel provide their own `.babelrc` file if they want, but we will default to the basic `es2015` transformation for everyone else.

/cc @justinfagnani 

