### PR TITLE
Add support for polymer.json build configurations

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "polylint": "^2.10.0",
     "polymer-analyzer": "2.0.0-alpha.20",
     "polymer-build": "0.6.0-alpha.3",
-    "polymer-project-config": "^1.0.0",
+    "polymer-project-config": "^1.2.0",
     "polyserve": "0.16.0-prerelease.9",
     "request": "^2.72.0",
     "resolve": "^1.1.7",

--- a/src/build/build.ts
+++ b/src/build/build.ts
@@ -12,7 +12,6 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import * as del from 'del';
 import * as path from 'path';
 import * as logging from 'plylog';
 import {dest} from 'vinyl-fs';
@@ -20,32 +19,24 @@ import mergeStream = require('merge-stream');
 import {PolymerProject, addServiceWorker, SWConfig} from 'polymer-build';
 
 import {OptimizeOptions, getOptimizeStreams} from './optimize-streams';
-import {ProjectConfig} from 'polymer-project-config';
+import {ProjectConfig, ProjectBuildOptions} from 'polymer-project-config';
 import {PrefetchTransform} from './prefetch';
 import {waitFor, pipeStreams} from './streams';
 import {loadServiceWorkerConfig} from './load-config';
 
 const logger = logging.getLogger('cli.build.build');
 
