### PR TITLE
remove node v4 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,7 @@ addons:
       - google-chrome-stable
 language: node_js
 node_js:
-  - "4"
+  - "node"
   - "6"
-  - "7"
 script:
   - xvfb-run npm test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 - `init`: Update polymer 2.0 application & element tests to improve and fix broken tests
 - `init`: Update polymer 1.x application & element template WCT dependency to `^6.0.0-prerelease.5`.
 - `init`: Update polymer application & element READMEs
-- [Breaking] Remove Node v4 support: Node v4 is no longer in Active LTS, so as per the [Polymer Tools Node.js Support Policy](https://www.polymer-project.org/2.0/docs/tools/node-support) polyserve will not support Node v4. Please update to Node v6 or later to continue using the latest verisons of Polymer tooling.
+- [Breaking] Remove Node v4 support: Node v4 is no longer in Active LTS, so as per the [Polymer Tools Node.js Support Policy](https://www.polymer-project.org/2.0/docs/tools/node-support) the Polymer CLI will not support Node v4. Please update to Node v6 or later to continue using the latest verisons of Polymer tooling.
 
 ## v0.18.0-pre.15 [03-22-2017]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - `init`: Update polymer 2.0 application & element tests to improve and fix broken tests
 - `init`: Update polymer 1.x application & element template WCT dependency to `^6.0.0-prerelease.5`.
 - `init`: Update polymer application & element READMEs
+- [Breaking] Remove Node v4 support: Node v4 is no longer in Active LTS, so as per the [Polymer Tools Node.js Support Policy](https://www.polymer-project.org/2.0/docs/tools/node-support) polyserve will not support Node v4. Please update to Node v6 or later to continue using the latest verisons of Polymer tooling.
 
 ## v0.18.0-pre.15 [03-22-2017]
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A commandline tool for Polymer projects",
   "main": "lib/polymer-cli.js",
   "engines": {
-    "node": ">=4.0"
+    "node": ">=6.0"
   },
   "bin": {
     "polymer": "bin/polymer.js"
@@ -82,7 +82,7 @@
   },
   "devDependencies": {
     "@types/fs-extra": "0.0.37",
-    "@types/node": "^4.2.2",
+    "@types/node": "^6",
     "chai": "^3.5.0",
     "clang-format": "=1.0.45",
     "depcheck": "^0.6.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -219,7 +219,7 @@
     "@types/bluebird" "*"
     "@types/node" "*"
 
-"@types/node@*", "@types/node@^4.0.30", "@types/node@^4.2.2", "@types/node@^4.2.3":
+"@types/node@*", "@types/node@^4.0.30", "@types/node@^4.2.3":
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-4.2.3.tgz#4405d19dcabae1fb0dfc9f267c8de5c114d47ce9"
 
@@ -227,7 +227,7 @@
   version "4.0.30"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-4.0.30.tgz#553f490ed3030311620f88003e7abfc0edcb301e"
 
-"@types/node@6.0.*", "@types/node@^6.0.0", "@types/node@^6.0.31", "@types/node@^6.0.41":
+"@types/node@6.0.*", "@types/node@^6", "@types/node@^6.0.0", "@types/node@^6.0.31", "@types/node@^6.0.41":
   version "6.0.65"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-6.0.65.tgz#c00faa7ffcfc9842b5dd7bf650872562504d5670"
 
@@ -5137,16 +5137,7 @@ polymer-linter@1.0.1:
     polymer-analyzer "2.0.0-alpha.34"
     strip-indent "^2.0.0"
 
-polymer-project-config@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/polymer-project-config/-/polymer-project-config-2.0.1.tgz#95f262fa6246c09d92e49914232543722255fc17"
-  dependencies:
-    "@types/node" "^6.0.41"
-    jsonschema "^1.1.1"
-    minimatch-all "^1.1.0"
-    plylog "^0.5.0"
-
-polymer-project-config@^2.1.0:
+polymer-project-config@^2.0.0, polymer-project-config@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/polymer-project-config/-/polymer-project-config-2.1.0.tgz#8ee3fea5bcb38ca945fa5688e6ccd751e4f942c0"
   dependencies:


### PR DESCRIPTION
Because this is already being done downstream, we might as well announce it in Polymer CLI and make it explicit so that no one is surprised.

If we see demand from users for the latest tagged version of the CLI that still supports Node v4, we should branch from the commit right before polymer-build@v1.0.0 was updated and create a new npm `node4` release tag so that users can `npm install -g polymer-cli@node4`. But it's still tbd if the demand for this is there.