### PR TITLE
tools-sample-projects integration tests

### DIFF
--- a/test/integration/integration_test.js
+++ b/test/integration/integration_test.js
@@ -119,4 +119,45 @@ suite('integration tests', function() {
 
   });
 
+  // TODO(fks): Two things are needed to unskip these tests:
+  //   1. Make the tools-sample-projects repo public
+  //   2. Create a new release when the add-projects branch/pr is merged
+  suite.skip('tools-sample-projects templates', () => {
+
+    let tspDir;
+
+    suiteSetup(() => {
+      const TSPGenerator = createGithubGenerator({
+        owner: 'Polymer',
+        repo: 'tools-sample-projects',
+        githubToken,
+      });
+
+      return runGenerator(TSPGenerator)
+        .toPromise()
+        .then((dir) => { tspDir = dir });
+    });
+
+    test('test the "polymer-1-app" template', () => {
+      const dir = path.join(tspDir, 'polymer-1-app');
+
+      return runCommand(binPath, ['install'], {cwd: dir})
+        // TODO(fks): reenable with new linter.
+        // .then(() => runCommand(binPath, ['lint'], {cwd: dir}))
+        // .then(() => runCommand(binPath, ['test'], {cwd: dir}))
+        .then(() => runCommand(binPath, ['build'], {cwd: dir}));
+    });
+
+    test('test the "polymer-2-app" template', () => {
+      const dir = path.join(tspDir, 'polymer-2-app');
+
+      return runCommand(binPath, ['install'], {cwd: dir})
+        // TODO(fks): reenable with new linter.
+        // .then(() => runCommand(binPath, ['lint'], {cwd: dir}))
+        // .then(() => runCommand(binPath, ['test'], {cwd: dir}))
+        .then(() => runCommand(binPath, ['build'], {cwd: dir}));
+    });
+
+  });
+
 });

--- a/test/integration/integration_test.js
+++ b/test/integration/integration_test.js
@@ -13,7 +13,6 @@ const path = require('path');
 const runGenerator = require('yeoman-test').run;
 const createGithubGenerator
   = require('../../lib/init/github').createGithubGenerator;
-
 const runCommand = require('./run-command').runCommand;
 
 // Template Generators
@@ -25,16 +24,6 @@ const createElementGenerator
 // A zero priveledge github token of a nonce account, used for quota.
 const githubToken = '8d8622bf09bb1d85cb411b5e475a35e742a7ce35';
 
