### PR TITLE
remove ability for CLI to resolve to run a different version of the CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - `serve` now respects the `entrypoint` configured in `polymer.json`.
+- Remove global command-line behavior to run a locally install version of the CLI if it existed in the current working directory. This unexpected behavior was never documented but some users could be running an incorrect version of the CLI as a result.
 
 ## v0.18.0 [04-13-2017]
 

--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
     "polymer-project-config": "^2.1.0",
     "polyserve": "^0.18.0",
     "request": "^2.72.0",
-    "resolve": "^1.1.7",
     "semver": "^5.3.0",
     "tar-fs": "^1.12.0",
     "temp": "^0.8.3",
@@ -82,9 +81,9 @@
     "yeoman-generator": "^1.0.1"
   },
   "devDependencies": {
+    "@polymer/tools-common": "^1.0.1",
     "@types/fs-extra": "0.0.37",
     "@types/node": "=6.0.65",
-    "@polymer/tools-common": "^1.0.1",
     "chai": "^3.5.0",
     "clang-format": "=1.0.48",
     "depcheck": "^0.6.3",

--- a/src/run.ts
+++ b/src/run.ts
@@ -13,24 +13,20 @@
  */
 
 import * as logging from 'plylog';
-import * as resolve from 'resolve';
 import * as updateNotifier from 'update-notifier';
-import * as cliTypeOnly from './polymer-cli';
+import {PolymerCli} from './polymer-cli';
 
 const packageJson = require('../package.json');
-
 const logger = logging.getLogger('cli.main');
-
 
 // Update Notifier: Asynchronously check for package updates and, if needed,
 // notify on the next time the CLI is run.
-// See https://github.com/yeoman/update-notifier#how for how this works.
+// See https://github.com/yeoman/update-notifier#how for info on how this works.
 updateNotifier({pkg: packageJson}).notify();
 
-resolve('polymer-cli', {basedir: process.cwd()}, async(_error, path) => {
-  const lib: typeof cliTypeOnly = path ? require(path) : require('..');
+(async() => {
   const args = process.argv.slice(2);
-  const cli = new lib.PolymerCli(args);
+  const cli = new PolymerCli(args);
   try {
     const result = await cli.run();
     if (result && result.constructor &&
@@ -44,4 +40,4 @@ resolve('polymer-cli', {basedir: process.cwd()}, async(_error, path) => {
     }
     process.exit(1);
   }
-});
+})();

--- a/yarn.lock
+++ b/yarn.lock
@@ -234,15 +234,15 @@
     "@types/bluebird" "*"
     "@types/node" "*"
 
-"@types/node@*", "@types/node@6.0.*", "@types/node@^6", "@types/node@^6.0.0", "@types/node@^6.0.31", "@types/node@^6.0.41":
+"@types/node@*", "@types/node@6.0.*", "@types/node@=6.0.65", "@types/node@^6.0.0", "@types/node@^6.0.31", "@types/node@^6.0.41":
   version "6.0.65"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-6.0.65.tgz#c00faa7ffcfc9842b5dd7bf650872562504d5670"
 
-"@types/node@4.0.30":
+"@types/node@4.0.30", "@types/node@^4.0.30":
   version "4.0.30"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-4.0.30.tgz#553f490ed3030311620f88003e7abfc0edcb301e"
 
-"@types/node@^4.0.30", "@types/node@^4.2.3":
+"@types/node@^4.2.3":
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-4.2.3.tgz#4405d19dcabae1fb0dfc9f267c8de5c114d47ce9"
 
@@ -466,12 +466,6 @@
 "@types/vinyl@*", "@types/vinyl@^2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@types/vinyl/-/vinyl-2.0.0.tgz#fd213bf7f4136dde21fe1895500b12c186f8c268"
-  dependencies:
-    "@types/node" "*"
-
-"@types/vinyl@^1.1.29":
-  version "1.2.30"
-  resolved "https://registry.yarnpkg.com/@types/vinyl/-/vinyl-1.2.30.tgz#9115c0c45c40c575738906be9fb4df6f5b9e5013"
   dependencies:
     "@types/node" "*"
 
@@ -5178,13 +5172,13 @@ polymer-analyzer@2.0.0-alpha.34:
     strip-indent "^2.0.0"
     typescript "^2.2.0"
 
-polymer-build@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/polymer-build/-/polymer-build-1.0.0.tgz#ab16d78681d7a72ff17b9b215035470dab178385"
+polymer-build@1.1.0, polymer-build@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/polymer-build/-/polymer-build-1.1.0.tgz#909050868db9bc913a068ab14b96995c5201e0b5"
   dependencies:
     "@types/node" "^4.2.3"
     "@types/parse5" "^2.2.32"
-    "@types/vinyl" "^1.1.29"
+    "@types/vinyl" "^2.0.0"
     "@types/vinyl-fs" "0.0.28"
     dom5 "^2.0.1"
     multipipe "^1.0.2"
@@ -5292,9 +5286,9 @@ polyserve@0.16.0-prerelease.9:
     spdy "^3.3.3"
     ua-parser-js "^0.7.12"
 
-polyserve@^0.17.0:
-  version "0.17.0"
-  resolved "https://registry.yarnpkg.com/polyserve/-/polyserve-0.17.0.tgz#4d199a9145e134620f9c0c61dffa2fac866551b5"
+polyserve@^0.18.0:
+  version "0.18.0"
+  resolved "https://registry.yarnpkg.com/polyserve/-/polyserve-0.18.0.tgz#6eaf6c1e2ad0eae2d1a30b123a5aabba7cc0225c"
   dependencies:
     "@types/babel-core" "^6.7.14"
     "@types/content-type" "^1.0.33"
@@ -5341,6 +5335,7 @@ polyserve@^0.17.0:
     opn "^3.0.2"
     parse5 "^2.2.3"
     pem "^1.8.3"
+    polymer-build "^1.1.0"
     resolve "^1.0.0"
     send "^0.14.1"
     spdy "^3.3.3"


### PR DESCRIPTION
- Closing the loop on yesterdays CLI wild goose chase into npm by removing this functionality
- This behavior was undocumented and has no useful purpose in our modern CLI.
- Please comment if you are using this behavior for anything / believe it should continue to be supported.
- [X] CHANGELOG.md has been updated

/cc @keanulee 