### PR TITLE
update webcomponentsjs polyfill to use the new custom-elements-es5-adapter

### DIFF
--- a/src/build/rewrite-webcomponents-loader.ts
+++ b/src/build/rewrite-webcomponents-loader.ts
@@ -59,9 +59,12 @@ export class UseES5WebcomponentsLoader extends stream.Transform {
       callback(null, file);
       return;
     }
+
     const scriptPath = dom5.getAttribute(script, 'src')!;
-    const es5Url = url.resolve(scriptPath, 'webcomponents-es5-loader.js');
-    dom5.setAttribute(script, 'src', es5Url);
+    const scriptUrl = url.resolve(scriptPath, 'custom-elements-es5-adapter.js');
+    const es5AdapterScript = parse5.parseFragment(`<script src="${scriptUrl}"></script>`);
+    dom5.insertBefore(script.parentNode!, script, es5AdapterScript);
+
     const correctedFile = file.clone();
     correctedFile.contents = new Buffer(parse5.serialize(parsed), 'utf-8');
     callback(null, correctedFile);


### PR DESCRIPTION
- Fixes #605
- Old version of `webcomponentsjs` polyfills required the `webcomponents-es5-loader` when using compiled JS
- New version (release imminent) requires a separate polyfill before the loader, and now all scenarios use the default `webcomponents-loader`
- This PR changes the CLI from the old system to the new system
- Release will be coordinated with @azakus 