### PR TITLE
Update WCT for Polymer 1.x templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - `init`: Init template elements now properly inherit from the given element/app name.
 - `init`: For `polymer-2-element` template, remove iron-component-page from the served `index.html` file until it can support Polymer 2.0 class-based elements.
 - `init`: Updates polymer 2.0 application & element tests to improve and fix broken tests
+- `init`: Updates polymer 1.x application & element template WCT dependency to 6.0.0-prerelease.5.
 
 ## v0.18.0-pre.15 [03-22-2017]
 

--- a/src/init/application/templates/polymer-1.x/bower.json
+++ b/src/init/application/templates/polymer-1.x/bower.json
@@ -9,7 +9,7 @@
   "devDependencies": {
     "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",
     "iron-demo-helpers": "PolymerElements/iron-demo-helpers#^1.0.0",
-    "web-component-tester": "^4.0.0",
+    "web-component-tester": "Polymer/web-component-tester#^6.0.0-prerelease.5",
     "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0"
   }
 }

--- a/src/init/element/templates/polymer-1.x/bower.json
+++ b/src/init/element/templates/polymer-1.x/bower.json
@@ -9,7 +9,7 @@
   "devDependencies": {
     "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",
     "iron-demo-helpers": "PolymerElements/iron-demo-helpers#^1.0.0",
-    "web-component-tester": "^4.0.0",
+    "web-component-tester": "Polymer/web-component-tester#^6.0.0-prerelease.5",
     "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0"
   }
 }


### PR DESCRIPTION
<!--
  Thanks for the PR!

  If this change has a user visible change (including
  bug fixes, new features, etc) please describe the change in
  CHANGELOG.md.

  If the change is an entirely package-internal reshuffling/refactoring
  should the change not be described in the CHANGELOG.

  Consider also updating the README.

  More info: http://keepachangelog.com/en/0.3.0/
 -->

 - [x] CHANGELOG.md has been updated


Updating the Polymer 1.x application and element templates to latest released version of WCT. Seems odd that cli and 2.0 were updated a while back but the element templates haven't.

Wasn't sure if we wanted to update them to the pre-release WCT 6 or not.
