### PR TITLE
stop stripping "polymer-starter-kit" from those templates

### DIFF
--- a/src/init/init.ts
+++ b/src/init/init.ts
@@ -156,12 +156,11 @@ function getDisplayName(generatorName: string) {
   // -------------------------------------------------------------------
   // (generator-)?           | Grp 1; Match "generator-"; Optional
   // (polymer-init)?         | Grp 2; Match "polymer-init-"; Optional
-  // (polymer-starter-kit-)? | Grp 3; Match "polymer-starter-kit-"; Optional
-  // ([^:]+)                 | Grp 4; Match one or more characters != ":"
-  // (:.*)?                  | Grp 5; Match ":" followed by anything; Optional
+  // ([^:]+)                 | Grp 3; Match one or more characters != ":"
+  // (:.*)?                  | Grp 4; Match ":" followed by anything; Optional
   return generatorName.replace(
-      /(generator-)?(polymer-init-)?(polymer-starter-kit-)?([^:]+)(:.*)?/g,
-      '$4');
+      /(generator-)?(polymer-init-)?([^:]+)(:.*)?/g,
+      '$3');
 }
 
 /**

--- a/src/init/init.ts
+++ b/src/init/init.ts
@@ -136,9 +136,9 @@ function getGeneratorMeta(
 
 /**
  * Extract the meaningful name from the full Yeoman generator name.
- * Strip the standard generator prefixes ("generator-", "polymer-init-",
- * and "polymer-starter-kit-"), and extract the remainder of the name
- * (the first part of the string before any colons).
+ * Strip the standard generator prefixes ("generator-" and "polymer-init-"),
+ * and extract the remainder of the name (the first part of the string before
+ * any colons).
  *
  * Examples:
  *
@@ -150,7 +150,7 @@ function getGeneratorMeta(
  *   'foo-bar:ccc'                        === 'foo-bar'
  */
 function getDisplayName(generatorName: string) {
-  // Breakdown of regular expression to extract name (group 4 in pattern):
+  // Breakdown of regular expression to extract name (group 3 in pattern):
   //
   // Pattern                 | Meaning
   // -------------------------------------------------------------------

--- a/test/unit/init/init_test.js
+++ b/test/unit/init/init_test.js
@@ -105,14 +105,14 @@ suite('init', () => {
       },
       {
         generatorName: 'polymer-init-polymer-starter-kit-custom-1:app',
-        metaName: 'polymer-init-polymer-starter-kit-psk-1',
-        shortName: 'psk-1',
+        metaName: 'polymer-init-polymer-starter-kit-1',
+        shortName: 'polymer-starter-kit-1',
         description: 'PSK 1',
       },
       {
         generatorName: 'polymer-init-polymer-starter-kit-custom-2:app',
-        metaName: 'generator-polymer-init-polymer-starter-kit-psk-2',
-        shortName: 'psk-2',
+        metaName: 'generator-polymer-init-polymer-starter-kit-2',
+        shortName: 'polymer-starter-kit-2',
         description: 'PSK 2',
       },
       {


### PR DESCRIPTION
Follow up from https://github.com/Polymer/polymer-cli/pull/472. 

We are now resolving bundled generators properly, but @justinfagnani pointed out that the `polymer-starter-kit-` prefix that is stripped out is important info. This PR removes that stripping.

### Current Behavior
![old behavior](https://cloud.githubusercontent.com/assets/622227/21113449/7fc6e8ce-c05e-11e6-9071-dec24288561f.png)

### This PR
<img width="863" alt="screen shot 2016-12-22 at 11 46 01 am" src="https://cloud.githubusercontent.com/assets/622227/21438087/3dec4df0-c83c-11e6-9f1d-4fd34f9efdf9.png">


/cc @justinfagnani @tony19 