### PR TITLE
More clang-format.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,11 +1,12 @@
 /**
  * @license
  * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
- * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt The complete set of authors may be found
+ * at http://polymer.github.io/AUTHORS.txt The complete set of contributors may
+ * be found at http://polymer.github.io/CONTRIBUTORS.txt Code distributed by
+ * Google as part of the polymer project is also subject to an additional IP
+ * rights grant found at http://polymer.github.io/PATENTS.txt
  */
 
 'use strict';
@@ -18,7 +19,7 @@ const mergeStream = require('merge-stream');
 const mocha = require('gulp-spawn-mocha');
 const path = require('path');
 const runSeq = require('run-sequence');
-const tslint = require("gulp-tslint");
+const tslint = require('gulp-tslint');
 const typescript = require('gulp-typescript');
 
 const tsProject = typescript.createProject('tsconfig.json');
@@ -32,50 +33,54 @@ gulp.task('clean', (done) => {
 gulp.task('build', ['clean'], () => {
   let tsReporter = typescript.reporter.defaultReporter();
   return mergeStream(
-      tsProject.src().pipe(tsProject(tsReporter)),
-      gulp.src(['src/**/*', '!src/**/*.ts'])
-    ).pipe(gulp.dest('lib'));
+             tsProject.src().pipe(tsProject(tsReporter)),
+             gulp.src(['src/**/*', '!src/**/*.ts']))
+      .pipe(gulp.dest('lib'));
 });
 
-gulp.task('test', ['build'], () =>
-  gulp.src('test/unit/**/*_test.js', {read: false})
-      .pipe(mocha({
-        ui: 'tdd',
-        reporter: 'spec',
-      }))
-);
+gulp.task(
+    'test',
+    ['build'],
+    () => gulp.src('test/unit/**/*_test.js', {read: false}).pipe(mocha({
+      ui: 'tdd',
+      reporter: 'spec',
+    })));
 
-gulp.task('test:integration', ['build'], () =>
-  gulp.src(['test/integration/**/*_test.js'], {read: false})
-      .pipe(mocha({
-        ui: 'tdd',
-        reporter: 'spec',
-      }))
-);
+gulp.task(
+    'test:integration',
+    ['build'],
+    () =>
+        gulp.src(['test/integration/**/*_test.js'], {read: false}).pipe(mocha({
+          ui: 'tdd',
+          reporter: 'spec',
+        })));
 
 
-gulp.task('tslint', () =>
-  gulp.src('src/**/*.ts')
-    .pipe(tslint({
-      configuration: 'tslint.json',
-      formatter: 'verbose',
-    }))
-    .pipe(tslint.report()));
+gulp.task(
+    'tslint',
+    () => gulp.src('src/**/*.ts')
+              .pipe(tslint({
+                configuration: 'tslint.json',
+                formatter: 'verbose',
+              }))
+              .pipe(tslint.report()));
 
-gulp.task('eslint', () =>
-  gulp.src('test/**/*_test.js')
-    .pipe(eslint())
-    .pipe(eslint.format())
-    .pipe(eslint.failAfterError()));
+gulp.task(
+    'eslint',
+    () => gulp.src('test/**/*_test.js')
+              .pipe(eslint())
+              .pipe(eslint.format())
+              .pipe(eslint.failAfterError()));
 
-gulp.task('depcheck', () =>
-  depcheck(__dirname, {
-      // "@types/*" dependencies are type declarations that are automatically
-      // loaded by TypeScript during build. depcheck can't detect this
-      // so we ignore them here.
-      ignoreMatches: ['@types/*', 'vinyl']
-    })
-    .then((result) => {
+gulp.task(
+    'depcheck',
+    () => depcheck(__dirname, {
+            // "@types/*" dependencies are type declarations that are
+            // automatically
+            // loaded by TypeScript during build. depcheck can't detect this
+            // so we ignore them here.
+            ignoreMatches: ['@types/*', 'vinyl']
+          }).then((result) => {
       let invalidFiles = Object.keys(result.invalidFiles) || [];
       let invalidJsFiles = invalidFiles.filter((f) => f.endsWith('.js'));
       if (invalidJsFiles.length > 0) {
@@ -84,4 +89,4 @@ gulp.task('depcheck', () =>
       if (result.dependencies.length) {
         throw new Error(`Unused dependencies: ${result.dependencies}`);
       }
-  }));
+    }));

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "build": "gulp build",
     "test": "gulp lint test && gulp test:integration",
     "test:smoke": "gulp test",
-    "format": "find src test | grep '\\.js$\\|\\.ts$' | xargs clang-format --style=file -i"
+    "format": "find src test gulpfile.js \\( -iname '*.ts' -o -iname '*.js' \\) -not -path '*fixtures*' | xargs clang-format --style=file -i"
   },
   "repository": {
     "type": "git",

--- a/src/build/rewrite-webcomponents-loader.ts
+++ b/src/build/rewrite-webcomponents-loader.ts
@@ -62,7 +62,8 @@ export class UseES5WebcomponentsLoader extends stream.Transform {
 
     const scriptPath = dom5.getAttribute(script, 'src')!;
     const scriptUrl = url.resolve(scriptPath, 'custom-elements-es5-adapter.js');
-    const es5AdapterScript = parse5.parseFragment(`<script src="${scriptUrl}"></script>`);
+    const es5AdapterScript =
+        parse5.parseFragment(`<script src="${scriptUrl}"></script>`);
     dom5.insertBefore(script.parentNode!, script, es5AdapterScript);
 
     const correctedFile = file.clone();

--- a/src/commands/lint.ts
+++ b/src/commands/lint.ts
@@ -83,8 +83,9 @@ export class LintCommand implements Command {
     this._loadPlugins(config);
     let collectionsDocs = [];
     for (const collection of lintLib.registry.allRuleCollections) {
-      collectionsDocs.push(`  ${chalk.bold(collection.code)}: ${this._indent(
-          collection.description)}`);
+      collectionsDocs.push(`  ${
+                                chalk.bold(collection.code)
+                              }: ${this._indent(collection.description)}`);
     }
     let rulesDocs = [];
     for (const rule of lintLib.registry.allRules) {

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -91,9 +91,9 @@ export class ServeCommand implements Command {
     if (serverInfos.kind === 'mainline') {
       const mainlineServer = serverInfos;
       const urls = getServerUrls(options, mainlineServer.server);
-      logger.info(`Files in this directory are available under the following URLs
-      applications: ${
-                    url.format(urls.serverUrl)}
+      logger.info(
+          `Files in this directory are available under the following URLs
+      applications: ${url.format(urls.serverUrl)}
       reusable components: ${url.format(urls.componentUrl)}
     `);
     } else {

--- a/src/github/github.ts
+++ b/src/github/github.ts
@@ -155,8 +155,10 @@ export class Github {
     const maxSatisfyingRelease =
         releases.find((r) => r.tag_name === maxSatisfyingReleaseVersion);
     if (!maxSatisfyingRelease) {
-      throw new Error(`${this._owner}/${this._repo
-                      } has no releases matching ${semverRange}.`);
+      throw new Error(
+          `${this._owner}/${this._repo} has no releases matching ${
+                                                                   semverRange
+                                                                 }.`);
     }
     return maxSatisfyingRelease;
   }

--- a/test/integration/install-variants_test.js
+++ b/test/integration/install-variants_test.js
@@ -1,10 +1,11 @@
 /*
  * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
- * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt The complete set of authors may be found
+ * at http://polymer.github.io/AUTHORS.txt The complete set of contributors may
+ * be found at http://polymer.github.io/CONTRIBUTORS.txt Code distributed by
+ * Google as part of the polymer project is also subject to an additional IP
+ * rights grant found at http://polymer.github.io/PATENTS.txt
  */
 
 'use strict';
@@ -33,19 +34,26 @@ suite('install-variants', function() {
         }
 
         const env = envExcludingBowerVars();
-        runCommand(binPath, ['install', '--variants', '--offline'], { cwd: tmpPath, env }).then(() => {
-          const mainDir = path.join(tmpPath, 'bower_components');
-          assert.isTrue(fs.statSync(mainDir).isDirectory());
+        runCommand(
+            binPath,
+            ['install', '--variants', '--offline'],
+            {cwd: tmpPath, env})
+            .then(() => {
+              const mainDir = path.join(tmpPath, 'bower_components');
+              assert.isTrue(fs.statSync(mainDir).isDirectory());
 
-          const variant1Dir = path.join(tmpPath, 'bower_components-variant-1');
-          assert.isTrue(fs.statSync(variant1Dir).isDirectory());
+              const variant1Dir =
+                  path.join(tmpPath, 'bower_components-variant-1');
+              assert.isTrue(fs.statSync(variant1Dir).isDirectory());
 
-          const variant2Dir = path.join(tmpPath, 'bower_components-variant-1');
-          assert.isTrue(fs.statSync(variant2Dir).isDirectory());
-          done();
-        }).catch((e) => {
-          done(e);
-        });
+              const variant2Dir =
+                  path.join(tmpPath, 'bower_components-variant-1');
+              assert.isTrue(fs.statSync(variant2Dir).isDirectory());
+              done();
+            })
+            .catch((e) => {
+              done(e);
+            });
       });
     });
   });

--- a/test/integration/integration_test.js
+++ b/test/integration/integration_test.js
@@ -1,25 +1,27 @@
 /*
  * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
- * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt The complete set of authors may be found
+ * at http://polymer.github.io/AUTHORS.txt The complete set of contributors may
+ * be found at http://polymer.github.io/CONTRIBUTORS.txt Code distributed by
+ * Google as part of the polymer project is also subject to an additional IP
+ * rights grant found at http://polymer.github.io/PATENTS.txt
  */
 
 'use strict';
 
 const path = require('path');
 const runGenerator = require('yeoman-test').run;
-const createGithubGenerator
-  = require('../../lib/init/github').createGithubGenerator;
+const createGithubGenerator =
+    require('../../lib/init/github').createGithubGenerator;
 const runCommand = require('./run-command').runCommand;
 
 // Template Generators
-const createApplicationGenerator
-  = require('../../lib/init/application/application').createApplicationGenerator;
-const createElementGenerator
-  = require('../../lib/init/element/element').createElementGenerator;
+const createApplicationGenerator =
+    require('../../lib/init/application/application')
+        .createApplicationGenerator;
+const createElementGenerator =
+    require('../../lib/init/element/element').createElementGenerator;
 
 // A zero priveledge github token of a nonce account, used for quota.
 const githubToken = '8d8622bf09bb1d85cb411b5e475a35e742a7ce35';
@@ -38,67 +40,66 @@ suite('integration tests', function() {
     test('test the Polymer 1.x application template', () => {
       let dir;
       return runGenerator(createApplicationGenerator('polymer-1.x'))
-        .withPrompts({ name: 'my-app' }) // Mock the prompt answers
-        .toPromise()
-        .then((_dir) => { dir = _dir })
-        .then(() => runCommand(binPath, ['install'], {cwd: dir}))
-        .then(() => runCommand(binPath, ['lint'], {cwd: dir}))
-        // .then(() => runCommand(binPath, ['test'], {cwd: dir}))
-        .then(() => runCommand(binPath, ['build'], {cwd: dir}));
+          .withPrompts({name: 'my-app'})  // Mock the prompt answers
+          .toPromise()
+          .then((_dir) => {dir = _dir})
+          .then(() => runCommand(binPath, ['install'], {cwd: dir}))
+          .then(() => runCommand(binPath, ['lint'], {cwd: dir}))
+          // .then(() => runCommand(binPath, ['test'], {cwd: dir}))
+          .then(() => runCommand(binPath, ['build'], {cwd: dir}));
     });
 
     test('test the Polymer 2.x application template', () => {
       let dir;
       return runGenerator(createApplicationGenerator('polymer-2.x'))
-        .withPrompts({ name: 'my-app' }) // Mock the prompt answers
-        .toPromise()
-        .then((_dir) => { dir = _dir })
-        .then(() => runCommand(binPath, ['install'], { cwd: dir }))
-        .then(() => runCommand(binPath, ['lint'], {cwd: dir}))
-        // .then(() => runCommand(binPath, ['test'], {cwd: dir}))
-        .then(() => runCommand(binPath, ['build'], {cwd: dir}));
+          .withPrompts({name: 'my-app'})  // Mock the prompt answers
+          .toPromise()
+          .then((_dir) => {dir = _dir})
+          .then(() => runCommand(binPath, ['install'], {cwd: dir}))
+          .then(() => runCommand(binPath, ['lint'], {cwd: dir}))
+          // .then(() => runCommand(binPath, ['test'], {cwd: dir}))
+          .then(() => runCommand(binPath, ['build'], {cwd: dir}));
     });
 
     test('test the Polymer 2.x "element" template', () => {
       let dir;
       return runGenerator(createElementGenerator('polymer-2.x'))
-        .withPrompts({ name: 'my-element' }) // Mock the prompt answers
-        .toPromise()
-        .then((_dir) => { dir = _dir })
-        .then(() => runCommand(binPath, ['install'], { cwd: dir }))
-        .then(() => runCommand(binPath, ['lint'], {cwd: dir}))
-        // .then(() => runCommand(binPath, ['test'], {cwd: dir}));
+          .withPrompts({name: 'my-element'})  // Mock the prompt answers
+          .toPromise()
+          .then((_dir) => {dir = _dir})
+          .then(() => runCommand(binPath, ['install'], {cwd: dir}))
+          .then(() => runCommand(binPath, ['lint'], {cwd: dir}))
+      // .then(() => runCommand(binPath, ['test'], {cwd: dir}));
     });
 
     test('test the Polymer 1.x "element" template', () => {
       let dir;
       return runGenerator(createElementGenerator('polymer-1.x'))
-        .withPrompts({ name: 'my-element' }) // Mock the prompt answers
-        .toPromise()
-        .then((_dir) => { dir = _dir })
-        .then(() => runCommand(binPath, ['install'], { cwd: dir }))
-        .then(() => runCommand(binPath, ['lint'], {cwd: dir}))
-        // .then(() => runCommand(binPath, ['test'], {cwd: dir}));
+          .withPrompts({name: 'my-element'})  // Mock the prompt answers
+          .toPromise()
+          .then((_dir) => {dir = _dir})
+          .then(() => runCommand(binPath, ['install'], {cwd: dir}))
+          .then(() => runCommand(binPath, ['lint'], {cwd: dir}))
+      // .then(() => runCommand(binPath, ['test'], {cwd: dir}));
     });
 
     test('test the "shop" template', () => {
       let dir;
       const ShopGenerator = createGithubGenerator({
         owner: 'Polymer',
-        repo: 'shop',
-        githubToken,
+        repo: 'shop', githubToken,
       });
 
       return runGenerator(ShopGenerator)
-        .toPromise()
-        .then((_dir) => { dir = _dir })
-        .then(() => runCommand(binPath, ['install'], { cwd: dir }))
-        // See: https://github.com/Polymer/shop/pull/114
-        // .then(() => runCommand(
-        //   binPath, ['lint', '--rules=polymer-2-hybrid'],
-        //   {cwd: dir}))
-        // .then(() => runCommand(binPath, ['test'], {cwd: dir}))
-        .then(() => runCommand(binPath, ['build'], {cwd: dir}));
+          .toPromise()
+          .then((_dir) => {dir = _dir})
+          .then(() => runCommand(binPath, ['install'], {cwd: dir}))
+          // See: https://github.com/Polymer/shop/pull/114
+          // .then(() => runCommand(
+          //   binPath, ['lint', '--rules=polymer-2-hybrid'],
+          //   {cwd: dir}))
+          // .then(() => runCommand(binPath, ['test'], {cwd: dir}))
+          .then(() => runCommand(binPath, ['build'], {cwd: dir}));
     });
 
     // TODO(justinfagnani): consider removing these integration tests
@@ -109,19 +110,18 @@ suite('integration tests', function() {
       const PSKGenerator = createGithubGenerator({
         owner: 'PolymerElements',
         repo: 'polymer-starter-kit',
-        semverRange: '^2.0.0',
-        githubToken,
+        semverRange: '^2.0.0', githubToken,
       });
 
       return runGenerator(PSKGenerator)
-        .toPromise()
-        .then((_dir) => { dir = _dir })
-        .then(() => runCommand(binPath, ['install'], { cwd: dir }))
-        .then(() => runCommand(
-            binPath, ['lint', '--rules=polymer-2-hybrid'],
-            { cwd: dir }))
-        // .then(() => runCommand(binPath, ['test'], {cwd: dir}))
-        .then(() => runCommand(binPath, ['build'], {cwd: dir}));
+          .toPromise()
+          .then((_dir) => {dir = _dir})
+          .then(() => runCommand(binPath, ['install'], {cwd: dir}))
+          .then(
+              () => runCommand(
+                  binPath, ['lint', '--rules=polymer-2-hybrid'], {cwd: dir}))
+          // .then(() => runCommand(binPath, ['test'], {cwd: dir}))
+          .then(() => runCommand(binPath, ['build'], {cwd: dir}));
     });
 
     // TODO(justinfagnani): consider removing these integration tests
@@ -132,19 +132,18 @@ suite('integration tests', function() {
       const PSKGenerator = createGithubGenerator({
         owner: 'PolymerElements',
         repo: 'polymer-starter-kit',
-        semverRange: '^3.0.0',
-        githubToken,
+        semverRange: '^3.0.0', githubToken,
       });
 
       return runGenerator(PSKGenerator)
-        .toPromise()
-        .then((_dir) => { dir = _dir })
-        .then(() => runCommand(binPath, ['install'], { cwd: dir }))
-        .then(() => runCommand(
-            binPath, ['lint', '--rules=polymer-2'],
-            { cwd: dir }))
-        // .then(() => runCommand(binPath, ['test'], {cwd: dir}))
-        .then(() => runCommand(binPath, ['build'], {cwd: dir}));
+          .toPromise()
+          .then((_dir) => {dir = _dir})
+          .then(() => runCommand(binPath, ['install'], {cwd: dir}))
+          .then(
+              () => runCommand(
+                  binPath, ['lint', '--rules=polymer-2'], {cwd: dir}))
+          // .then(() => runCommand(binPath, ['test'], {cwd: dir}))
+          .then(() => runCommand(binPath, ['build'], {cwd: dir}));
     });
 
 
@@ -160,31 +159,30 @@ suite('integration tests', function() {
     suiteSetup(() => {
       const TSPGenerator = createGithubGenerator({
         owner: 'Polymer',
-        repo: 'tools-sample-projects',
-        githubToken,
+        repo: 'tools-sample-projects', githubToken,
       });
 
       return runGenerator(TSPGenerator)
-        .toPromise()
-        .then((dir) => { tspDir = dir });
+          .toPromise()
+          .then((dir) => {tspDir = dir});
     });
 
     test('test the "polymer-1-app" template', () => {
       const dir = path.join(tspDir, 'polymer-1-app');
 
       return runCommand(binPath, ['install'], {cwd: dir})
-        .then(() => runCommand(binPath, ['lint'], {cwd: dir}))
-        // .then(() => runCommand(binPath, ['test'], {cwd: dir}))
-        .then(() => runCommand(binPath, ['build'], {cwd: dir}));
+          .then(() => runCommand(binPath, ['lint'], {cwd: dir}))
+          // .then(() => runCommand(binPath, ['test'], {cwd: dir}))
+          .then(() => runCommand(binPath, ['build'], {cwd: dir}));
     });
 
     test('test the "polymer-2-app" template', () => {
       const dir = path.join(tspDir, 'polymer-2-app');
 
       return runCommand(binPath, ['install'], {cwd: dir})
-        .then(() => runCommand(binPath, ['lint'], {cwd: dir}))
-        // .then(() => runCommand(binPath, ['test'], {cwd: dir}))
-        .then(() => runCommand(binPath, ['build'], {cwd: dir}));
+          .then(() => runCommand(binPath, ['lint'], {cwd: dir}))
+          // .then(() => runCommand(binPath, ['test'], {cwd: dir}))
+          .then(() => runCommand(binPath, ['build'], {cwd: dir}));
     });
 
   });

--- a/test/integration/lint_test.js
+++ b/test/integration/lint_test.js
@@ -1,10 +1,11 @@
 /*
  * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
- * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt The complete set of authors may be found
+ * at http://polymer.github.io/AUTHORS.txt The complete set of contributors may
+ * be found at http://polymer.github.io/CONTRIBUTORS.txt Code distributed by
+ * Google as part of the polymer project is also subject to an additional IP
+ * rights grant found at http://polymer.github.io/PATENTS.txt
  */
 
 'use strict';
@@ -36,8 +37,7 @@ suite('polymer lint', function() {
 
   test('fails when rules are not specified', () => {
     const cwd = path.join(fixturePath, 'lint-no-polymer-json');
-    const result = runCommand(
-        binPath, ['lint'], { cwd, failureExpected: true });
+    const result = runCommand(binPath, ['lint'], {cwd, failureExpected: true});
     return invertPromise(result);
   });
 

--- a/test/integration/run-command.js
+++ b/test/integration/run-command.js
@@ -1,10 +1,11 @@
 /*
  * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
- * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt The complete set of authors may be found
+ * at http://polymer.github.io/AUTHORS.txt The complete set of contributors may
+ * be found at http://polymer.github.io/CONTRIBUTORS.txt Code distributed by
+ * Google as part of the polymer project is also subject to an additional IP
+ * rights grant found at http://polymer.github.io/PATENTS.txt
  */
 
 'use strict';
@@ -22,41 +23,53 @@ const childProcess = require('child_process');
 function runCommand(path, args, options) {
   let contents;
   return new Promise((resolve, reject) => {
-    let commandError;
-    options.silent = true;
-    const forkedProcess = childProcess.fork(path, args, options);
-    contents = pipesToString(forkedProcess.stdout, forkedProcess.stderr);
+           let commandError;
+           options.silent = true;
+           const forkedProcess = childProcess.fork(path, args, options);
+           contents = pipesToString(forkedProcess.stdout, forkedProcess.stderr);
 
-    // listen for errors as they may prevent the exit event from firing
-    forkedProcess.on('error', (error) => { commandError = error });
-    // execute the callback once the forkedProcess has finished running
-    forkedProcess.on('exit', (code) => {
-      if (commandError) {
-        reject(commandError);
-        return;
-      }
-      if (code !== 0) {
-        reject(new Error(
-          `Error running ${path} with args ${args}. Got exit code: ${code}`));
-        return;
-      }
-      resolve(contents);
-    });
-  }).catch((err) => {
-    // If the command was successful there's no need to print anything to the
-    // console, but if it failed then its output is probably helpful.
-    // Print out the output, then reject the final result with the original
-    // error.
-    return contents.then((out) => {
-      if (!options.failureExpected) {
-        console.log(`Output of failed command 'node ${path} ${args.join(' ')}' in directory ${options.cwd}`);
-        console.log(out);
-        throw err;
-      } else {
-        throw out;
-      }
-    });
-  });
+           // listen for errors as they may prevent the exit event from firing
+           forkedProcess.on('error', (error) => {commandError = error});
+           // execute the callback once the forkedProcess has finished running
+           forkedProcess.on('exit', (code) => {
+             if (commandError) {
+               reject(commandError);
+               return;
+             }
+             if (code !== 0) {
+               reject(new Error(
+                   `Error running ${path} with args ${
+                                                      args
+                                                    }. Got exit code: ${
+                                                                        code
+                                                                      }`));
+               return;
+             }
+             resolve(contents);
+           });
+         })
+      .catch((err) => {
+        // If the command was successful there's no need to print anything to
+        // the console, but if it failed then its output is probably helpful.
+        // Print out the output, then reject the final result with the original
+        // error.
+        return contents.then((out) => {
+          if (!options.failureExpected) {
+            console.log(
+                `Output of failed command 'node ${
+                                                  path
+                                                } ${
+                                                    args.join(' ')
+                                                  }' in directory ${
+                                                                    options.cwd
+                                                                  }`);
+            console.log(out);
+            throw err;
+          } else {
+            throw out;
+          }
+        });
+      });
 }
 
 /**

--- a/test/unit/args_test.js
+++ b/test/unit/args_test.js
@@ -1,11 +1,12 @@
 /**
  * @license
  * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
- * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt The complete set of authors may be found
+ * at http://polymer.github.io/AUTHORS.txt The complete set of contributors may
+ * be found at http://polymer.github.io/CONTRIBUTORS.txt Code distributed by
+ * Google as part of the polymer project is also subject to an additional IP
+ * rights grant found at http://polymer.github.io/PATENTS.txt
  */
 'use strict';
 
@@ -19,31 +20,34 @@ suite('args', () => {
   suite('mergeArguments', () => {
 
     test('merges argument lists', () => {
-      const merged = argsLib.mergeArguments([[
-        {
-          name: 'one',
-          description: 'description one',
-          group: 'group one',
-        },
-        {
-          name: 'two',
-          type: String,
-          description: 'description two',
-          group: 'group two',
-        },
-      ],[
-        {
-          name: 'two',
-          description: 'description two modified',
-          group: 'group two',
-          multiple: true,
-        },
-        {
-          name: 'three',
-          description: 'description three',
-          group: 'group three',
-        },
-      ]]);
+      const merged = argsLib.mergeArguments([
+        [
+          {
+            name: 'one',
+            description: 'description one',
+            group: 'group one',
+          },
+          {
+            name: 'two',
+            type: String,
+            description: 'description two',
+            group: 'group two',
+          },
+        ],
+        [
+          {
+            name: 'two',
+            description: 'description two modified',
+            group: 'group two',
+            multiple: true,
+          },
+          {
+            name: 'three',
+            description: 'description three',
+            group: 'group three',
+          },
+        ],
+      ]);
       assert.deepEqual(merged, [
         {
           name: 'one',
@@ -80,8 +84,10 @@ suite('args', () => {
         for (const arg of command.args) {
           const name = arg.name;
           if (arg.defaultOption) {
-            assert.isNull(defaultOption, `multiple default options for ` +
-              `${command.name}: ${defaultOption} and ${name}`);
+            assert.isNull(
+                defaultOption,
+                `multiple default options for ` +
+                    `${command.name}: ${defaultOption} and ${name}`);
             defaultOption = name;
           }
           const globalArg = globals.get(name);
@@ -90,8 +96,10 @@ suite('args', () => {
               const commandValue = arg[prop];
               const globalValue = globalArg[prop];
               if (globalValue) {
-                assert.equal(globalValue, commandValue,
-                  `conflicting values for ${command.name} ${name}.${prop}`);
+                assert.equal(
+                    globalValue,
+                    commandValue,
+                    `conflicting values for ${command.name} ${name}.${prop}`);
               }
             }
           }

--- a/test/unit/build/load-config_test.js
+++ b/test/unit/build/load-config_test.js
@@ -1,11 +1,12 @@
 /**
  * @license
  * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
- * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt The complete set of authors may be found
+ * at http://polymer.github.io/AUTHORS.txt The complete set of contributors may
+ * be found at http://polymer.github.io/CONTRIBUTORS.txt Code distributed by
+ * Google as part of the polymer project is also subject to an additional IP
+ * rights grant found at http://polymer.github.io/PATENTS.txt
  */
 
 'use strict';
@@ -13,12 +14,14 @@
 const assert = require('chai').assert;
 const path = require('path');
 
-const loadServiceWorkerConfig = require('../../../lib/build/load-config').loadServiceWorkerConfig;
+const loadServiceWorkerConfig =
+    require('../../../lib/build/load-config').loadServiceWorkerConfig;
 
 suite('load-config', () => {
   suite('loadServiceWorkerConfig()', () => {
     test('should parse the given js file', (done) => {
-      const configFile = path.resolve(__dirname, '../', 'fixtures', 'service-worker-config.js');
+      const configFile = path.resolve(
+          __dirname, '../', 'fixtures', 'service-worker-config.js');
       loadServiceWorkerConfig(configFile).then((config) => {
         assert.ok(config);
         assert.deepEqual(config.staticFileGlobs, ['*']);

--- a/test/unit/build/optimize_test.js
+++ b/test/unit/build/optimize_test.js
@@ -1,26 +1,26 @@
 /**
  * @license
  * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
- * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt The complete set of authors may be found
+ * at http://polymer.github.io/AUTHORS.txt The complete set of contributors may
+ * be found at http://polymer.github.io/CONTRIBUTORS.txt Code distributed by
+ * Google as part of the polymer project is also subject to an additional IP
+ * rights grant found at http://polymer.github.io/PATENTS.txt
  */
 
 'use strict';
 
 const assert = require('chai').assert;
 const vfs = require('vinyl-fs-fake');
-const getOptimizeStreams = require('../../../lib/build/optimize-streams').getOptimizeStreams;
+const getOptimizeStreams =
+    require('../../../lib/build/optimize-streams').getOptimizeStreams;
 const pipeStreams = require('../../../lib/build/streams').pipeStreams;
 
 suite('optimize-streams', () => {
 
   function testStream(stream, cb) {
-    stream.on('data', (data) => {
-      cb(null, data)
-    });
+    stream.on('data', (data) => {cb(null, data)});
     stream.on('error', cb);
   }
 
@@ -32,7 +32,8 @@ suite('optimize-streams', () => {
         contents: `const apple = 'apple'; let banana = 'banana';`,
       },
     ]);
-    const op = pipeStreams([sourceStream, getOptimizeStreams({js: {compile: true}})]);
+    const op =
+        pipeStreams([sourceStream, getOptimizeStreams({js: {compile: true}})]);
     testStream(op, (error, f) => {
       if (error) {
         return done(error);
@@ -46,11 +47,13 @@ suite('optimize-streams', () => {
     const es6Contents = `const apple = 'apple';`;
     const sourceStream = vfs.src([
       {
-        path: 'A:\\project\\bower_components\\webcomponentsjs\\webcomponents-es5-loader.js',
+        path:
+            'A:\\project\\bower_components\\webcomponentsjs\\webcomponents-es5-loader.js',
         contents: es6Contents,
       },
     ]);
-    const op = pipeStreams([sourceStream, getOptimizeStreams({js: {compile: true}})]);
+    const op =
+        pipeStreams([sourceStream, getOptimizeStreams({js: {compile: true}})]);
     testStream(op, (error, f) => {
       if (error) {
         return done(error);
@@ -64,11 +67,13 @@ suite('optimize-streams', () => {
     const es6Contents = `const apple = 'apple';`;
     const sourceStream = vfs.src([
       {
-        path: '/project/bower_components/webcomponentsjs/webcomponents-es5-loader.js',
+        path:
+            '/project/bower_components/webcomponentsjs/webcomponents-es5-loader.js',
         contents: es6Contents,
       },
     ]);
-    const op = pipeStreams([sourceStream, getOptimizeStreams({js: {compile: true}})]);
+    const op =
+        pipeStreams([sourceStream, getOptimizeStreams({js: {compile: true}})]);
     testStream(op, (error, f) => {
       if (error) {
         return done(error);
@@ -86,7 +91,8 @@ suite('optimize-streams', () => {
         contents: 'var foo = 3',
       },
     ]);
-    const op = pipeStreams([sourceStream, getOptimizeStreams({js: {minify: true}})]);
+    const op =
+        pipeStreams([sourceStream, getOptimizeStreams({js: {minify: true}})]);
     testStream(op, (error, f) => {
       if (error) {
         return done(error);
@@ -103,7 +109,8 @@ suite('optimize-streams', () => {
         contents: '[1,2,3].map(n => n + 1);',
       },
     ]);
-    const op = pipeStreams([sourceStream, getOptimizeStreams({js: {minify: true}})]);
+    const op =
+        pipeStreams([sourceStream, getOptimizeStreams({js: {minify: true}})]);
     testStream(op, (error, f) => {
       if (error) {
         return done(error);
@@ -114,14 +121,14 @@ suite('optimize-streams', () => {
   });
 
   test('minify html', (done) => {
-    const expected =
-      `<!doctype html><style>foo {
+    const expected = `<!doctype html><style>foo {
             background: blue;
           }</style><script>document.registerElement(\'x-foo\', XFoo);</script><x-foo>bar</x-foo>`;
-    const sourceStream = vfs.src([
-      {
-        path: 'foo.html',
-        contents: `
+    const sourceStream = vfs.src(
+        [
+          {
+            path: 'foo.html',
+            contents: `
         <!doctype html>
         <style>
           foo {
@@ -135,9 +142,11 @@ suite('optimize-streams', () => {
           bar
         </x-foo>
         `,
-      },
-    ], {cwdbase: true});
-    const op = pipeStreams([sourceStream, getOptimizeStreams({html: {minify: true}})]);
+          },
+        ],
+        {cwdbase: true});
+    const op =
+        pipeStreams([sourceStream, getOptimizeStreams({html: {minify: true}})]);
     testStream(op, (error, f) => {
       if (error) {
         return done(error);
@@ -154,7 +163,8 @@ suite('optimize-streams', () => {
         contents: '/* comment */ selector { property: value; }',
       },
     ]);
-    const op = pipeStreams([sourceStream, getOptimizeStreams({css: {minify: true}})]);
+    const op =
+        pipeStreams([sourceStream, getOptimizeStreams({css: {minify: true}})]);
     testStream(op, (error, f) => {
       if (error) {
         return done(error);
@@ -165,11 +175,12 @@ suite('optimize-streams', () => {
   });
 
   test('minify css (inlined)', (done) => {
-    const expected =`<style>foo{background:blue;}</style>`;
-    const sourceStream = vfs.src([
-      {
-        path: 'foo.html',
-        contents: `
+    const expected = `<style>foo{background:blue;}</style>`;
+    const sourceStream = vfs.src(
+        [
+          {
+            path: 'foo.html',
+            contents: `
           <!doctype html>
           <html>
             <head>
@@ -182,9 +193,11 @@ suite('optimize-streams', () => {
             <body></body>
           </html>
         `,
-      },
-    ], {cwdbase: true});
-    const op = pipeStreams([sourceStream, getOptimizeStreams({css: {minify: true}})]);
+          },
+        ],
+        {cwdbase: true});
+    const op =
+        pipeStreams([sourceStream, getOptimizeStreams({css: {minify: true}})]);
     testStream(op, (error, f) => {
       if (error) {
         return done(error);

--- a/test/unit/commands/cli_test.js
+++ b/test/unit/commands/cli_test.js
@@ -1,11 +1,12 @@
 /**
  * @license
  * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
- * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt The complete set of authors may be found
+ * at http://polymer.github.io/AUTHORS.txt The complete set of contributors may
+ * be found at http://polymer.github.io/CONTRIBUTORS.txt Code distributed by
+ * Google as part of the polymer project is also subject to an additional IP
+ * rights grant found at http://polymer.github.io/PATENTS.txt
  */
 
 'use strict';
@@ -29,15 +30,17 @@ suite('The general CLI', () => {
     });
   });
 
-  test('displays general help when no command is called with the --help flag', () => {
-    let cli = new PolymerCli(['--help']);
-    let helpCommand = cli.commands.get('help');
-    let helpCommandSpy = sinon.spy(helpCommand, 'run');
-    return cli.run().then(() => {
-      assert.isOk(helpCommandSpy.calledOnce);
-      assert.deepEqual(helpCommandSpy.firstCall.args[0], {command: null});
-    });
-  });
+  test(
+      'displays general help when no command is called with the --help flag',
+      () => {
+        let cli = new PolymerCli(['--help']);
+        let helpCommand = cli.commands.get('help');
+        let helpCommandSpy = sinon.spy(helpCommand, 'run');
+        return cli.run().then(() => {
+          assert.isOk(helpCommandSpy.calledOnce);
+          assert.deepEqual(helpCommandSpy.firstCall.args[0], {command: null});
+        });
+      });
 
   test('displays general help when unknown command is called', () => {
     let cli = new PolymerCli(['THIS_IS_SOME_UNKNOWN_COMMAND']);
@@ -45,7 +48,9 @@ suite('The general CLI', () => {
     let helpCommandSpy = sinon.spy(helpCommand, 'run');
     return cli.run().then(() => {
       assert.isOk(helpCommandSpy.calledOnce);
-      assert.deepEqual(helpCommandSpy.firstCall.args[0], {command: 'THIS_IS_SOME_UNKNOWN_COMMAND'});
+      assert.deepEqual(
+          helpCommandSpy.firstCall.args[0],
+          {command: 'THIS_IS_SOME_UNKNOWN_COMMAND'});
     });
   });
 
@@ -69,42 +74,55 @@ suite('The general CLI', () => {
     });
   });
 
-  test('displays version information when called with the --version flag', () => {
-    let cli = new PolymerCli(['--version']);
-    let consoleLogSpy = sinon.spy(console, 'log');
-    return cli.run().then(() => {
-      assert.isOk(consoleLogSpy.calledWithExactly(packageJSON.version));
-      consoleLogSpy.restore();
-    });
-  });
+  test(
+      'displays version information when called with the --version flag',
+      () => {
+        let cli = new PolymerCli(['--version']);
+        let consoleLogSpy = sinon.spy(console, 'log');
+        return cli.run().then(() => {
+          assert.isOk(consoleLogSpy.calledWithExactly(packageJSON.version));
+          consoleLogSpy.restore();
+        });
+      });
 
-  test('sets the appropriate log levels when the --verbose & --quiet flags are used', () => {
-    let logger = logging.getLogger('TEST_LOGGER');
-    new PolymerCli(['help', '--verbose']);
-    assert.equal(logger.level, 'debug');
-    new PolymerCli(['help', '--quiet']);
-    assert.equal(logger.level, 'error');
-  });
+  test(
+      'sets the appropriate log levels when the --verbose & --quiet flags are used',
+      () => {
+        let logger = logging.getLogger('TEST_LOGGER');
+        new PolymerCli(['help', '--verbose']);
+        assert.equal(logger.level, 'debug');
+        new PolymerCli(['help', '--quiet']);
+        assert.equal(logger.level, 'error');
+      });
 
   test('read config from flags', () => {
     let cli = new PolymerCli([
       'build',
-      '--root', 'public-cli',
-      '--entrypoint', 'foo-cli.html',
-      '--shell', 'bar-cli.html',
-      '--sources', '**/*',
-      '--extra-dependencies', 'bower_components/baz-cli/**/*',
+      '--root',
+      'public-cli',
+      '--entrypoint',
+      'foo-cli.html',
+      '--shell',
+      'bar-cli.html',
+      '--sources',
+      '**/*',
+      '--extra-dependencies',
+      'bower_components/baz-cli/**/*',
     ]);
     let buildCommand = cli.commands.get('build');
-    let buildCommandStub = sinon.stub(buildCommand, 'run').returns(Promise.resolve());
+    let buildCommandStub =
+        sinon.stub(buildCommand, 'run').returns(Promise.resolve());
     return cli.run().then(() => {
       assert.isOk(buildCommandStub.calledOnce);
       let config = buildCommandStub.firstCall.args[1];
       let expectedRoot = path.resolve('public-cli');
       assert.equal(config.root, expectedRoot);
-      assert.equal(config.entrypoint, path.resolve(expectedRoot, 'foo-cli.html'));
+      assert.equal(
+          config.entrypoint, path.resolve(expectedRoot, 'foo-cli.html'));
       assert.equal(config.shell, path.resolve(expectedRoot, 'bar-cli.html'));
-      assert.deepEqual(config.extraDependencies, [path.resolve(expectedRoot, 'bower_components/baz-cli/**/*')]);
+      assert.deepEqual(
+          config.extraDependencies,
+          [path.resolve(expectedRoot, 'bower_components/baz-cli/**/*')]);
       assert.deepEqual(config.sources, [
         path.resolve(expectedRoot, '**/*'),
         path.resolve(expectedRoot, 'foo-cli.html'),
@@ -113,28 +131,38 @@ suite('The general CLI', () => {
     });
   });
 
- test('flags override default config values', () => {
-    let cli = new PolymerCli(['build',
-        '--root', 'public-cli',
-        '--entrypoint', 'foo-cli.html',
-        '--extra-dependencies', 'bower_components/baz-cli/**/*',
-      ], {
-        root: 'public',
-        entrypoint: 'foo.html',
-        shell: 'bar.html',
-        extraDependencies: ['bower_components/baz/**/*'],
-        sources: ['src/**'],
-      });
+  test('flags override default config values', () => {
+    let cli = new PolymerCli(
+        [
+          'build',
+          '--root',
+          'public-cli',
+          '--entrypoint',
+          'foo-cli.html',
+          '--extra-dependencies',
+          'bower_components/baz-cli/**/*',
+        ],
+        {
+          root: 'public',
+          entrypoint: 'foo.html',
+          shell: 'bar.html',
+          extraDependencies: ['bower_components/baz/**/*'],
+          sources: ['src/**'],
+        });
     let buildCommand = cli.commands.get('build');
-    let buildCommandStub = sinon.stub(buildCommand, 'run').returns(Promise.resolve());
+    let buildCommandStub =
+        sinon.stub(buildCommand, 'run').returns(Promise.resolve());
     return cli.run().then(() => {
       assert.isOk(buildCommandStub.calledOnce);
       let config = buildCommandStub.firstCall.args[1];
       let expectedRoot = path.resolve('public-cli');
       assert.equal(config.root, expectedRoot);
-      assert.equal(config.entrypoint, path.resolve(expectedRoot, 'foo-cli.html'));
+      assert.equal(
+          config.entrypoint, path.resolve(expectedRoot, 'foo-cli.html'));
       assert.equal(config.shell, path.resolve(expectedRoot, 'bar.html'));
-      assert.deepEqual(config.extraDependencies, [path.resolve(expectedRoot, 'bower_components/baz-cli/**/*')]);
+      assert.deepEqual(
+          config.extraDependencies,
+          [path.resolve(expectedRoot, 'bower_components/baz-cli/**/*')]);
       assert.deepEqual(config.sources, [
         path.resolve(expectedRoot, 'src/**'),
         path.resolve(expectedRoot, 'foo-cli.html'),

--- a/test/unit/commands/help_test.js
+++ b/test/unit/commands/help_test.js
@@ -1,11 +1,12 @@
 /**
  * @license
  * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
- * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt The complete set of authors may be found
+ * at http://polymer.github.io/AUTHORS.txt The complete set of contributors may
+ * be found at http://polymer.github.io/CONTRIBUTORS.txt Code distributed by
+ * Google as part of the polymer project is also subject to an additional IP
+ * rights grant found at http://polymer.github.io/PATENTS.txt
  */
 
 'use strict';
@@ -21,25 +22,29 @@ suite('help', () => {
     extraDependencies: [path.resolve('bower_components/webcomponentsjs/*.js')],
   });
 
-  test('displays help for a specific command when called with that command', () => {
-    let cli = new PolymerCli(['help', 'build']);
-    let helpCommand = cli.commands.get('help');
-    let helpCommandSpy = sinon.spy(helpCommand, 'run');
-    cli.run();
-    assert.isOk(helpCommandSpy.calledOnce);
-    assert.deepEqual(
-      helpCommandSpy.firstCall.args,
-      [{command: 'build'}, expectedDefaultConfig]
-    );
-  });
+  test(
+      'displays help for a specific command when called with that command',
+      () => {
+        let cli = new PolymerCli(['help', 'build']);
+        let helpCommand = cli.commands.get('help');
+        let helpCommandSpy = sinon.spy(helpCommand, 'run');
+        cli.run();
+        assert.isOk(helpCommandSpy.calledOnce);
+        assert.deepEqual(
+            helpCommandSpy.firstCall.args,
+            [{command: 'build'}, expectedDefaultConfig]);
+      });
 
-  test('displays general help when the help command is called with no arguments', () => {
-    let cli = new PolymerCli(['help']);
-    let helpCommand = cli.commands.get('help');
-    let helpCommandSpy = sinon.spy(helpCommand, 'run');
-    cli.run();
-    assert.isOk(helpCommandSpy.calledOnce);
-    assert.deepEqual(helpCommandSpy.firstCall.args, [{}, expectedDefaultConfig]);
-  });
+  test(
+      'displays general help when the help command is called with no arguments',
+      () => {
+        let cli = new PolymerCli(['help']);
+        let helpCommand = cli.commands.get('help');
+        let helpCommandSpy = sinon.spy(helpCommand, 'run');
+        cli.run();
+        assert.isOk(helpCommandSpy.calledOnce);
+        assert.deepEqual(
+            helpCommandSpy.firstCall.args, [{}, expectedDefaultConfig]);
+      });
 
 });

--- a/test/unit/commands/init_test.js
+++ b/test/unit/commands/init_test.js
@@ -1,11 +1,12 @@
 /**
  * @license
  * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
- * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt The complete set of authors may be found
+ * at http://polymer.github.io/AUTHORS.txt The complete set of contributors may
+ * be found at http://polymer.github.io/CONTRIBUTORS.txt Code distributed by
+ * Google as part of the polymer project is also subject to an additional IP
+ * rights grant found at http://polymer.github.io/PATENTS.txt
  */
 'use strict';
 
@@ -26,7 +27,8 @@ suite('init', () => {
   });
 
   test('runs the given generator when name argument is provided', () => {
-    let runGeneratorStub = sandbox.stub(polymerInit, 'runGenerator').returns(Promise.resolve());
+    let runGeneratorStub =
+        sandbox.stub(polymerInit, 'runGenerator').returns(Promise.resolve());
     let cli = new PolymerCli(['init', 'shop'], null);
     cli.run();
     assert.isOk(runGeneratorStub.calledOnce);
@@ -35,11 +37,15 @@ suite('init', () => {
     }));
   });
 
-  test('prompts the user to select a generator when no argument is provided', () => {
-    let promptSelectionStub = sandbox.stub(polymerInit, 'promptGeneratorSelection').returns(Promise.resolve());
-    let cli = new PolymerCli(['init'], null);
-    cli.run();
-    assert.isOk(promptSelectionStub.calledOnce);
-  });
+  test(
+      'prompts the user to select a generator when no argument is provided',
+      () => {
+        let promptSelectionStub =
+            sandbox.stub(polymerInit, 'promptGeneratorSelection')
+                .returns(Promise.resolve());
+        let cli = new PolymerCli(['init'], null);
+        cli.run();
+        assert.isOk(promptSelectionStub.calledOnce);
+      });
 
 });

--- a/test/unit/github/github_test.js
+++ b/test/unit/github/github_test.js
@@ -1,10 +1,11 @@
 /*
  * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
- * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt The complete set of authors may be found
+ * at http://polymer.github.io/AUTHORS.txt The complete set of contributors may
+ * be found at http://polymer.github.io/CONTRIBUTORS.txt Code distributed by
+ * Google as part of the polymer project is also subject to an additional IP
+ * rights grant found at http://polymer.github.io/PATENTS.txt
  */
 
 'use strict';
@@ -23,12 +24,16 @@ const GithubResponseError = GithubModule.GithubResponseError;
 suite('github/github', () => {
 
   suite('tokenFromFile()', () => {
-    test.skip('returns a token from file if that file exists', () => {
-      // not currently in use, add tests if put back into use
-    });
-    test.skip('returns null if token file cannot be read', () => {
-      // not currently in use, add tests if put back into use
-    });
+    test.skip(
+        'returns a token from file if that file exists',
+        () => {
+            // not currently in use, add tests if put back into use
+        });
+    test.skip(
+        'returns null if token file cannot be read',
+        () => {
+            // not currently in use, add tests if put back into use
+        });
   });
 
   suite('extractReleaseTarball()', () => {
@@ -39,7 +44,7 @@ suite('github/github', () => {
       const mockRequestApi = (options) => {
         requestedUrl = options.url;
         return fs.createReadStream(
-        path.join(__dirname, 'github-test-data/test_tarball.tgz'));
+            path.join(__dirname, 'github-test-data/test_tarball.tgz'));
       };
       const github = new Github({
         owner: 'TEST_OWNER',
@@ -58,8 +63,8 @@ suite('github/github', () => {
         const readStream = new PassThrough();
         setTimeout(() => {
           readStream.emit('response', {
-          statusCode: 404,
-          statusMessage: 'TEST MESSAGE - 404',
+            statusCode: 404,
+            statusMessage: 'TEST MESSAGE - 404',
           });
         }, 10);
         return readStream;
@@ -71,12 +76,14 @@ suite('github/github', () => {
       });
       const tmpDir = temp.mkdirSync();
       return github.extractReleaseTarball('http://foo.com/bar.tar', tmpDir)
-        .then(() => {
-          throw new Error('GithubResponseError expected');
-        }).catch((err) => {
-          assert.instanceOf(err, GithubResponseError);
-          assert.equal(err.message, 'unexpected response: 404 TEST MESSAGE - 404');
-        });
+          .then(() => {
+            throw new Error('GithubResponseError expected');
+          })
+          .catch((err) => {
+            assert.instanceOf(err, GithubResponseError);
+            assert.equal(
+                err.message, 'unexpected response: 404 TEST MESSAGE - 404');
+          });
     });
 
   });
@@ -113,52 +120,56 @@ suite('github/github', () => {
     test('calls the github API with correct params', () => {
       getReleasesStub.returns(Promise.resolve(basicReleasesResponse));
 
-      return github.getSemverRelease('*')
-        .then(() => {
-          assert.isOk(getReleasesStub.calledWithExactly({
-            owner: 'TEST_OWNER',
-            repo: 'TEST_REPO',
-            per_page: 100,
-          }));
-        });
+      return github.getSemverRelease('*').then(() => {
+        assert.isOk(getReleasesStub.calledWithExactly({
+          owner: 'TEST_OWNER',
+          repo: 'TEST_REPO',
+          per_page: 100,
+        }));
+      });
     });
 
-    test('resolves with latest semver release that matches the range: *', () => {
-      getReleasesStub.returns(Promise.resolve(basicReleasesResponse));
+    test(
+        'resolves with latest semver release that matches the range: *', () => {
+          getReleasesStub.returns(Promise.resolve(basicReleasesResponse));
 
-      return github.getSemverRelease('*')
-        .then((release) => {
-          assert.deepEqual(release, {tag_name: 'v2.1.0'});
+          return github.getSemverRelease('*').then((release) => {
+            assert.deepEqual(release, {tag_name: 'v2.1.0'});
+          });
         });
-    });
 
-    test('resolves with latest semver release that matches the range: ^v1.0.0', () => {
-      getReleasesStub.returns(Promise.resolve(basicReleasesResponse));
+    test(
+        'resolves with latest semver release that matches the range: ^v1.0.0',
+        () => {
+          getReleasesStub.returns(Promise.resolve(basicReleasesResponse));
 
-      return github.getSemverRelease('^v1.0.0')
-        .then((release) => {
-          assert.deepEqual(release, {tag_name: 'v1.2.1'});
+          return github.getSemverRelease('^v1.0.0').then((release) => {
+            assert.deepEqual(release, {tag_name: 'v1.2.1'});
+          });
         });
-    });
 
-    test('resolves with latest semver release that matches the range: ^v2.0.0', () => {
-      getReleasesStub.returns(Promise.resolve(basicReleasesResponse));
+    test(
+        'resolves with latest semver release that matches the range: ^v2.0.0',
+        () => {
+          getReleasesStub.returns(Promise.resolve(basicReleasesResponse));
 
-      return github.getSemverRelease('^v2.0.0')
-        .then((release) => {
-          assert.deepEqual(release, {tag_name: 'v2.1.0'});
+          return github.getSemverRelease('^v2.0.0').then((release) => {
+            assert.deepEqual(release, {tag_name: 'v2.1.0'});
+          });
         });
-    });
 
     test('rejects with an error if no matching releases are found', () => {
       getReleasesStub.returns(Promise.resolve(basicReleasesResponse));
 
       return github.getSemverRelease('^v3.0.0')
-        .then(() => {
-          throw new Error('Error expected');
-        }).catch((err) => {
-          assert.equal(err.message, 'TEST_OWNER/TEST_REPO has no releases matching ^v3.0.0.');
-        });
+          .then(() => {
+            throw new Error('Error expected');
+          })
+          .catch((err) => {
+            assert.equal(
+                err.message,
+                'TEST_OWNER/TEST_REPO has no releases matching ^v3.0.0.');
+          });
     });
   });
 

--- a/test/unit/init/application_test.js
+++ b/test/unit/init/application_test.js
@@ -1,10 +1,11 @@
 /*
  * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
- * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt The complete set of authors may be found
+ * at http://polymer.github.io/AUTHORS.txt The complete set of contributors may
+ * be found at http://polymer.github.io/CONTRIBUTORS.txt Code distributed by
+ * Google as part of the polymer project is also subject to an additional IP
+ * rights grant found at http://polymer.github.io/PATENTS.txt
  */
 
 'use strict';
@@ -15,59 +16,65 @@ const path = require('path');
 const yoAssert = require('yeoman-assert');
 const helpers = require('yeoman-test');
 
-const createApplicationGenerator
-  = require('../../../lib/init/application/application').createApplicationGenerator;
+const createApplicationGenerator =
+    require('../../../lib/init/application/application')
+        .createApplicationGenerator;
 
 suite('init/application', () => {
 
-  test('creates expected 1.x files while passed the 1.x template name', (done) => {
-    const TestGenerator = createApplicationGenerator('polymer-1.x');
-    helpers
-      .run(TestGenerator)
-      .withPrompts({name: 'foobar'})
-      .on('end', (a) => {
-        yoAssert.file(['bower.json']);
-        yoAssert.fileContent('src/foobar-app/foobar-app.html', 'Polymer({');
-        done();
+  test(
+      'creates expected 1.x files while passed the 1.x template name',
+      (done) => {
+        const TestGenerator = createApplicationGenerator('polymer-1.x');
+        helpers.run(TestGenerator)
+            .withPrompts({name: 'foobar'})
+            .on('end', (a) => {
+              yoAssert.file(['bower.json']);
+              yoAssert.fileContent(
+                  'src/foobar-app/foobar-app.html', 'Polymer({');
+              done();
+            });
       });
-  });
 
-  test('creates expected 2.x files while passed the 2.x template name', (done) => {
-    const TestGenerator = createApplicationGenerator('polymer-2.x');
-    helpers
-      .run(TestGenerator)
-      .withPrompts({name: 'foobar'})
-      .on('end', (a) => {
-        yoAssert.file(['bower.json']);
-        yoAssert.fileContent('src/foobar-app/foobar-app.html', 'class MyApplication extends Polymer.Element');
-        done();
+  test(
+      'creates expected 2.x files while passed the 2.x template name',
+      (done) => {
+        const TestGenerator = createApplicationGenerator('polymer-2.x');
+        helpers.run(TestGenerator)
+            .withPrompts({name: 'foobar'})
+            .on('end', (a) => {
+              yoAssert.file(['bower.json']);
+              yoAssert.fileContent(
+                  'src/foobar-app/foobar-app.html',
+                  'class MyApplication extends Polymer.Element');
+              done();
+            });
       });
-  });
 
-  test('ignoring filenames with dangling underscores when generating templates', (done) => {
-    const TestGenerator = createApplicationGenerator('polymer-1.x');
-    helpers
-      .run(TestGenerator)
-      .on('end', (a) => {
-        yoAssert.noFile(['src/_element/_element.html']);
-        done();
+  test(
+      'ignoring filenames with dangling underscores when generating templates',
+      (done) => {
+        const TestGenerator = createApplicationGenerator('polymer-1.x');
+        helpers.run(TestGenerator).on('end', (a) => {
+          yoAssert.noFile(['src/_element/_element.html']);
+          done();
+        });
       });
-  });
 
   test('works when package.json with no name is present', (done) => {
     const TestGenerator = createApplicationGenerator('polymer-1.x');
-    helpers
-      .run(TestGenerator)
-      .inTmpDir((tempDir) => {
-        fs.writeFileSync(path.join(tempDir, 'package.json'), '{}');
-      })
-      .on('error', (error) => {
-        assert.fail();
-        done();
-      })
-      .on('end', (a) => {
-        done();
-      });
+    helpers.run(TestGenerator)
+        .inTmpDir((tempDir) => {
+          fs.writeFileSync(path.join(tempDir, 'package.json'), '{}');
+        })
+        .on('error',
+            (error) => {
+              assert.fail();
+              done();
+            })
+        .on('end', (a) => {
+          done();
+        });
   });
 
 });

--- a/test/unit/init/element_test.js
+++ b/test/unit/init/element_test.js
@@ -1,10 +1,11 @@
 /*
  * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
- * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt The complete set of authors may be found
+ * at http://polymer.github.io/AUTHORS.txt The complete set of contributors may
+ * be found at http://polymer.github.io/CONTRIBUTORS.txt Code distributed by
+ * Google as part of the polymer project is also subject to an additional IP
+ * rights grant found at http://polymer.github.io/PATENTS.txt
  */
 
 'use strict';
@@ -15,59 +16,63 @@ const path = require('path');
 const yoAssert = require('yeoman-assert');
 const helpers = require('yeoman-test');
 
-const createElementGenerator
-  = require('../../../lib/init/element/element').createElementGenerator;
+const createElementGenerator =
+    require('../../../lib/init/element/element').createElementGenerator;
 
 suite('init/element', () => {
 
-  test('creates expected 1.x files while passed the 1.x template name', (done) => {
-    const TestGenerator = createElementGenerator('polymer-1.x');
-    helpers
-      .run(TestGenerator)
-      .withPrompts({name: 'foobar-element'})
-      .on('end', (a) => {
-        yoAssert.file(['bower.json']);
-        yoAssert.fileContent('foobar-element.html', 'Polymer({');
-        done();
+  test(
+      'creates expected 1.x files while passed the 1.x template name',
+      (done) => {
+        const TestGenerator = createElementGenerator('polymer-1.x');
+        helpers.run(TestGenerator)
+            .withPrompts({name: 'foobar-element'})
+            .on('end', (a) => {
+              yoAssert.file(['bower.json']);
+              yoAssert.fileContent('foobar-element.html', 'Polymer({');
+              done();
+            });
       });
-  });
 
-  test('creates expected 2.x files while passed the 2.x template name', (done) => {
-    const TestGenerator = createElementGenerator('polymer-2.x');
-    helpers
-      .run(TestGenerator)
-      .withPrompts({name: 'foobar-element'})
-      .on('end', (a) => {
-        yoAssert.file(['bower.json']);
-        yoAssert.fileContent('foobar-element.html', 'class MyElement extends Polymer.Element');
-        done();
+  test(
+      'creates expected 2.x files while passed the 2.x template name',
+      (done) => {
+        const TestGenerator = createElementGenerator('polymer-2.x');
+        helpers.run(TestGenerator)
+            .withPrompts({name: 'foobar-element'})
+            .on('end', (a) => {
+              yoAssert.file(['bower.json']);
+              yoAssert.fileContent(
+                  'foobar-element.html',
+                  'class MyElement extends Polymer.Element');
+              done();
+            });
       });
-  });
 
-  test('ignoring filenames with dangling underscores when generating templates', (done) => {
-    const TestGenerator = createElementGenerator('polymer-1.x');
-    helpers
-      .run(TestGenerator)
-      .on('end', (a) => {
-        yoAssert.noFile(['_element.html']);
-        done();
+  test(
+      'ignoring filenames with dangling underscores when generating templates',
+      (done) => {
+        const TestGenerator = createElementGenerator('polymer-1.x');
+        helpers.run(TestGenerator).on('end', (a) => {
+          yoAssert.noFile(['_element.html']);
+          done();
+        });
       });
-  });
 
   test('works when package.json with no name is present', (done) => {
     const TestGenerator = createElementGenerator('polymer-1.x');
-    helpers
-      .run(TestGenerator)
-      .inTmpDir((tempDir) => {
-        fs.writeFileSync(path.join(tempDir, 'package.json'), '{}');
-      })
-      .on('error', (error) => {
-        assert.fail();
-        done();
-      })
-      .on('end', (a) => {
-        done();
-      });
+    helpers.run(TestGenerator)
+        .inTmpDir((tempDir) => {
+          fs.writeFileSync(path.join(tempDir, 'package.json'), '{}');
+        })
+        .on('error',
+            (error) => {
+              assert.fail();
+              done();
+            })
+        .on('end', (a) => {
+          done();
+        });
   });
 
 

--- a/test/unit/init/github_test.js
+++ b/test/unit/init/github_test.js
@@ -1,10 +1,11 @@
 /*
  * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
- * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt The complete set of authors may be found
+ * at http://polymer.github.io/AUTHORS.txt The complete set of contributors may
+ * be found at http://polymer.github.io/CONTRIBUTORS.txt Code distributed by
+ * Google as part of the polymer project is also subject to an additional IP
+ * rights grant found at http://polymer.github.io/PATENTS.txt
  */
 
 'use strict';
@@ -13,8 +14,8 @@ const assert = require('chai').assert;
 const sinon = require('sinon');
 const helpers = require('yeoman-test');
 
-const createGithubGenerator
-  = require('../../../lib/init/github').createGithubGenerator;
+const createGithubGenerator =
+    require('../../../lib/init/github').createGithubGenerator;
 
 /**
  * This small helper function wraps createGithubGenerator() so that we may add a
@@ -40,55 +41,63 @@ suite('init/github', () => {
       tag_name: 'MATCHING_RELEASE_TAG_NAME',
     };
 
-    test('returns a generator that untars the latest release when no semver range is given', (done) => {
-      let getSemverReleaseStub;
-      let extractReleaseTarballStub;
+    test(
+        'returns a generator that untars the latest release when no semver range is given',
+        (done) => {
+          let getSemverReleaseStub;
+          let extractReleaseTarballStub;
 
-      const TestGenerator = createTestGenerator({
-        owner: 'Polymer',
-        repo: 'shop',
-      }, function setupGeneratorStubs(generator) {
-        getSemverReleaseStub = sinon
-            .stub(generator._github, 'getSemverRelease')
-            .returns(Promise.resolve(semverMatchingRelease));
-        extractReleaseTarballStub = sinon
-            .stub(generator._github, 'extractReleaseTarball')
-            .returns(Promise.resolve());
-      });
+          const TestGenerator = createTestGenerator(
+              {
+                owner: 'Polymer',
+                repo: 'shop',
+              },
+              function setupGeneratorStubs(generator) {
+                getSemverReleaseStub =
+                    sinon.stub(generator._github, 'getSemverRelease')
+                        .returns(Promise.resolve(semverMatchingRelease));
+                extractReleaseTarballStub =
+                    sinon.stub(generator._github, 'extractReleaseTarball')
+                        .returns(Promise.resolve());
+              });
 
-      helpers.run(TestGenerator)
-        .on('end', (a) => {
-          assert.isOk(getSemverReleaseStub.calledWith('*'));
-          assert.isOk(extractReleaseTarballStub.calledWith(semverMatchingRelease.tarball_url));
-          done();
+          helpers.run(TestGenerator).on('end', (a) => {
+            assert.isOk(getSemverReleaseStub.calledWith('*'));
+            assert.isOk(extractReleaseTarballStub.calledWith(
+                semverMatchingRelease.tarball_url));
+            done();
+          });
         });
-    });
 
-    test('returns a generator that untars the latest matching release when a semver range is given', (done) => {
-      const testSemverRange = '^v123.456.789';
-      let getSemverReleaseStub;
-      let extractReleaseTarballStub;
+    test(
+        'returns a generator that untars the latest matching release when a semver range is given',
+        (done) => {
+          const testSemverRange = '^v123.456.789';
+          let getSemverReleaseStub;
+          let extractReleaseTarballStub;
 
-      const TestGenerator = createTestGenerator({
-        owner: 'Polymer',
-        repo: 'shop',
-        semverRange: testSemverRange,
-      }, function setupGeneratorStubs(generator) {
-        getSemverReleaseStub = sinon
-            .stub(generator._github, 'getSemverRelease')
-            .returns(Promise.resolve(semverMatchingRelease));
-        extractReleaseTarballStub = sinon
-            .stub(generator._github, 'extractReleaseTarball')
-            .returns(Promise.resolve());
-      });
+          const TestGenerator = createTestGenerator(
+              {
+                owner: 'Polymer',
+                repo: 'shop',
+                semverRange: testSemverRange,
+              },
+              function setupGeneratorStubs(generator) {
+                getSemverReleaseStub =
+                    sinon.stub(generator._github, 'getSemverRelease')
+                        .returns(Promise.resolve(semverMatchingRelease));
+                extractReleaseTarballStub =
+                    sinon.stub(generator._github, 'extractReleaseTarball')
+                        .returns(Promise.resolve());
+              });
 
-      helpers.run(TestGenerator)
-        .on('end', (a) => {
-          assert.isOk(getSemverReleaseStub.calledWith(testSemverRange));
-          assert.isOk(extractReleaseTarballStub.calledWith(semverMatchingRelease.tarball_url));
-          done();
+          helpers.run(TestGenerator).on('end', (a) => {
+            assert.isOk(getSemverReleaseStub.calledWith(testSemverRange));
+            assert.isOk(extractReleaseTarballStub.calledWith(
+                semverMatchingRelease.tarball_url));
+            done();
+          });
         });
-    });
 
   });
 

--- a/test/unit/init/init_test.js
+++ b/test/unit/init/init_test.js
@@ -1,11 +1,12 @@
 /**
  * @license
  * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
- * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt The complete set of authors may be found
+ * at http://polymer.github.io/AUTHORS.txt The complete set of contributors may
+ * be found at http://polymer.github.io/CONTRIBUTORS.txt Code distributed by
+ * Google as part of the polymer project is also subject to an additional IP
+ * rights grant found at http://polymer.github.io/PATENTS.txt
  */
 'use strict';
 
@@ -23,7 +24,8 @@ const polymerInit = require('../../../lib/init/init');
 var isPlatformWin = /^win/.test(process.platform);
 
 function stripAnsi(str) {
-  let ansiRegex = /[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g;
+  let ansiRegex =
+      /[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g;
   return str.replace(ansiRegex, '');
 }
 
@@ -54,9 +56,10 @@ suite('init', () => {
         [GENERATOR_NAME]: GENERATOR_NAME,
       });
 
-      return polymerInit.runGenerator(GENERATOR_NAME, {env: yeomanEnv}).then(() => {
-        assert.isOk(yeomanEnv.run.calledWith(GENERATOR_NAME));
-      });
+      return polymerInit.runGenerator(GENERATOR_NAME, {env: yeomanEnv})
+          .then(() => {
+            assert.isOk(yeomanEnv.run.calledWith(GENERATOR_NAME));
+          });
     });
 
     test('fails if an unknown generator is requested', () => {
@@ -66,22 +69,34 @@ suite('init', () => {
         'TEST-GENERATOR': 'TEST-GENERATOR',
       });
 
-      return polymerInit.runGenerator(UNKNOWN_GENERATOR_NAME, {env: yeomanEnv}).then(() => {
-        throw new Error('The promise should have been rejected before it got here');
-      }, (error) => {
-        assert.equal(error.message, `Template ${UNKNOWN_GENERATOR_NAME} not found`);
-      });
+      return polymerInit.runGenerator(UNKNOWN_GENERATOR_NAME, {env: yeomanEnv})
+          .then(
+              () => {
+                throw new Error(
+                    'The promise should have been rejected before it got here');
+              },
+              (error) => {
+                assert.equal(
+                    error.message,
+                    `Template ${UNKNOWN_GENERATOR_NAME} not found`);
+              });
     });
 
     test('works with the default yeoman environment', () => {
       // Note: Do not use a fake Yeoman environment in this test so that we get
       // coverage of the case where env isn't specified.
       const UNKNOWN_GENERATOR_NAME = 'UNKNOWN-GENERATOR';
-      return polymerInit.runGenerator(UNKNOWN_GENERATOR_NAME).then(() => {
-        throw new Error('The promise should have been rejected before it got here');
-      }, (error) => {
-        assert.equal(error.message, `Template ${UNKNOWN_GENERATOR_NAME} not found`);
-      });
+      return polymerInit.runGenerator(UNKNOWN_GENERATOR_NAME)
+          .then(
+              () => {
+                throw new Error(
+                    'The promise should have been rejected before it got here');
+              },
+              (error) => {
+                assert.equal(
+                    error.message,
+                    `Template ${UNKNOWN_GENERATOR_NAME} not found`);
+              });
     });
 
   });
@@ -160,7 +175,9 @@ suite('init', () => {
     });
 
     test('works with the default yeoman environment', () => {
-      sandbox.stub(inquirer, 'prompt').returns(Promise.resolve({generatorName: 'TEST'}));
+      sandbox.stub(inquirer, 'prompt').returns(Promise.resolve({
+        generatorName: 'TEST',
+      }));
       polymerInit.runGenerator = function(name, options) {};
       return polymerInit.promptGeneratorSelection().catch((error) => {
         assert.equal(error.message, 'Template TEST not found');
@@ -168,76 +185,108 @@ suite('init', () => {
     });
 
     test('prompts with a list to get generatorName property from user', () => {
-      let promptStub = sandbox.stub(inquirer, 'prompt').returns(Promise.resolve({generatorName: 'TEST'}));
-      return polymerInit.promptGeneratorSelection({env: yeomanEnvMock}).catch((error) => {
-        assert.equal(error.message, 'Template TEST not found');
-      }).then(() => {
-        assert.isTrue(promptStub.calledOnce);
-        assert.equal(promptStub.firstCall.args[0][0].type, 'list');
-        assert.equal(promptStub.firstCall.args[0][0].name, 'generatorName');
-        assert.equal(promptStub.firstCall.args[0][0].message,  'Which starter template would you like to use?');
-      });
+      let promptStub = sandbox.stub(inquirer, 'prompt')
+                           .returns(Promise.resolve({generatorName: 'TEST'}));
+      return polymerInit.promptGeneratorSelection({env: yeomanEnvMock})
+          .catch((error) => {
+            assert.equal(error.message, 'Template TEST not found');
+          })
+          .then(() => {
+            assert.isTrue(promptStub.calledOnce);
+            assert.equal(promptStub.firstCall.args[0][0].type, 'list');
+            assert.equal(promptStub.firstCall.args[0][0].name, 'generatorName');
+            assert.equal(
+                promptStub.firstCall.args[0][0].message,
+                'Which starter template would you like to use?');
+          });
     });
 
     test('prompts with a list of all registered generators', () => {
-      let promptStub = sandbox.stub(inquirer, 'prompt').returns(Promise.resolve({generatorName: 'TEST'}));
-      return polymerInit.promptGeneratorSelection({env: yeomanEnvMock}).catch((error) => {
-        assert.equal(error.message, 'Template TEST not found');
-      }).then(() => {
-        let choices = promptStub.firstCall.args[0][0].choices;
-        assert.equal(choices.length, GENERATORS.length);
+      let promptStub = sandbox.stub(inquirer, 'prompt')
+                           .returns(Promise.resolve({generatorName: 'TEST'}));
+      return polymerInit.promptGeneratorSelection({env: yeomanEnvMock})
+          .catch((error) => {
+            assert.equal(error.message, 'Template TEST not found');
+          })
+          .then(() => {
+            let choices = promptStub.firstCall.args[0][0].choices;
+            assert.equal(choices.length, GENERATORS.length);
 
-        for (let choice of choices) {
-          let generator = GENERATORS.find(generator => generator.generatorName === choice.value);
-          assert.isDefined(generator, `generator not found: ${choice.value}`);
-          assert.oneOf(stripAnsi(choice.name), [generator.shortName, `${generator.shortName} - ${generator.description}`]);
-          assert.equal(choice.value, generator.generatorName);
-          assert.equal(choice.short, generator.shortName);
-        }
-      });
+            for (let choice of choices) {
+              let generator = GENERATORS.find(
+                  generator => generator.generatorName === choice.value);
+              assert.isDefined(
+                  generator, `generator not found: ${choice.value}`);
+              assert.oneOf(stripAnsi(choice.name), [
+                generator.shortName,
+                `${generator.shortName} - ${generator.description}`,
+              ]);
+              assert.equal(choice.value, generator.generatorName);
+              assert.equal(choice.short, generator.shortName);
+            }
+          });
     });
 
-    test('includes user-provided generators in the list when properly installed/registered', () => {
-      let yeomanEnv = new YeomanEnvironment();
-      let promptStub = sandbox.stub(inquirer, 'prompt').returns(Promise.resolve({generatorName: 'TEST'}));
-      helpers.registerDependencies(yeomanEnv, [[helpers.createDummyGenerator(), 'polymer-init-custom-template:app']]);
-      return polymerInit.promptGeneratorSelection({env: yeomanEnv}).catch((error) => {
-        assert.equal(error.message, 'Template TEST not found');
-      }).then(() => {
-        assert.isTrue(promptStub.calledOnce);
-        let choices = promptStub.firstCall.args[0][0].choices;
-        let customGeneratorChoice = choices[choices.length-1];
-        assert.equal(stripAnsi(customGeneratorChoice.name), 'custom-template');
-        assert.equal(customGeneratorChoice.value, 'polymer-init-custom-template:app');
-        assert.equal(customGeneratorChoice.short, 'custom-template');
-      });
-    });
+    test(
+        'includes user-provided generators in the list when properly installed/registered',
+        () => {
+          let yeomanEnv = new YeomanEnvironment();
+          let promptStub =
+              sandbox.stub(inquirer, 'prompt').returns(Promise.resolve({
+                generatorName: 'TEST',
+              }));
+          helpers.registerDependencies(yeomanEnv, [[
+                                         helpers.createDummyGenerator(),
+                                         'polymer-init-custom-template:app',
+                                       ]]);
+          return polymerInit.promptGeneratorSelection({env: yeomanEnv})
+              .catch((error) => {
+                assert.equal(error.message, 'Template TEST not found');
+              })
+              .then(() => {
+                assert.isTrue(promptStub.calledOnce);
+                let choices = promptStub.firstCall.args[0][0].choices;
+                let customGeneratorChoice = choices[choices.length - 1];
+                assert.equal(
+                    stripAnsi(customGeneratorChoice.name), 'custom-template');
+                assert.equal(
+                    customGeneratorChoice.value,
+                    'polymer-init-custom-template:app');
+                assert.equal(customGeneratorChoice.short, 'custom-template');
+              });
+        });
 
     test('prompts the user with a list', () => {
-      let promptStub = sandbox.stub(inquirer, 'prompt').returns(Promise.resolve({generatorName: 'TEST'}));
+      let promptStub = sandbox.stub(inquirer, 'prompt')
+                           .returns(Promise.resolve({generatorName: 'TEST'}));
 
-      return polymerInit.promptGeneratorSelection({env: yeomanEnvMock}).catch((error) => {
-        assert.equal(error.message, 'Template TEST not found');
-      }).then(() => {
-        assert.isTrue(promptStub.calledOnce);
-        assert.equal(promptStub.firstCall.args[0][0].type, 'list');
-      });
+      return polymerInit.promptGeneratorSelection({env: yeomanEnvMock})
+          .catch((error) => {
+            assert.equal(error.message, 'Template TEST not found');
+          })
+          .then(() => {
+            assert.isTrue(promptStub.calledOnce);
+            assert.equal(promptStub.firstCall.args[0][0].type, 'list');
+          });
     });
 
     if (isPlatformWin) {
-
       test('prompts with a rawlist if being used in MinGW shell', () => {
-        let promptStub = sandbox.stub(inquirer, 'prompt').returns(Promise.resolve({generatorName: 'TEST'}));
-        sandbox.stub(childProcess, 'execSync').withArgs('uname -s').returns('mingw');
+        let promptStub = sandbox.stub(inquirer, 'prompt')
+                             .returns(Promise.resolve({generatorName: 'TEST'}));
+        sandbox.stub(childProcess, 'execSync')
+            .withArgs('uname -s')
+            .returns('mingw');
 
-        return polymerInit.promptGeneratorSelection({env: yeomanEnvMock}).catch((error) => {
-          assert.equal(error.message, 'Template TEST not found');
-        }).then(() => {
-          assert.isTrue(promptStub.calledOnce);
-          assert.equal(promptStub.firstCall.args[0][0].type, 'rawlist');
-        });
+        return polymerInit.promptGeneratorSelection({env: yeomanEnvMock})
+            .catch((error) => {
+              assert.equal(error.message, 'Template TEST not found');
+            })
+            .then(() => {
+              assert.isTrue(promptStub.calledOnce);
+              assert.equal(promptStub.firstCall.args[0][0].type, 'rawlist');
+            });
       });
-
     }
 
   });

--- a/test/unit/install/install_test.js
+++ b/test/unit/install/install_test.js
@@ -1,11 +1,12 @@
 /**
  * @license
  * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
- * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt The complete set of authors may be found
+ * at http://polymer.github.io/AUTHORS.txt The complete set of contributors may
+ * be found at http://polymer.github.io/CONTRIBUTORS.txt Code distributed by
+ * Google as part of the polymer project is also subject to an additional IP
+ * rights grant found at http://polymer.github.io/PATENTS.txt
  */
 'use strict';
 


### PR DESCRIPTION
* Bump clang-format to 1.0.48.
* Fix find command in npm format script, which wasn't properly catching test JS.
* Include gulp.js in formatted files.
* Format everything.

 - [x] CHANGELOG.md update unnecessary
