### PR TITLE
skip optimizing for any web-component polyfills

### DIFF
--- a/src/build/optimize-streams.ts
+++ b/src/build/optimize-streams.ts
@@ -66,6 +66,16 @@ export class GenericOptimizeTransform extends Transform {
   }
 
   _transform(file: File, _encoding: string, callback: FileCB): void {
+    // TODO(fks) 03-07-2017: This is a quick fix to make sure that
+    // "webcomponentsjs" files aren't compiled down to ES5, because they contain
+    // an important ES6 shim to make custom elements possible. Remove/refactor
+    // when we have a better plan for excluding some files from optimization.
+    if (!file.path || file.path.indexOf('webcomponentsjs/') >= 0 ||
+        file.path.indexOf('webcomponentsjs\\') >= 0) {
+      callback(null, file);
+      return;
+    }
+
     if (file.contents) {
       try {
         let contents = file.contents.toString();

--- a/test/unit/build/optimize_test.js
+++ b/test/unit/build/optimize_test.js
@@ -42,6 +42,43 @@ suite('optimize-streams', () => {
     });
   });
 
+  test('does not compile webcomponents.js files (windows)', (done) => {
+    const es6Contents = `const apple = 'apple';`;
+    const sourceStream = vfs.src([
+      {
+        path: 'A:\\project\\bower_components\\webcomponentsjs\\webcomponents-es5-loader.js',
+        contents: es6Contents,
+      },
+    ]);
+    const op = pipeStreams([sourceStream, getOptimizeStreams({js: {compile: true}})]);
+    testStream(op, (error, f) => {
+      if (error) {
+        return done(error);
+      }
+      assert.equal(f.contents.toString(), es6Contents);
+      done();
+    });
+  });
+
+  test('does not compile webcomponents.js files (unix)', (done) => {
+    const es6Contents = `const apple = 'apple';`;
+    const sourceStream = vfs.src([
+      {
+        path: '/project/bower_components/webcomponentsjs/webcomponents-es5-loader.js',
+        contents: es6Contents,
+      },
+    ]);
+    const op = pipeStreams([sourceStream, getOptimizeStreams({js: {compile: true}})]);
+    testStream(op, (error, f) => {
+      if (error) {
+        return done(error);
+      }
+      assert.equal(f.contents.toString(), es6Contents);
+      done();
+    });
+  });
+
+
   test('minify js', (done) => {
     const sourceStream = vfs.src([
       {


### PR DESCRIPTION
This is a quick fix so that we aren't blocking 2.0 release. After release, we should better address this (ex: as an option for the user to specify).
