### PR TITLE
reenable some integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,3 +13,4 @@ node_js:
   - "6"
 script:
   - xvfb-run npm test
+  - xvfb-run npm run test:integration

--- a/package.json
+++ b/package.json
@@ -12,8 +12,9 @@
   "scripts": {
     "lint": "gulp lint",
     "build": "gulp build",
-    "test": "gulp lint test && gulp test:integration",
+    "test": "gulp lint test",
     "test:smoke": "gulp test",
+    "test:integration": "gulp test:integration",
     "format": "find src test gulpfile.js \\( -iname '*.ts' -o -iname '*.js' \\) -not -path '*fixtures*' | xargs clang-format --style=file -i"
   },
   "repository": {

--- a/src/init/element/templates/polymer-2.x/_element.html
+++ b/src/init/element/templates/polymer-2.x/_element.html
@@ -33,6 +33,6 @@
       }
     }
 
-    window.customElements.define(MyElement.is, MyElement);
+    window.customElements.define(<%= elementClassName %>.is, <%= elementClassName %>);
   </script>
 </dom-module>

--- a/test/integration/integration_test.js
+++ b/test/integration/integration_test.js
@@ -45,7 +45,7 @@ suite('integration tests', function() {
           .then((_dir) => {dir = _dir})
           .then(() => runCommand(binPath, ['install'], {cwd: dir}))
           .then(() => runCommand(binPath, ['lint'], {cwd: dir}))
-          // .then(() => runCommand(binPath, ['test'], {cwd: dir}))
+          .then(() => runCommand(binPath, ['test'], {cwd: dir}))
           .then(() => runCommand(binPath, ['build'], {cwd: dir}));
     });
 
@@ -57,7 +57,7 @@ suite('integration tests', function() {
           .then((_dir) => {dir = _dir})
           .then(() => runCommand(binPath, ['install'], {cwd: dir}))
           .then(() => runCommand(binPath, ['lint'], {cwd: dir}))
-          // .then(() => runCommand(binPath, ['test'], {cwd: dir}))
+          .then(() => runCommand(binPath, ['test'], {cwd: dir}))
           .then(() => runCommand(binPath, ['build'], {cwd: dir}));
     });
 
@@ -69,7 +69,7 @@ suite('integration tests', function() {
           .then((_dir) => {dir = _dir})
           .then(() => runCommand(binPath, ['install'], {cwd: dir}))
           .then(() => runCommand(binPath, ['lint'], {cwd: dir}))
-      // .then(() => runCommand(binPath, ['test'], {cwd: dir}));
+          .then(() => runCommand(binPath, ['test'], {cwd: dir}));
     });
 
     test('test the Polymer 1.x "element" template', () => {
@@ -80,7 +80,7 @@ suite('integration tests', function() {
           .then((_dir) => {dir = _dir})
           .then(() => runCommand(binPath, ['install'], {cwd: dir}))
           .then(() => runCommand(binPath, ['lint'], {cwd: dir}))
-      // .then(() => runCommand(binPath, ['test'], {cwd: dir}));
+          .then(() => runCommand(binPath, ['test'], {cwd: dir}));
     });
 
     test('test the "shop" template', () => {


### PR DESCRIPTION
#672 We've seen a few issues now about broken tests due to our work on the 8+ bundled templates, and I just realized those integration tests are still commented out. This PR uncomments them.

Re-enabling these locally made `npm test` take several minutes longer, so I'm experimenting with moving them out of `npm test` and into a separate `npm run test:integration` command. Travis will still run them by default.