### PR TITLE
unskip integration tests

### DIFF
--- a/test/integration/integration_test.js
+++ b/test/integration/integration_test.js
@@ -121,10 +121,7 @@ suite('integration tests', function() {
 
   });
 
-  // TODO(fks): Two things are needed to unskip these tests:
-  //   1. Make the tools-sample-projects repo public
-  //   2. Create a new release when the add-projects branch/pr is merged
-  suite.skip('tools-sample-projects templates', () => {
+  suite('tools-sample-projects templates', () => {
 
     let tspDir;
 


### PR DESCRIPTION
Now that tools-sample-projects is public we can connect them to the CLI tests.

/cc @rictic 