### PR TITLE
Fix an issue when compiling with the latest TSC.

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,9 @@
 {
   "compilerOptions": {
     "target": "es6",
-    "lib": ["es2016"],
+    "lib": [
+      "es2016"
+    ],
     "module": "commonjs",
     "moduleResolution": "node",
     "isolatedModules": false,
@@ -15,7 +17,8 @@
     "suppressImplicitAnyIndexErrors": false,
     "outDir": "lib",
     "rootDir": "src",
-    "sourceMap": true
+    "sourceMap": true,
+    "skipLibCheck": true
   },
   "include": [
     "custom_typings/**/*.ts",


### PR DESCRIPTION
The latest version of typescript's standard library requires that the keys of a WeakMap be objects. So

interface WeakMap<K,V> { ... }

became

interface WeakMap<K extends object, V> { ... }

This conflicts with a declaration of WeakMap in the lodash typings (which the CLI depends on transitively).

Temporary workaround is to not typecheck libs.

More info: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/14324