### PR TITLE
Add .polymerignore mechanism

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@types/parse5": "^2.2.33",
     "@types/request": "0.0.39",
     "@types/resolve": "0.0.4",
+    "@types/rimraf": "^0.0.28",
     "@types/semver": "^5.3.30",
     "@types/temp": "^0.8.28",
     "@types/uglify-js": "^2.6.28",

--- a/src/init/github.ts
+++ b/src/init/github.ts
@@ -67,6 +67,7 @@ export function createGithubGenerator(githubOptions: GithubGeneratorOptions):
       try {
         await this._github.extractReleaseTarball(
             release.tarball_url, this.destinationRoot());
+        this._github.filterPolymerignore(this.destinationRoot());
         done();
       } catch (error) {
         logger.error(`Could not download release from ${owner}/${repo}`);


### PR DESCRIPTION
Several templates for the init command are stored on github:
- polymer-1-starter-kit
- polymer-2-starter-kit
- shop

These projects have several files that are not meant to be used by
consumers of the template.  Examples:
- .travis.yml
- .github
- .gitattributes

The solution offered in this commit is provides a mechanism to read a
`.polymerignore` file that filters for the purpose of `polymer init`
templates.  This way, any new files that get added to the template do
not need to be registered in polymer-cli.  The `.polymerignore` format
is very much like the `.gitignore` format.
- Each line is a glob pattern (both * and ** are respected).
- Empty lines are ignored.
- Lines that begin with # are ignored.
- Lines that begin with / are considered to be at the root of the project.

Issues:
- #446
- #629
