### PR TITLE
Cleanup how optimize streams work, in preparation for babel stream

### DIFF
--- a/src/build/build.ts
+++ b/src/build/build.ts
@@ -13,7 +13,6 @@
  */
 
 import * as del from 'del';
-import * as gulpif from 'gulp-if';
 import * as path from 'path';
 import * as logging from 'plylog';
 import {dest} from 'vinyl-fs';

--- a/src/build/build.ts
+++ b/src/build/build.ts
@@ -32,15 +32,16 @@ const logger = logging.getLogger('cli.build.build');
 
 const buildDirectory = 'build/';
 
-export interface BuildOptions {
+export interface BuildOptions extends OptimizeOptions {
   swPrecacheConfig?: string;
   insertPrefetchLinks?: boolean;
   bundle?: boolean;
-  optimize?: OptimizeOptions;
 };
 
 export async function build(
     options: BuildOptions, config: ProjectConfig): Promise<void> {
+  const optimizeOptions:
+      OptimizeOptions = {css: options.css, js: options.js, html: options.html};
   const polymerProject = new PolymerProject(config);
   const swPrecacheConfig = path.resolve(
       config.root, options.swPrecacheConfig || 'sw-precache-config.js');
@@ -52,7 +53,7 @@ export async function build(
   const sourcesStream = pipeStreams([
     polymerProject.sources(),
     polymerProject.splitHtml(),
-    getOptimizeStreams(options.optimize),
+    getOptimizeStreams(optimizeOptions),
     polymerProject.rejoinHtml()
   ]);
 
@@ -60,7 +61,7 @@ export async function build(
   const depsStream = pipeStreams([
     polymerProject.dependencies(),
     polymerProject.splitHtml(),
-    getOptimizeStreams(options.optimize),
+    getOptimizeStreams(optimizeOptions),
     polymerProject.rejoinHtml()
   ]);
 

--- a/src/build/optimize-streams.ts
+++ b/src/build/optimize-streams.ts
@@ -31,9 +31,9 @@ export type CSSOptimizeOptions = {
   stripWhitespace?: boolean;
 };
 export interface OptimizeOptions {
-  htmlMinify?: HTMLMinifierOptions;
-  cssMinify?: CSSOptimizeOptions;
-  jsMinify?: UglifyOptions;
+  html?: {minify: boolean};
+  css?: {minify: boolean};
+  js?: {minify?: boolean};
 };
 
 /**
@@ -142,20 +142,21 @@ export class HTMLOptimizeStream extends GenericOptimizeStream {
  * Returns an array of optimization streams to use in your build, based on the
  * OptimizeOptions given.
  */
-export function getOptimizeStreams(optimizeOptions: OptimizeOptions) {
+export function getOptimizeStreams(options?: OptimizeOptions) {
+  options = options || {};
   const streams = [];
 
   // add optimizers
-  if (optimizeOptions.htmlMinify) {
+  if (options.html && options.html.minify) {
     streams.push(gulpif(/\.html$/, new HTMLOptimizeStream({collapseWhitespace: true, removeComments: true})));
   }
-  if (optimizeOptions.cssMinify) {
+  if (options.css && options.css.minify) {
     streams.push(gulpif(/\.css$/, new CSSOptimizeStream({stripWhitespace: true})));
     // TODO(fks): Remove this InlineCSSOptimizeStream stream once CSS
     // is properly being isolated by splitHtml() & rejoinHtml().
     streams.push(gulpif(/\.html$/, new InlineCSSOptimizeStream({stripWhitespace: true})));
   }
-  if (optimizeOptions.jsMinify) {
+  if (options.js && options.js.minify) {
     streams.push(gulpif(/\.js$/, new JSOptimizeStream({fromString: true})));
   }
 

--- a/src/build/optimize-streams.ts
+++ b/src/build/optimize-streams.ts
@@ -142,19 +142,25 @@ export class HTMLOptimizeStream extends GenericOptimizeStream {
  * Returns an array of optimization streams to use in your build, based on the
  * OptimizeOptions given.
  */
-export function getOptimizeStreams(options?: OptimizeOptions) {
+export function getOptimizeStreams(options?: OptimizeOptions):
+    NodeJS.ReadWriteStream[] {
   options = options || {};
   const streams = [];
 
   // add optimizers
   if (options.html && options.html.minify) {
-    streams.push(gulpif(/\.html$/, new HTMLOptimizeStream({collapseWhitespace: true, removeComments: true})));
+    streams.push(gulpif(
+        /\.html$/,
+        new HTMLOptimizeStream(
+            {collapseWhitespace: true, removeComments: true})));
   }
   if (options.css && options.css.minify) {
-    streams.push(gulpif(/\.css$/, new CSSOptimizeStream({stripWhitespace: true})));
+    streams.push(
+        gulpif(/\.css$/, new CSSOptimizeStream({stripWhitespace: true})));
     // TODO(fks): Remove this InlineCSSOptimizeStream stream once CSS
     // is properly being isolated by splitHtml() & rejoinHtml().
-    streams.push(gulpif(/\.html$/, new InlineCSSOptimizeStream({stripWhitespace: true})));
+    streams.push(gulpif(
+        /\.html$/, new InlineCSSOptimizeStream({stripWhitespace: true})));
   }
   if (options.js && options.js.minify) {
     streams.push(gulpif(/\.js$/, new JSOptimizeStream({fromString: true})));

--- a/src/build/optimize-streams.ts
+++ b/src/build/optimize-streams.ts
@@ -24,7 +24,7 @@ import {minify as uglify, MinifyOptions as UglifyOptions} from 'uglify-js';
 // or consider writing a custom declaration in the `custom_typings/` folder.
 import File = require('vinyl');
 
-let logger = logging.getLogger('cli.build.optimize-streams');
+const logger = logging.getLogger('cli.build.optimize-streams');
 
 export type FileCB = (error?: any, file?: File) => void;
 export type CSSOptimizeOptions = {
@@ -82,11 +82,11 @@ export class JSOptimizeStream extends GenericOptimizeStream {
     // uglify is special, in that it returns an object with a code property
     // instead of just a code string. We create a compliant optimizer here
     // that returns a string instead.
-    let uglifyOptimizer = (contents: string, options: UglifyOptions) => {
+    const uglifyOptimizer = (contents: string, options: UglifyOptions) => {
       return uglify(contents, options).code;
     };
     // We automatically add the fromString option because it is required.
-    let uglifyOptions = Object.assign({fromString: true}, options);
+    const uglifyOptions = Object.assign({fromString: true}, options);
     super('uglify-js', uglifyOptimizer, uglifyOptions);
   }
 }
@@ -143,7 +143,7 @@ export class HTMLOptimizeStream extends GenericOptimizeStream {
  * OptimizeOptions given.
  */
 export function getOptimizeStreams(optimizeOptions: OptimizeOptions) {
-  let streams = [];
+  const streams = [];
 
   // add optimizers
   if (optimizeOptions.htmlMinify) {

--- a/src/build/streams.ts
+++ b/src/build/streams.ts
@@ -30,3 +30,19 @@ export function waitForAll(streams: NodeJS.ReadableStream[]):
     Promise<NodeJS.ReadableStream[]> {
   return Promise.all<NodeJS.ReadableStream>(streams.map((s) => waitFor(s)));
 }
+
+type PipeStream = (NodeJS.ReadableStream|NodeJS.WritableStream|
+                   NodeJS.ReadableStream[]|NodeJS.WritableStream[]);
+
+/**
+ * pipeStreams() takes in a collection streams and pipes them together,
+ * returning the last stream in the pipeline. Each element in the `streams`
+ * array must be either a stream, or an array of streams (see PipeStream).
+ * pipeStreams() will then flatten this array before piping them all together.
+ */
+export function pipeStreams(streams: PipeStream[]): NodeJS.ReadableStream {
+  return Array.prototype.concat.apply([], streams)
+      .reduce((a: NodeJS.ReadableStream, b: NodeJS.ReadWriteStream) => {
+        return a.pipe(b);
+      });
+}

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -13,13 +13,13 @@
  */
 
 import * as logging from 'plylog';
+import {ProjectConfig} from 'polymer-project-config';
 
 // Only import type definitions here, otherwise this line will be included in
 // the JS output, triggering  the entire build library & its dependencies to
 // be loaded and parsed.
 import {BuildOptions} from '../build/build';
 
-import {ProjectConfig} from 'polymer-project-config';
 import {Command, CommandOptions} from './command';
 
 let logger = logging.getLogger('cli.command.build');

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -32,6 +32,21 @@ export class BuildCommand implements Command {
 
   args = [
     {
+      name: 'js-minify',
+      type: Boolean,
+      description: 'minify inlined and external JavaScript.'
+    },
+    {
+      name: 'css-minify',
+      type: Boolean,
+      description: 'minify inlined and external CSS.'
+    },
+    {
+      name: 'html-minify',
+      type: Boolean,
+      description: 'minify HTML by removing comments and whitespace.'
+    },
+    {
       name: 'sw-precache-config',
       defaultValue: 'sw-precache-config.js',
       description: 'Path to an sw-precache configuration to be ' +
@@ -44,11 +59,6 @@ export class BuildCommand implements Command {
           'additional `<link rel="prefetch">` tags into ' +
           'entrypoint and `<link rel="import">` tags into fragments and shell.'
     },
-    {
-      name: 'html.collapseWhitespace',
-      type: Boolean,
-      description: 'Collapse whitespace in HTML files'
-    }
   ];
 
   run(options: CommandOptions, config: ProjectConfig): Promise<any> {
@@ -58,13 +68,17 @@ export class BuildCommand implements Command {
     let buildOptions: BuildOptions = {
       swPrecacheConfig: options['sw-precache-config'],
       insertDependencyLinks: options['insert-dependency-links'],
-      html: {},
-      css: {},
-      js: {},
+      html: {
+        minify: !!options['html-minify'],
+      },
+      css: {
+        minify: !!options['css-minify'],
+      },
+      js: {
+        minify: !!options['js-minify'],
+      },
     };
-    if (options['html.collapseWhitespace']) {
-      buildOptions.html!.collapseWhitespace = true;
-    }
+
     logger.debug('building with options', buildOptions);
 
     if (options['env'] && options['env'].build) {

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -68,14 +68,16 @@ export class BuildCommand implements Command {
     let buildOptions: BuildOptions = {
       swPrecacheConfig: options['sw-precache-config'],
       insertDependencyLinks: options['insert-dependency-links'],
-      html: {
-        minify: !!options['html-minify'],
-      },
-      css: {
-        minify: !!options['css-minify'],
-      },
-      js: {
-        minify: !!options['js-minify'],
+      optimize: {
+        html: {
+          minify: !!options['html-minify'],
+        },
+        css: {
+          minify: !!options['css-minify'],
+        },
+        js: {
+          minify: !!options['js-minify'],
+        },
       },
     };
 

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -32,17 +32,17 @@ export class BuildCommand implements Command {
 
   args = [
     {
-      name: 'js-minify',
+      name: 'js.minify',
       type: Boolean,
       description: 'minify inlined and external JavaScript.'
     },
     {
-      name: 'css-minify',
+      name: 'css.minify',
       type: Boolean,
       description: 'minify inlined and external CSS.'
     },
     {
-      name: 'html-minify',
+      name: 'html.minify',
       type: Boolean,
       description: 'minify HTML by removing comments and whitespace.'
     },
@@ -70,13 +70,13 @@ export class BuildCommand implements Command {
       insertDependencyLinks: options['insert-dependency-links'],
       optimize: {
         html: {
-          minify: !!options['html-minify'],
+          minify: !!options['html.minify'],
         },
         css: {
-          minify: !!options['css-minify'],
+          minify: !!options['css.minify'],
         },
         js: {
-          minify: !!options['js-minify'],
+          minify: !!options['js.minify'],
         },
       },
     };

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -77,16 +77,14 @@ export class BuildCommand implements Command {
       swPrecacheConfig: options['sw-precache-config'],
       insertPrefetchLinks: options['insert-prefetch-links'],
       bundle: options['bundle'],
-      optimize: {
-        html: {
-          minify: !!options['html-minify'],
-        },
-        css: {
-          minify: !!options['css-minify'],
-        },
-        js: {
-          minify: !!options['js-minify'],
-        },
+      html: {
+        minify: !!options['html-minify'],
+      },
+      css: {
+        minify: !!options['css-minify'],
+      },
+      js: {
+        minify: !!options['js-minify'],
       },
     };
 


### PR DESCRIPTION
This PR addresses two problems:
- All the build options had gotten pretty confusing, and assumed a world where each language only had one optimizer. This PR cleans up the CLI commands and simplified the optimize options that the main build function accepts.
- Constructing our optimize stream inside of pipes and gulp if's was too limiting. We now call out to `getOptimizeStreams` to calculate and return the optimize streams that we need.

This PR should be a noop functionality-wise, and prepares for a much easier diff in https://github.com/Polymer/polymer-cli/pull/525.