-const buildDirectory = 'build/';
-
-export interface BuildOptions extends OptimizeOptions {
-  addServiceWorker?: boolean;
-  swPrecacheConfig?: string;
-  insertPrefetchLinks?: boolean;
-  bundle?: boolean;
-};
-
 export async function build(
-    options: BuildOptions, config: ProjectConfig): Promise<void> {
+    options: ProjectBuildOptions, config: ProjectConfig): Promise<void> {
   const optimizeOptions:
       OptimizeOptions = {css: options.css, js: options.js, html: options.html};
   const polymerProject = new PolymerProject(config);
 
-  logger.info(`Deleting build/ directory...`);
-  await del([buildDirectory]);
+  // If no name is provided, write directly to the build/ directory.
+  // If a build name is provided, write to that subdirectory.
+  const buildDirectory = `build/${options.name || ''}`;
+  logger.debug(`Building ${buildDirectory} with options`, options);
 
-  logger.debug(`Reading source files...`);
   const sourcesStream = pipeStreams([
     polymerProject.sources(),
     polymerProject.splitHtml(),
@@ -53,7 +44,6 @@ export async function build(
     polymerProject.rejoinHtml()
   ]);
 
-  logger.debug(`Reading dependencies...`);
   const depsStream = pipeStreams([
     polymerProject.dependencies(),
     polymerProject.splitHtml(),
@@ -64,10 +54,6 @@ export async function build(
   let buildStream: NodeJS.ReadableStream =
       mergeStream(sourcesStream, depsStream);
 
-  buildStream.once('data', () => {
-    logger.debug('Analyzing build dependencies...');
-  });
-
   if (options.bundle) {
     buildStream = buildStream.pipe(polymerProject.bundler);
   }
@@ -77,7 +63,7 @@ export async function build(
   }
 
   buildStream.once('data', () => {
-    logger.info('Generating build/ directory...');
+    logger.info(`Generating ${buildDirectory}...`);
   });
 
   // Finish the build stream by piping it into the final build directory.
@@ -99,11 +85,12 @@ export async function build(
   // addServiceWorker() reads from the file system, so we need to wait for
   // the build stream to finish writing to disk before calling it.
   if (options.addServiceWorker) {
-    logger.info(`Generating service worker...`);
+    logger.debug(`Generating service worker...`);
     if (swConfig) {
       logger.debug(`Service worker config found`, swConfig);
     } else {
-      logger.debug(`No service worker configuration found at ` +
+      logger.debug(
+          `No service worker configuration found at ` +
           `${swPrecacheConfigPath}, continuing with defaults`);
     }
     await addServiceWorker({
@@ -113,6 +100,9 @@ export async function build(
       bundled: options.bundle,
     });
   }
-
-  logger.info('Build complete!');
+  if (options.name) {
+    logger.info(`Build "${options.name}" complete!`);
+  } else {
+    logger.info(`Build complete!`);
+  }
 }

--- a/src/build/build.ts
+++ b/src/build/build.ts
@@ -27,6 +27,15 @@ import {loadServiceWorkerConfig} from './load-config';
 const logger = logging.getLogger('cli.build.build');
 export const mainBuildDirectoryName = 'build';
 
+/**
+ * Generate a single build based on the given `options` ProjectBuildOptions.
+ * Note that this function is only concerned with that single build, and does
+ * not care about the collection of builds defined on the config.
+ *
+ * TODO(fks) 01-26-2017: Generate multiple builds with a single PolymerProject
+ * instance. Currently blocked because splitHtml() & rejoinHtml() cannot be run
+ * on multiple streams in parallel. See: https://github.com/Polymer/polymer-build/issues/113
+ */
 export async function build(
     options: ProjectBuildOptions, config: ProjectConfig): Promise<void> {
   const optimizeOptions:

--- a/src/build/build.ts
+++ b/src/build/build.ts
@@ -25,6 +25,7 @@ import {waitFor, pipeStreams} from './streams';
 import {loadServiceWorkerConfig} from './load-config';
 
 const logger = logging.getLogger('cli.build.build');
+export const mainBuildDirectoryName = 'build';
 
 export async function build(
     options: ProjectBuildOptions, config: ProjectConfig): Promise<void> {
@@ -34,7 +35,7 @@ export async function build(
 
   // If no name is provided, write directly to the build/ directory.
   // If a build name is provided, write to that subdirectory.
-  const buildDirectory = `build/${options.name || ''}`;
+  const buildDirectory = path.join(mainBuildDirectoryName, options.name);
   logger.debug(`Building ${buildDirectory} with options`, options);
 
   const sourcesStream = pipeStreams([
@@ -63,7 +64,7 @@ export async function build(
   }
 
   buildStream.once('data', () => {
-    logger.info(`Generating ${buildDirectory}...`);
+    logger.info(`Building "${options.name}"...`);
   });
 
   // Finish the build stream by piping it into the final build directory.

--- a/src/build/build.ts
+++ b/src/build/build.ts
@@ -38,14 +38,15 @@ export const mainBuildDirectoryName = 'build';
  */
 export async function build(
     options: ProjectBuildOptions, config: ProjectConfig): Promise<void> {
+  const buildName = options.name || 'default';
   const optimizeOptions:
       OptimizeOptions = {css: options.css, js: options.js, html: options.html};
   const polymerProject = new PolymerProject(config);
 
   // If no name is provided, write directly to the build/ directory.
   // If a build name is provided, write to that subdirectory.
-  const buildDirectory = path.join(mainBuildDirectoryName, options.name);
-  logger.debug(`Building ${buildDirectory} with options`, options);
+  const buildDirectory = path.join(mainBuildDirectoryName, buildName);
+  logger.debug(`"${buildDirectory}": Building with options:`, options);
 
   const sourcesStream = pipeStreams([
     polymerProject.sources(),
@@ -73,7 +74,7 @@ export async function build(
   }
 
   buildStream.once('data', () => {
-    logger.info(`Building "${options.name}"...`);
+    logger.info(`(${buildName}) Building...`);
   });
 
   // Finish the build stream by piping it into the final build directory.
@@ -110,9 +111,6 @@ export async function build(
       bundled: options.bundle,
     });
   }
-  if (options.name) {
-    logger.info(`Build "${options.name}" complete!`);
-  } else {
-    logger.info(`Build complete!`);
-  }
+
+  logger.info(`(${buildName}) Build complete!`);
 }

--- a/src/build/optimize-streams.ts
+++ b/src/build/optimize-streams.ts
@@ -37,8 +37,8 @@ export type CSSOptimizeOptions = {
   stripWhitespace?: boolean;
 };
 export interface OptimizeOptions {
-  html?: {minify: boolean};
-  css?: {minify: boolean};
+  html?: {minify?: boolean};
+  css?: {minify?: boolean};
   js?: {minify?: boolean, compile?: boolean};
 }
 ;

--- a/src/environment/environment.ts
+++ b/src/environment/environment.ts
@@ -11,12 +11,10 @@
  * subject to an additional IP rights grant found at
  * http://polymer.github.io/PATENTS.txt
  */
-import {ProjectConfig} from 'polymer-project-config';
+import {ProjectBuildOptions, ProjectConfig} from 'polymer-project-config';
 import {ServerOptions} from 'polyserve/lib/start_server';
-
-import {BuildOptions} from '../build/build';
 
 export interface Environment {
   serve(options: ServerOptions): Promise<any>;
-  build(options: BuildOptions, config: ProjectConfig): Promise<any>;
+  build(options: ProjectBuildOptions, config: ProjectConfig): Promise<any>;
 }

--- a/src/environments/reyserve.ts
+++ b/src/environments/reyserve.ts
@@ -15,11 +15,11 @@
 import * as child_process from 'child_process';
 import * as fs from 'fs-extra';
 import * as path from 'path';
-import {ProjectConfig} from 'polymer-project-config';
+import {ProjectBuildOptions, ProjectConfig} from 'polymer-project-config';
 import {ServerOptions} from 'polyserve/lib/start_server';
 import * as temp from 'temp';
 
-import {build, BuildOptions} from '../build/build';
+import {build} from '../build/build';
 import {Environment} from '../environment/environment';
 import {Github} from '../github/github';
 
@@ -29,7 +29,7 @@ const REYSERVE_FILES = ['app.yaml', 'reyserve.py', 'http2push.py'];
 
 
 export class ReyServe implements Environment {
-  build(opts: BuildOptions, config: ProjectConfig): Promise<any> {
+  build(opts: ProjectBuildOptions, config: ProjectConfig): Promise<any> {
     const bundled = path.join(process.cwd(), 'build/bundled');
     const unbundled = path.join(process.cwd(), 'build/unbundled');
     const reyserveFiles = temp.mkdirSync('reyserve');


### PR DESCRIPTION
This PR adds support for build configurations stored in a user's `polymer.json`. See [Build Permutations Design Doc](https://docs.google.com/document/d/1mD1cVhxdxY-bUsGBX44anC1875Afx7UHue4uRCNVc4o) for design overview.

*Note: Because of https://github.com/Polymer/polymer-build/issues/113, we need to create new instances of polymer-build projects for each build. This adds unnecessary reads and file analysis for each additional build. Once this is no longer required, we'll rewrite this logic to only use a single polymer-project instance for all builds.*

***Note: Requires release of https://github.com/Polymer/polymer-project-config/pull/5. Tests will pass once that is released.***