-const ShopGenerator = createGithubGenerator({
-  owner: 'Polymer',
-  repo: 'shop',
-  githubToken,
-});
-const PSKGenerator = createGithubGenerator({
-  owner: 'PolymerElements',
-  repo: 'polymer-starter-kit',
-  githubToken,
-});
 
 suite('integration tests', function() {
 
@@ -43,75 +32,91 @@ suite('integration tests', function() {
   // Extend timeout limit to 90 seconds for slower systems
   this.timeout(90000);
 
-  // TODO(#562): enable test commands.
-  // TODO(rictic): run linter once new linter lands.
-  test('test the polymer 1.x application template', () => {
-    let dir;
-    return runGenerator(createApplicationGenerator('polymer-1.x'))
-      .withPrompts({ name: 'my-app' }) // Mock the prompt answers
-      .toPromise()
-      .then((_dir) => { dir = _dir })
-      .then(() => runCommand(binPath, ['install'], {cwd: dir}))
-      // .then(() => runCommand(binPath, ['lint'], {cwd: dir}))
-      // .then(() => runCommand(binPath, ['test'], {cwd: dir}))
-      .then(() => runCommand(binPath, ['build'], {cwd: dir}));
-  });
+  suite('init templates', () => {
 
-  test('test the polymer 2.x application template', () => {
-    let dir;
-    return runGenerator(createApplicationGenerator('polymer-2.x'))
-      .withPrompts({ name: 'my-app' }) // Mock the prompt answers
-      .toPromise()
-      .then((_dir) => { dir = _dir })
-      .then(() => runCommand(binPath, ['install'], { cwd: dir }))
-      // .then(() => runCommand(binPath, ['lint'], {cwd: dir}))
-      // .then(() => runCommand(binPath, ['test'], {cwd: dir}))
-      .then(() => runCommand(binPath, ['build'], {cwd: dir}));
-  });
+    // TODO(#562): enable test commands.
+    // TODO(rictic): run linter once new linter lands.
+    test('test the polymer 1.x application template', () => {
+      let dir;
+      return runGenerator(createApplicationGenerator('polymer-1.x'))
+        .withPrompts({ name: 'my-app' }) // Mock the prompt answers
+        .toPromise()
+        .then((_dir) => { dir = _dir })
+        .then(() => runCommand(binPath, ['install'], {cwd: dir}))
+        // .then(() => runCommand(binPath, ['lint'], {cwd: dir}))
+        // .then(() => runCommand(binPath, ['test'], {cwd: dir}))
+        .then(() => runCommand(binPath, ['build'], {cwd: dir}));
+    });
 
-  test('test the polymer 2.x "element" template', () => {
-    let dir;
-    return runGenerator(createElementGenerator('polymer-2.x'))
-      .withPrompts({ name: 'my-element' }) // Mock the prompt answers
-      .toPromise()
-      .then((_dir) => { dir = _dir })
-      .then(() => runCommand(binPath, ['install'], { cwd: dir }))
-      // .then(() => runCommand(binPath, ['lint'], {cwd: dir}))
-      // .then(() => runCommand(binPath, ['test'], {cwd: dir}));
-  });
+    test('test the polymer 2.x application template', () => {
+      let dir;
+      return runGenerator(createApplicationGenerator('polymer-2.x'))
+        .withPrompts({ name: 'my-app' }) // Mock the prompt answers
+        .toPromise()
+        .then((_dir) => { dir = _dir })
+        .then(() => runCommand(binPath, ['install'], { cwd: dir }))
+        // .then(() => runCommand(binPath, ['lint'], {cwd: dir}))
+        // .then(() => runCommand(binPath, ['test'], {cwd: dir}))
+        .then(() => runCommand(binPath, ['build'], {cwd: dir}));
+    });
 
-  test('test the polymer 1.x "element" template', () => {
-    let dir;
-    return runGenerator(createElementGenerator('polymer-1.x'))
-      .withPrompts({ name: 'my-element' }) // Mock the prompt answers
-      .toPromise()
-      .then((_dir) => { dir = _dir })
-      .then(() => runCommand(binPath, ['install'], { cwd: dir }))
-      // TODO(rictic): reenable with new linter.
-      // .then(() => runCommand(binPath, ['lint'], {cwd: dir}))
-      // .then(() => runCommand(binPath, ['test'], {cwd: dir}));
-  });
+    test('test the polymer 2.x "element" template', () => {
+      let dir;
+      return runGenerator(createElementGenerator('polymer-2.x'))
+        .withPrompts({ name: 'my-element' }) // Mock the prompt answers
+        .toPromise()
+        .then((_dir) => { dir = _dir })
+        .then(() => runCommand(binPath, ['install'], { cwd: dir }))
+        // .then(() => runCommand(binPath, ['lint'], {cwd: dir}))
+        // .then(() => runCommand(binPath, ['test'], {cwd: dir}));
+    });
 
-  test('test the "shop" template', () => {
-    let dir;
-    return runGenerator(ShopGenerator)
-      .toPromise()
-      .then((_dir) => { dir = _dir })
-      .then(() => runCommand(binPath, ['install'], {cwd: dir}))
-      // .then(() => runCommand(binPath, ['lint'], {cwd: dir}))
-      // .then(() => runCommand(binPath, ['test'], {cwd: dir}))
-      .then(() => runCommand(binPath, ['build'], {cwd: dir}));
-  });
+    test('test the polymer 1.x "element" template', () => {
+      let dir;
+      return runGenerator(createElementGenerator('polymer-1.x'))
+        .withPrompts({ name: 'my-element' }) // Mock the prompt answers
+        .toPromise()
+        .then((_dir) => { dir = _dir })
+        .then(() => runCommand(binPath, ['install'], { cwd: dir }))
+        // TODO(rictic): reenable with new linter.
+        // .then(() => runCommand(binPath, ['lint'], {cwd: dir}))
+        // .then(() => runCommand(binPath, ['test'], {cwd: dir}));
+    });
 
-  test('test the "starter-kit" template', () => {
-    let dir;
-    return runGenerator(PSKGenerator)
-      .toPromise()
-      .then((_dir) => { dir = _dir })
-      .then(() => runCommand(binPath, ['install'], { cwd: dir }))
-      // .then(() => runCommand(binPath, ['lint'], {cwd: dir}))
-      // .then(() => runCommand(binPath, ['test'], {cwd: dir}))
-      .then(() => runCommand(binPath, ['build'], {cwd: dir}));
+    test('test the "shop" template', () => {
+      let dir;
+      const ShopGenerator = createGithubGenerator({
+        owner: 'Polymer',
+        repo: 'shop',
+        githubToken,
+      });
+
+      return runGenerator(ShopGenerator)
+        .toPromise()
+        .then((_dir) => { dir = _dir })
+        .then(() => runCommand(binPath, ['install'], {cwd: dir}))
+        // .then(() => runCommand(binPath, ['lint'], {cwd: dir}))
+        // .then(() => runCommand(binPath, ['test'], {cwd: dir}))
+        .then(() => runCommand(binPath, ['build'], {cwd: dir}));
+    });
+
+    test('test the "starter-kit" template', () => {
+      let dir;
+      const PSKGenerator = createGithubGenerator({
+        owner: 'PolymerElements',
+        repo: 'polymer-starter-kit',
+        githubToken,
+      });
+
+      return runGenerator(PSKGenerator)
+        .toPromise()
+        .then((_dir) => { dir = _dir })
+        .then(() => runCommand(binPath, ['install'], { cwd: dir }))
+        // .then(() => runCommand(binPath, ['lint'], {cwd: dir}))
+        // .then(() => runCommand(binPath, ['test'], {cwd: dir}))
+        .then(() => runCommand(binPath, ['build'], {cwd: dir}));
+    });
+
   });
 
 });


### PR DESCRIPTION
This PR nests the current integration tests in an "init templates" test suite, and adds a new suite for  testing the templates in the `tools-starter-projects`.  It builds on top of @rictic's work in the `integration-tests` branch.

As a code comment mentions, there are two things needed before we can unskip these tests:
- [ ] Make the tools-sample-projects repo public so that travis can test against it
- [ ] Create a new release once the add-projects branch/pr is merged into master

/cc @justinfagnani @rictic 