### PR TITLE
Fix failing polymer 2 application and element tests

### DIFF
--- a/src/init/application/templates/polymer-2.x/test/_element/_element_test.html
+++ b/src/init/application/templates/polymer-2.x/test/_element/_element_test.html
@@ -33,7 +33,7 @@
           assert.equal(element.prop1, '<%= elementName %>');
           var elementShadowRoot = element.shadowRoot;
           var elementHeader = elementShadowRoot.querySelector('h2');
-          assert.equal(elementHeader.outerHTML, '<h2>Hello <%= elementName %>!</h2>');
+          assert.equal(elementHeader.innerHTML, 'Hello <%= elementName %>!');
         });
 
         test('setting a property on the element works', function() {
@@ -42,7 +42,7 @@
           assert.equal(element.prop1, 'new-prop1');
           var elementShadowRoot = element.shadowRoot;
           var elementHeader = elementShadowRoot.querySelector('h2');
-          assert.equal(elementHeader.outerHTML, '<h2>Hello new-prop1!</h2>');
+          assert.equal(elementHeader.innerHTML, 'Hello new-prop1!');
         });
 
       });

--- a/src/init/element/templates/polymer-2.x/test/_element_test.html
+++ b/src/init/element/templates/polymer-2.x/test/_element_test.html
@@ -33,7 +33,7 @@
           assert.equal(element.prop1, '<%= name %>');
           var elementShadowRoot = element.shadowRoot;
           var elementHeader = elementShadowRoot.querySelector('h2');
-          assert.equal(elementHeader.outerHTML, '<h2>Hello <%= name %>!</h2>');
+          assert.equal(elementHeader.innerHTML, 'Hello <%= name %>!');
         });
 
         test('setting a property on the element works', function() {
@@ -42,7 +42,7 @@
           assert.equal(element.prop1, 'new-prop1');
           var elementShadowRoot = element.shadowRoot;
           var elementHeader = elementShadowRoot.querySelector('h2');
-          assert.equal(elementHeader.outerHTML, '<h2>Hello new-prop1!</h2>');
+          assert.equal(elementHeader.innerHTML, 'Hello new-prop1!');
         });
 
       });


### PR DESCRIPTION
The previous tests made the assumption that no classes would
be automagically added to the `<h2>` tags. This assumption
doesn't hold in firefox 52 and I suspect browsers where the
Shadow DOM polyfill is used.

The tests were changed to only test the innerHTML as opposed to
the outerHTML.

The CHANGELOG was not modified. An existing entry already
describes this change.
