### PR TITLE
Allow using .babelrc configuration files

### DIFF
--- a/src/build/optimize-streams.ts
+++ b/src/build/optimize-streams.ts
@@ -18,7 +18,7 @@ import * as gulpif from 'gulp-if';
 import {minify as htmlMinify, Options as HTMLMinifierOptions} from 'html-minifier';
 import * as logging from 'plylog';
 import {Transform} from 'stream';
-import {accessSync, readFileSync} from 'fs';
+import * as fs from 'fs';
 
 const babelPresetES2015 = require('babel-preset-es2015');
 const babiliPreset = require('babel-preset-babili');
@@ -124,16 +124,12 @@ export class JSDefaultCompileTransform extends JSBabelTransform {
  */
 export class JSDefaultMinifyTransform extends JSBabelTransform {
   constructor() {
-    if (!accessSync('.babelrc')) {
-      try {
-        let options = JSON.parse(String(readFileSync('.babelrc')));
-        logger.info('Using .babelrc configuration');
-        super(options);
-      } catch (err) {
-        logger.error('Error loading .babelrc configuration: ' + (err.message || ''));
-        super({presets: [babiliPreset]});
-      }
-    } else {
+    try {
+      let options = JSON.parse(String(fs.readFileSync('.babelrc')));
+      logger.info('Using .babelrc configuration');
+      super(options);
+    } catch (err) {
+      logger.warn('Error loading .babelrc configuration: ' + (err.message || ''));
       super({presets: [babiliPreset]});
     }
   }

--- a/src/build/optimize-streams.ts
+++ b/src/build/optimize-streams.ts
@@ -18,7 +18,7 @@ import * as gulpif from 'gulp-if';
 import {minify as htmlMinify, Options as HTMLMinifierOptions} from 'html-minifier';
 import * as logging from 'plylog';
 import {Transform} from 'stream';
-
+import {accessSync, readFileSync} from 'fs';
 
 const babelPresetES2015 = require('babel-preset-es2015');
 const babiliPreset = require('babel-preset-babili');
@@ -124,7 +124,19 @@ export class JSDefaultCompileTransform extends JSBabelTransform {
  */
 export class JSDefaultMinifyTransform extends JSBabelTransform {
   constructor() {
-    super({presets: [babiliPreset]});
+    if(!accessSync('.babelrc')){
+      try{
+        var options = JSON.parse(String(readFileSync('.babelrc')));
+        logger.info('Using .babelrc configuration');
+        super(options);
+      }
+      catch(err){
+        logger.error('Error loading .babelrc configuration: '+(err.message || ''));
+        super({presets: [babiliPreset]});
+      }
+    } else {
+      super({presets: [babiliPreset]});
+    }
   }
 }
 

--- a/src/build/optimize-streams.ts
+++ b/src/build/optimize-streams.ts
@@ -124,13 +124,12 @@ export class JSDefaultCompileTransform extends JSBabelTransform {
  */
 export class JSDefaultMinifyTransform extends JSBabelTransform {
   constructor() {
-    if(!accessSync('.babelrc')){
-      try{
-        var options = JSON.parse(String(readFileSync('.babelrc')));
+    if (!accessSync('.babelrc')) {
+      try {
+        let options = JSON.parse(String(readFileSync('.babelrc')));
         logger.info('Using .babelrc configuration');
         super(options);
-      }
-      catch(err){
+      } catch(err) {
         logger.error('Error loading .babelrc configuration: '+(err.message || ''));
         super({presets: [babiliPreset]});
       }

--- a/src/build/optimize-streams.ts
+++ b/src/build/optimize-streams.ts
@@ -129,8 +129,8 @@ export class JSDefaultMinifyTransform extends JSBabelTransform {
         let options = JSON.parse(String(readFileSync('.babelrc')));
         logger.info('Using .babelrc configuration');
         super(options);
-      } catch(err) {
-        logger.error('Error loading .babelrc configuration: '+(err.message || ''));
+      } catch (err) {
+        logger.error('Error loading .babelrc configuration: ' + (err.message || ''));
         super({presets: [babiliPreset]});
       }
     } else {


### PR DESCRIPTION
Allow using a `.babelrc` configuration file found in the current build directory as option for the `JSBabelTransform` class.
The file should be a valid JSON object, e.g.:

    { 
      "presets": [
        [
          "babili", 
          {
            "replace": {
              "replacements": [
                  {
                    "identifierName": "__DEBUG__",
                    "replacement": {
                      "type": "booleanLiteral",
                      "value": false
                    }
                  }
              ]
            }
        }]
      ] 
    }

<!--
  Thanks for the PR!

  If this change has a user visible change (including
  bug fixes, new features, etc) please describe the change in
  CHANGELOG.md.

  If the change is an entirely package-internal reshuffling/refactoring
  should the change not be described in the CHANGELOG.

  Consider also updating the README.

  More info: http://keepachangelog.com/en/0.3.0/
 -->

 - [ ] CHANGELOG.md has been updated
