### PR TITLE
updated README for v0.18.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,79 +3,49 @@
 [![Build Status](https://travis-ci.org/Polymer/polymer-cli.svg?branch=master)](https://travis-ci.org/Polymer/polymer-cli)
 [![Build status](https://ci.appveyor.com/api/projects/status/3xc7rkapu39rw9fs/branch/master?svg=true)](https://ci.appveyor.com/project/justinfagnani/polymer-cli/branch/master)
 
-A command-line tool for Polymer projects.
+The command-line tool for Polymer projects and Web Components.
 
-For detailed help, check out the
-[Polymer CLI](https://www.polymer-project.org/1.0/docs/tools/polymer-cli)
-guide.
+## Features
 
-## Overview
+  - **init** - Initialize a Polymer project from custom templates
+  - **install** - Install bower dependencies as well as [dependency variants](https://www.polymer-project.org/2.0/docs/glossary#dependency-variants) for testing
+  - **serve**	- Serve elements and applications locally
+  - **lint** - Lint a project to catch errors before your users
+  - **test** - Test your project with [`web-component-tester`](https://github.com/Polymer/web-component-tester/)
+  - **build**	- Build an application optimized for production
+  - **analyze** - Generate an analyzed JSON representation of your element or application
 
-Polymer-CLI includes a number of tools for working with Polymer and Web Components:
+> **For a detailed overview of the CLI, how it works and when to use it, check out the official
+[Polymer CLI guide](https://www.polymer-project.org/2.0/docs/tools/polymer-cli).**
+> This README will focus on the individual CLI commands and how to run them.
 
-  * __init__ - Initializes a Polymer project from one of several templates
-  * __build__	- Builds an application-style project
-  * __lint__ - Lints the project
-  * __serve__	- Runs a development server
-  * __test__ - Runs tests with web-component-tester
 
 ## Installation
 
-Install via npm:
+```bash
+$ npm install -g polymer-cli
+# or...
+$ yarn add global polymer-cli
+```
 
-    $ npm install -g polymer-cli
-
-Then run via `polymer <command>`:
-
-    $ polymer help
-
-## Project Structure
-
-Polymer-CLI is somewhat opinionated about project structure.
-
-There are two type of projects:
-
-* Elements projects
-
-  Element projects contain one or more reusable element definitions, intended to be used from other elements, applications or pages. Element definitions live at the top level of the project so they are easy to import. Elements import their dependencies with relative paths that reference sibling folders to the project folder.
-
-* Application projects
-
-  Application projects are self-contained and intended to be deployed as a standalone website. Application projects contain elements in a `src/` folder and import their dependencies with absolute paths, or relative paths that reference folders inside the project folder.
-
-### Application Styles
-
-Polymer-CLI currently supports two styles of applications:
-
-  * Monolithic applications, which have a single entrypoint (usually index.html) and eagerly import all dependencies.
-
-  * "App shell" applications, which have a very lightweight entrypoint, an app-shell with startup and routing logic, and possibly lazy loaded fragments.
-
-### App-shell Structure
-
-App-shell apps are currently the preferred style for Polymer CLI, and most commands are being optimized to support them. App-shell apps usually have client-side routing (see the [app-route](https://github.com/PolymerElements/app-route) element), and lazy load parts of the UI on demand.
-
-Polymer-CLI supports this style by understand these different types of files:
-
-  * entrypoint - The first file served by the web server for every valid route (usually index.html). This file should be very small, since it may not cache well and must reference resources with absolute URLs, due to being served from many URLs.
-  * shell - The actual app shell, which includes the top-level logic, routing, and so on.
-  * fragments - lazy loaded parts of the application, typically views and other elements loaded on-demand.
 
 ## Configuration
 
-The project files are specified either as global flags: `--entrypoint`, `--shell` and zero or more `--fragment` flags, or in a `polymer.json` configuration file.
+An application can be configured for all commands via global flags: `--entrypoint`, `--shell`, etc.
 
-### polymer.json
+We recommend saving your configuration to a `polymer.json` configuration file in your project so that they can be read automatically for every command. Other project settings, like build and lint rules, can also be defined here. Read the [polymer.json spec](https://www.polymer-project.org/2.0/docs/tools/polymer-json) for a full list of all supported configurations.
 
-You can specify the project files in `polymer.json` so that commands like `polymer build` work without flags:
+Below is an example of a simple `polymer.json` application configuration:
 
 ```json
 {
   "entrypoint": "index.html",
-  "shell": "src/my-app/my-app.html",
+  "shell": "src/my-app.html",
   "fragments": [
-    "src/app-home/app-home.html",
-    "src/app-view-1/app-view-1.html",
+    "src/app-home.html",
+    "src/app-view-1.html",
+    "src/app-view-2.html",
+    "src/app-view-3.html",
   ],
   "sources": [
     "src/**/*",
@@ -89,203 +59,101 @@ You can specify the project files in `polymer.json` so that commands like `polym
 }
 ```
 
-## Dependency Variants
 
-A number of commands use a concept called "dependency variants", which are different sets of dependencies that the project should work with.
+## Command Overview
 
-Typically, when a project can work with a wide range of major versions of
-dependencies, tests are only run against the most recent versions of the
-dependencies. This leaves compatibility with older versions untested. With
-dependency variants you can specify a a number of narrower sets of versions
-to test against to ensure compatibility.
+### `polymer help [COMMAND]`
 
-Variants are specified in a `"variants"` property of `bower.json`. `"variants"`
-is a map of variant name to a patch that's applied to the rest of `bower.json`.
-Each property in a variant overwrites a property in `bower.json` if the property
-is a simple value or an Array, otherwise if the property is an Object, it's
-merged.
+Run `polymer help` to get a helpful list of supported commands. Pass it a command name (ex: `polymer help serve`) to get detailed information about that command and the options it supports.
 
-The result of patching a variant into the `bower.json` is used to perform a
-separate Bower install into a directory named `bower_components-{variant_name}`.
 
-Example:
+### `polymer init [TEMPLATE]`
 
-```json
-{
-  "name": "example",
-  "dependencies": {
-    "polymer": "Polymer/polymer#1.7 - 2.x",
-    "foobar": "Foo/bar#^2.0.0"
-  },
-  "variants": {
-    "polymer-1": {
-      "dependencies": {
-        "polymer": "Polymer/polymer#^1.7.0"
-      }
-    },
-    "polymer-2": {
-      "dependencies": {
-        "polymer": "Polymer/polymer#^2.0.0"
-      }
-    }
-  }
-}
-```
+Initializes a Polymer project from one of several templates. Pre-bundled templates range from just bare-bones to fully featured applications like the [Polymer Starter Kit](https://github.com/PolymerElements/polymer-starter-kit).
 
-When using `polymer install --variants`, this results in two additional folders,
-`bower_components-polymer-1` and `bower_components-polymer-2`, installed as if
-they had their own `bower.json` files as follows:
+You can download and run templates built by our community as well. [Search npm](https://www.npmjs.com/search?q=generator-polymer-init) for a template you'd like to use. Then install it and the CLI will pick it up automatically.
 
-`bower_components-polymer-1`:
+Run `polymer init` to choose a template from a list of all installed templates. Or if you know the template name before hand, you can provide it as a command argument.
+
+
+### `polymer install [--variants]`
+
+Install your dependencies, similar to running `bower install`.
+
+If the `--variants` option is provided, the command will also search your project's `bower.json` for  a `"variants"` property and install any [dependency variants](https://www.polymer-project.org/2.0/docs/glossary#dependency-variants) listed there as well as well. This is useful if you need to test your elements against multiple versions of Polymer and/or sets of dependencies.
+
+
+### `polymer serve [options...]`
+
+Start a development server designed for serving Polymer & Web Component projects. Applications are served as-is, while elements are served from a special route where it can properly reference its dependencies.
+
+Run `polymer help serve` for the full list of available options.
+
+
+### `polymer lint [--rules RULE_SET] [options...]`
+
+Lint your project for common errors. Provide a set of linting rules via either your `polymer.json` configuration file or the `--rules` command option.
+
+For example, if you wanted to lint a Polymer 2.0 Hybrid element, you would run `polymer lint --rules polymer-2-hybrid`. To make sure the correct rule set is always used, you should add the following field to your `polymer.json`:
 
 ```json
-{
-  "name": "example",
-  "dependencies": {
-    "polymer": "Polymer/polymer#^1.7.0",
-    "foobar": "Foo/bar#^2.0.0"
-  }
-}
+"lint": {
+  "rules": [
+    "polymer-2-hybrid"
+  ]
+},
 ```
 
-`bower_components-polymer-2`:
+Run `polymer help lint` for the full list of available options.
+
+
+### `polymer test [options...]`
+
+Run your element or application tests with [`web-component-tester`](https://github.com/Polymer/web-component-tester/).
+
+Run `polymer help test` for the full list of available options.
+
+
+### `polymer build [options...]`
+
+Build a Polymer application for production. This includes support for site optimizations like code bundling, minification, and ES6 compilation to run on older browsers.
+
+Most optimizations and production enhancements are disabled by default. To make sure the correct build enhancements are always used, you can provide a set of build configurations via the ["builds"](https://www.polymer-project.org/2.0/docs/tools/polymer-json#builds) field of your `polymer.json` file:
 
 ```json
-{
-  "name": "example",
-  "dependencies": {
-    "polymer": "Polymer/polymer#^2.0.0",
-    "foobar": "Foo/bar#^2.0.0"
-  }
-}
+"builds": [{
+  "bundle": true,
+  "js": {"minify": true},
+  "css": {"minify": true},
+  "html": {"minify": true}
+}],
 ```
 
-Commands like `install`, `serve` and `test` recognize that variants are
-installed to offer additional support.
+Run `polymer help build` for the full list of available options & optimizations.
 
-`polymer install --variants` installs dependency variants into the proper
-folders.
-
-`polymer serve` will start up a development server for
-each variant on its own port so that you can easily switch between variants,
-viewing their demos and tests.
-
-`polymer test` will run the test suite once for each variant, ensuring that you
-have test coverage against supported configurations.
-
-## Commands
-
-### help
-
-Displays help on commands and options:
-
-    $ polymer help
-
-### init
-
-Initializes a Polymer project from one of several templates.
-
-Choose a template from a menu:
-
-    $ polymer init
-
-Create a new project from the 'element' template:
-
-    $ polymer init element
-
-You can download and run templates built by our community as well. [Search npm](https://www.npmjs.com/search?q=generator-polymer-init) for the full list.
-
-### install
-
-Installs Bower dependencies, optionally installing multiple variants.
-
-    $ polymer install
-
-This performs a Bower install of dependencies listed in `bower.json`, and is
-equivalent to `bower install`.
-
-    $ polymer install --variants
-
-This performs a Bower install, and also installs any dependency variants
-specified in the `"variants"` property of `bower.json`. See
-[Dependency Variants](#dependency-variants) above.
-
-### lint
-
-Add a "lint" section to your `polymer.json` file at the root of your project:
-
-```json
-{
-  "lint": {
-    "rules": [
-      "polymer-2-hybrid"
-    ]
-  }
-}
-```
-
-Then just
-
-    $ polymer lint
-
-You can also list specific files to lint and rules to use on the command line:
-
-    $ polymer lint --rules polymer-2-hybrid --input ./my-element.html
-
-### test
-
-Run test with web-component-tester:
-
-    $ polymer test
-
-### build
-
-Specify project files as flags:
-
-    $ polymer build --entrypoint index.html --shell src/my-app/my-app.html
-
-Use `index.html` as the entrypoint, or read from `polymer.json`:
-
-    $ polymer build
-
-`build` is opinionated and defaults to a good build for app-shell apps. It writes the built output to `build/bundled` and `build/unbundled` folders. Both outputs have been run though HTML, JS and CSS optimizers, and have a Service Worker generated for them. The bundled folder contains the application files process by Vulcanize, Polymer's HTML bundler, for optimal loading via HTTP/1. The unbundled folder is optimized for HTTP/2 + Push.
-
-While the build command should support most projects, some users will need greater control over their build pipeline. If that's you, check out the [polymer-build](https://github.com/Polymer/polymer-build) library. Polymer-build can be called and customized programmatically, giving you much greater control than the CLI can provide. Visit the repo for usage information and examples.
-
-#### --js-compile
-
-When your application uses the `--js-compile` CLI flag (or polymer.json config property) your application is compiled from ES6 to ES5. For this to work properly, some older browsers need the `custom-elements-es5-adapter.js` shim in addition to the `webcomponents-loader.js`/`webcomponents-lite.js` polyfill. The build process will automatically inject this ES5 adapter into your application when `--js-compile` is enabled so that your application works as expected on older browsers.
+If you need support for something that is missing from the CLI, check out the [polymer-build](https://github.com/Polymer/polymer-build) library. Is the JS library that powers the CLI, and calling it directly gives you much greater control than the CLI can provide. Visit the repo for usage information and examples.
 
 
-### serve
+### `polymer analyze [options...]`
 
-Start the development server:
+Generates an analyzed JSON representation of your element or project. This can be useful if you are working with other tooling that requires a cached analysis of your project.
 
-    $ polymer serve
+Run `polymer help analyze` for the full list of available options.
 
-Start the development server, and open the default browser:
 
-    $ polymer serve -o
+## Supported Node.js Versions
 
-By default the server listens to `localhost`. To listen to a different address use the `--hostname` flag. For example:
-
-    $ polymer serve -o --hostname 0.0.0.0
-
-## Templates and Generators
-
-Polymer-CLI initializes new projects with the `init` command, and includes
-a few built-in templates.
-
-New templates can be distributed and installed via npm. Yeoman generators
-prefixed with `generator-polymer-init` will show up in the `polymer init`
-menu.
+Polymer CLI supports the [current & active LTS versions](https://github.com/nodejs/LTS) of Node.js and later. See the [Polymer Tools Node.js Support Policy](https://www.polymer-project.org/2.0/docs/tools/node-support) for more information.
 
 ## Compiling from Source
 
-    $ npm run build
-
 You can compile and run the CLI from source by cloning the repo from Github and then running `npm run build`. But make sure you have already run `npm install` before building.
 
-## Supported node.js versions
+```bash
+# clone the repo from github
+npm install
+npm run build
+npm link # link your local copy of the CLI to your terminal path
+```
 
-Polymer CLI targets the current LTS version (4.x) of Node.js and later.
+

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ The command-line tool for Polymer projects and Web Components.
 
   - **init** - Create a new Polymer project from pre-configured starter templates
   - **install** - Install bower dependencies as well as [dependency variants](https://www.polymer-project.org/2.0/docs/glossary#dependency-variants) for testing
-  - **serve**	- Serve elements and applications locally
-  - **lint** - Lint a project to catch errors before your users do
+  - **serve**	- Serve elements and applications during development
+  - **lint** - Lint a project to find and diagnose errors quickly
   - **test** - Test your project with [`web-component-tester`](https://github.com/Polymer/web-component-tester/)
   - **build**	- Build an application optimized for production
   - **analyze** - Generate an analyzed JSON representation of your element or application
@@ -23,17 +23,18 @@ The command-line tool for Polymer projects and Web Components.
 ## Installation
 
 ```bash
-$ npm install -g polymer-cli
-# or...
 $ yarn add global polymer-cli
+# or...
+$ npm install -g polymer-cli
 ```
 
+For best results and a faster installation, we reccomend installing with [yarn](https://yarnpkg.com/en/).
 
 ## Configuration
 
 An application can be configured for all commands via global flags: `--entrypoint`, `--shell`, etc.
 
-We recommend saving your configuration to a `polymer.json` configuration file in your project so that they can be read automatically for every command. Other project settings, like build and lint rules, can also be defined here. Read the [polymer.json spec](https://www.polymer-project.org/2.0/docs/tools/polymer-json) for a full list of all supported configurations.
+We recommend saving your configuration to a `polymer.json` configuration file in your project so that they can be read automatically for every command. Other project settings, like build and lint rules, can also be defined here. Read the [polymer.json spec](https://www.polymer-project.org/2.0/docs/tools/polymer-json) for a full list of all supported fields.
 
 Below is an example of a simple `polymer.json` application configuration:
 
@@ -67,7 +68,7 @@ Below is an example of a simple `polymer.json` application configuration:
 Run `polymer help` to get a helpful list of supported commands. Pass it a command name (ex: `polymer help serve`) to get detailed information about that command and the options it supports.
 
 
-### `polymer init [TEMPLATE]`
+### `polymer init`
 
 Initializes a Polymer project from one of several templates. Pre-bundled templates range from just bare-bones to fully featured applications like the [Polymer Starter Kit](https://github.com/PolymerElements/polymer-starter-kit).
 
@@ -87,14 +88,14 @@ If the `--variants` option is provided, the command will also search your projec
 
 Start a development server designed for serving Polymer & Web Component projects. Applications are served as-is, while elements are served from a special route where it can properly reference its dependencies.
 
+Additionally, the development server will automatically use [Babel](https://babeljs.io) to transpile any ES6 code down to ES5 for browsers that don't have native support for important ES6 features like classes.
+
 Run `polymer help serve` for the full list of available options.
 
 
 ### `polymer lint [--rules RULE_SET] [options...]`
 
-Lint your project for common errors. Provide a set of linting rules via either your `polymer.json` configuration file or the `--rules` command option.
-
-For example, if you wanted to lint a Polymer 2.0 Hybrid element, you would run `polymer lint --rules polymer-2-hybrid`. To make sure the correct rule set is always used, you should add the following field to your `polymer.json`:
+Lint your project for common errors. Specify a set of linting rules via the `--rules` command option or your `polymer.json` configuration. To make sure you always use the correct rule set, we reccomend adding a "lint" section to your polymer.json like so:
 
 ```json
 "lint": {
@@ -104,7 +105,7 @@ For example, if you wanted to lint a Polymer 2.0 Hybrid element, you would run `
 },
 ```
 
-Run `polymer help lint` for the full list of available options.
+Run `polymer help lint` for the full list of available options and rule sets.
 
 
 ### `polymer test [options...]`
@@ -116,9 +117,9 @@ Run `polymer help test` for the full list of available options.
 
 ### `polymer build [options...]`
 
-Build a Polymer application for production. This includes support for site optimizations like code bundling, minification, and ES6 compilation to run on older browsers.
+Build a Polymer application for production. This includes support for optimizations like code bundling, minification, and ES6 compilation to run on older browsers.
 
-Most optimizations and production enhancements are disabled by default. To make sure the correct build enhancements are always used, you can provide a set of build configurations via the ["builds"](https://www.polymer-project.org/2.0/docs/tools/polymer-json#builds) field of your `polymer.json` file:
+Most optimizations are disabled by default. To make sure the correct build enhancements are always used, you can provide a set of build configurations via the ["builds"](https://www.polymer-project.org/2.0/docs/tools/polymer-json#builds) field of your `polymer.json` file:
 
 ```json
 "builds": [{

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ $ yarn add global polymer-cli
 $ npm install -g polymer-cli
 ```
 
-For best results and a faster installation, we recommend installing with [yarn](https://yarnpkg.com/en/).
+For best results and a faster installation, we recom,end installing with [yarn](https://yarnpkg.com/en/).
 
 ## Configuration
 
@@ -48,7 +48,7 @@ Below is an example of a simple `polymer.json` application configuration:
     "src/app-view-2.html",
     "src/app-view-3.html"
   ],
-  "sourceGlobs": [
+  "sources": [
     "src/**/*",
     "images/**/*",
     "bower.json"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The command-line tool for Polymer projects and Web Components.
 ## Features
 
   - **init** - Create a new Polymer project from pre-configured starter templates
-  - **install** - Install bower dependencies as well as [dependency variants](https://www.polymer-project.org/2.0/docs/glossary#dependency-variants) for testing
+  - **install** - Install dependencies and [dependency variants](https://www.polymer-project.org/2.0/docs/glossary#dependency-variants) via Bower
   - **serve**	- Serve elements and applications during development
   - **lint** - Lint a project to find and diagnose errors quickly
   - **test** - Test your project with [`web-component-tester`](https://github.com/Polymer/web-component-tester/)

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ $ yarn add global polymer-cli
 $ npm install -g polymer-cli
 ```
 
-For best results and a faster installation, we reccomend installing with [yarn](https://yarnpkg.com/en/).
+For best results and a faster installation, we recommend installing with [yarn](https://yarnpkg.com/en/).
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Here's a brief summary of the configuration options you can use to describe your
   - `root` (Defaults to current working directory): The web root of your application, can be a subfolder of your project directory.
   - `sources` (Defaults to `src/**/*`): The source files in your application.
 
-Configuration can be passed for all commands via the global CLI: `--entrypoint`, `--shell`, etc. However we recommend saving your configuration to a `polymer.json` configuration file in your project. This guarantees a single shared configuration that will be read automatically for every command. Other project settings, like build and lint rules, can also be defined here.
+Configuration can be passed to all commands via global CLI flags: `--entrypoint`, `--shell`, etc. However we recommend saving your configuration to a `polymer.json` configuration file in your project. This guarantees a single shared configuration that will be read automatically for every command. Other project settings, like build and lint rules, can also be defined here.
 
 Read the [polymer.json spec](https://www.polymer-project.org/2.0/docs/tools/polymer-json) for a full list of all supported fields with examples.
 
@@ -56,13 +56,13 @@ Read the [polymer.json spec](https://www.polymer-project.org/2.0/docs/tools/poly
 Run `polymer help` to get a helpful list of supported commands. Pass it a command name (ex: `polymer help serve`) to get detailed information about that command and the options it supports.
 
 
-### `polymer init`
+### `polymer init [TEMPLATE]`
 
 Initializes a Polymer project from one of several templates. Pre-bundled templates range from just bare-bones to fully featured applications like the [Polymer Starter Kit](https://github.com/PolymerElements/polymer-starter-kit).
 
 You can download and run templates built by our community as well. [Search npm](https://www.npmjs.com/search?q=generator-polymer-init) for a template you'd like to use. Then install it and the CLI will pick it up automatically.
 
-Run `polymer init` to choose a template from a list of all installed templates. Or if you know the template name before hand, you can provide it as a command argument.
+Run `polymer init` to choose a template from a list of all installed templates. Or, if you know the template name before hand, you can provide it as a command argument to select it automatically.
 
 
 ### `polymer install [--variants]`

--- a/README.md
+++ b/README.md
@@ -46,14 +46,14 @@ Below is an example of a simple `polymer.json` application configuration:
     "src/app-home.html",
     "src/app-view-1.html",
     "src/app-view-2.html",
-    "src/app-view-3.html",
+    "src/app-view-3.html"
   ],
-  "sources": [
+  "sourceGlobs": [
     "src/**/*",
     "images/**/*",
     "bower.json"
   ],
-  "includeDependencies": [
+  "extraDependencies": [
     "bower_components/additional-files-to-include-in-build/**/*",
     "bower_components/webcomponentsjs/webcomponents-lite.js"
   ]
@@ -95,7 +95,7 @@ Run `polymer help serve` for the full list of available options.
 
 ### `polymer lint [--rules RULE_SET] [options...]`
 
-Lint your project for common errors. Specify a set of linting rules via the `--rules` command option or your `polymer.json` configuration. To make sure you always use the correct rule set, we reccomend adding a "lint" section to your polymer.json like so:
+Lint your project for common errors. Specify a set of linting rules via the `--rules` command option or your `polymer.json` configuration. To make sure you always use the correct rule set, we recommend adding a "lint" section to your polymer.json like so:
 
 ```json
 "lint": {

--- a/README.md
+++ b/README.md
@@ -32,33 +32,21 @@ For best results and a faster installation, we recommend installing with [yarn](
 
 ## Configuration
 
-An application can be configured for all commands via global flags: `--entrypoint`, `--shell`, etc.
+No configuration is required to use the Polymer CLI to develop a standalone element.
 
-We recommend saving your configuration to a `polymer.json` configuration file in your project so that they can be read automatically for every command. Other project settings, like build and lint rules, can also be defined here. Read the [polymer.json spec](https://www.polymer-project.org/2.0/docs/tools/polymer-json) for a full list of all supported fields.
+When developing a web application, defining some configuration is recommended. Simple applications may work with the CLI's default settings, but following the [Application Shell Architecture](https://developers.google.com/web/updates/2015/11/app-shell) for your app and manually defining an application shell and fragments will give you the best performance in production.
 
-Below is an example of a simple `polymer.json` application configuration:
+Here's a brief summary of the configuration options you can use to describe your web application structure:
 
-```json
-{
-  "entrypoint": "index.html",
-  "shell": "src/my-app.html",
-  "fragments": [
-    "src/app-home.html",
-    "src/app-view-1.html",
-    "src/app-view-2.html",
-    "src/app-view-3.html"
-  ],
-  "sources": [
-    "src/**/*",
-    "images/**/*",
-    "bower.json"
-  ],
-  "extraDependencies": [
-    "bower_components/additional-files-to-include-in-build/**/*",
-    "bower_components/webcomponentsjs/webcomponents-lite.js"
-  ]
-}
-```
+  - [`entrypoint`](https://www.polymer-project.org/2.0/docs/tools/polymer-json#entrypoint) (Defaults to `index.html`): The main entrypoint to your app.
+  - [`shell`](https://www.polymer-project.org/2.0/docs/tools/polymer-json#shell) (Optional): The app shell.
+  - [`fragments`](https://www.polymer-project.org/2.0/docs/tools/polymer-json#fragments) (Optional): A list of other entrypoints into your application.
+  - `root` (Defaults to current working directory): The web root of your application, can be a subfolder of your project directory.
+  - `sources` (Defaults to `src/**/*`): The source files in your application.
+
+Configuration can be passed for all commands via the global CLI: `--entrypoint`, `--shell`, etc. However we recommend saving your configuration to a `polymer.json` configuration file in your project. This guarantees a single shared configuration that will be read automatically for every command. Other project settings, like build and lint rules, can also be defined here.
+
+Read the [polymer.json spec](https://www.polymer-project.org/2.0/docs/tools/polymer-json) for a full list of all supported fields with examples.
 
 
 ## Command Overview
@@ -88,7 +76,7 @@ If the `--variants` option is provided, the command will also search your projec
 
 Start a development server designed for serving Polymer & Web Component projects. Applications are served as-is, while elements are served from a special route where it can properly reference its dependencies.
 
-Additionally, the development server will automatically use [Babel](https://babeljs.io) to transpile any ES6 code down to ES5 for browsers that don't have native support for important ES6 features like classes.
+By default, the server will automatically use [Babel](https://babeljs.io) to transpile any ES6 code down to ES5 for browsers that don't have native support for important ES6 features like classes. This behavior can be explicitly turned on/off for all browsers via the `--compile` option.
 
 Run `polymer help serve` for the full list of available options.
 
@@ -135,7 +123,7 @@ Run `polymer help build` for the full list of available options & optimizations.
 If you need support for something that is missing from the CLI, check out the [polymer-build](https://github.com/Polymer/polymer-build) library. Is the JS library that powers the CLI, and calling it directly gives you much greater control than the CLI can provide. Visit the repo for usage information and examples.
 
 
-### `polymer analyze [options...]`
+### `polymer analyze [files...]`
 
 Generates an analyzed JSON representation of your element or project. This can be useful if you are working with other tooling that requires a cached analysis of your project.
 
@@ -152,9 +140,9 @@ You can compile and run the CLI from source by cloning the repo from Github and 
 
 ```bash
 # clone the repo from github
-npm install
-npm run build
-npm link # link your local copy of the CLI to your terminal path
+yarn install
+yarn run build
+yarn link # link your local copy of the CLI to your terminal path
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ $ yarn add global polymer-cli
 $ npm install -g polymer-cli
 ```
 
-For best results and a faster installation, we recom,end installing with [yarn](https://yarnpkg.com/en/).
+For best results and a faster installation, we recommend installing with [yarn](https://yarnpkg.com/en/).
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@ The command-line tool for Polymer projects and Web Components.
 
 ## Features
 
-  - **init** - Initialize a Polymer project from custom templates
+  - **init** - Create a new Polymer project from pre-configured starter templates
   - **install** - Install bower dependencies as well as [dependency variants](https://www.polymer-project.org/2.0/docs/glossary#dependency-variants) for testing
   - **serve**	- Serve elements and applications locally
-  - **lint** - Lint a project to catch errors before your users
+  - **lint** - Lint a project to catch errors before your users do
   - **test** - Test your project with [`web-component-tester`](https://github.com/Polymer/web-component-tester/)
   - **build**	- Build an application optimized for production
   - **analyze** - Generate an analyzed JSON representation of your element or application
@@ -80,7 +80,7 @@ Run `polymer init` to choose a template from a list of all installed templates. 
 
 Install your dependencies, similar to running `bower install`.
 
-If the `--variants` option is provided, the command will also search your project's `bower.json` for  a `"variants"` property and install any [dependency variants](https://www.polymer-project.org/2.0/docs/glossary#dependency-variants) listed there as well as well. This is useful if you need to test your elements against multiple versions of Polymer and/or sets of dependencies.
+If the `--variants` option is provided, the command will also search your project's `bower.json` for a `"variants"` property and install any [dependency variants](https://www.polymer-project.org/2.0/docs/glossary#dependency-variants) listed there as well as well. This is useful if you need to test your elements against multiple versions of Polymer and/or sets of dependencies.
 
 
 ### `polymer serve [options...]`

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Run `polymer init` to choose a template from a list of all installed templates. 
 
 Install your dependencies, similar to running `bower install`.
 
-If the `--variants` option is provided, the command will also search your project's `bower.json` for a `"variants"` property and install any [dependency variants](https://www.polymer-project.org/2.0/docs/glossary#dependency-variants) listed there as well as well. This is useful if you need to test your elements against multiple versions of Polymer and/or sets of dependencies.
+If the `--variants` option is provided, the command will also search your project's `bower.json` for a `"variants"` property and install any dependency variants listed there. [Dependency variants](https://www.polymer-project.org/2.0/docs/glossary#dependency-variants) describe alternative sets of dependencies to install alongside your normal `bower_components/` folder. Other CLI commands like `polymer test` and `polymer serve` are able to read these alternative dependency sets and test/serve them in parallel. This is especially useful if you need to test your elements against multiple versions of Polymer and/or other dependencies.
 
 
 ### `polymer serve [options...]`


### PR DESCRIPTION
Resolves #677

README was very out of date, both in terms of CLI behavior and missing references to our new polymer-project.org documentation. I wrote the new README to be more focus and hopefully need less maintenance going forward.

The diff isn't super helpful since it's a rewrite, so here's a link to the full document: https://github.com/Polymer/polymer-cli/blob/ce1255bff15f7e076d364109b918b2cca2710cf5/README.md

Trying to get this merged today if possible for a `latest` release tomorrow, so please review!