### PR TITLE
Pin @types/node to 6.0.65 to fix build in short term.

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
   },
   "devDependencies": {
     "@types/fs-extra": "0.0.37",
-    "@types/node": "^6",
+    "@types/node": "=6.0.65",
     "@polymer/tools-common": "^1.0.1",
     "chai": "^3.5.0",
     "clang-format": "=1.0.48",


### PR DESCRIPTION
- Fixes #679.
- A recent change to @types/node broke some interface compatibility relating to our usage of streams with gulpif (https://github.com/DefinitelyTyped/DefinitelyTyped/commit/915a86f88bc2aad2e1dd59e2fea5edb1603c3cd7#diff-8811b50169fd98160ad78b073b4d0163). Not sure yet what the underlying issue is, so this pins to the version we know works for now.

<!--
  Thanks for the PR!

  If this change has a user visible change (including
  bug fixes, new features, etc) please describe the change in
  CHANGELOG.md.

  If the change is an entirely package-internal reshuffling/refactoring
  should the change not be described in the CHANGELOG.

  Consider also updating the README.

  More info: http://keepachangelog.com/en/0.3.0/
 -->

 - [x] CHANGELOG.md does not need updating
