### PR TITLE
Propagate `description` to `index.html` in application templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- `init`: Propagate `description` from `init` to application templates in `index.html` meta tag.
+
 ## v0.18.1 [04-25-2017]
 
 - `init` small template fixes.

--- a/src/init/application/templates/polymer-1.x/index.html
+++ b/src/init/application/templates/polymer-1.x/index.html
@@ -5,7 +5,9 @@
     <meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
 
     <title><%= name %></title>
-    <meta name="description" content="<%= name %> description">
+    <meta name="description" content="<%
+      if (description) { -%><%= description %><% } else { -%><%= name %> description<% }
+    -%>">
 
     <!-- See https://goo.gl/OOhYW5 -->
     <link rel="manifest" href="/manifest.json">

--- a/src/init/application/templates/polymer-2.x/index.html
+++ b/src/init/application/templates/polymer-2.x/index.html
@@ -5,7 +5,9 @@
     <meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
 
     <title><%= name %></title>
-    <meta name="description" content="<%= name %> description">
+    <meta name="description" content="<%
+      if (description) { -%><%= description %><% } else { -%><%= name %> description<% }
+    -%>">
 
     <!-- See https://goo.gl/OOhYW5 -->
     <link rel="manifest" href="/manifest.json">

--- a/test/unit/init/application_test.js
+++ b/test/unit/init/application_test.js
@@ -52,7 +52,7 @@ suite('init/application', () => {
       });
 
   test(
-      'index.html description meta tag matches description prompt',
+      'index.html description meta tag matches description prompt (1.x)',
       (done) => {
         const TestGenerator = createApplicationGenerator('polymer-1.x');
         const description = 'This is a description entered by the prompt';
@@ -67,9 +67,38 @@ suite('init/application', () => {
       });
 
   test(
-      'index.html description meta tag contains default without prompt',
+      'index.html description meta tag contains default without prompt (1.x)',
       (done) => {
         const TestGenerator = createApplicationGenerator('polymer-1.x');
+        helpers.run(TestGenerator)
+            .withPrompts({name: 'foobar'})
+            .on('end', (a) => {
+              yoAssert.fileContent(
+                  'index.html',
+                  '<meta name="description" content="foobar description">');
+              done();
+            });
+      });
+
+  test(
+      'index.html description meta tag matches description prompt (2.x)',
+      (done) => {
+        const TestGenerator = createApplicationGenerator('polymer-2.x');
+        const description = 'This is a description entered by the prompt';
+        helpers.run(TestGenerator)
+            .withPrompts({name: 'foobar', description: description})
+            .on('end', (a) => {
+              yoAssert.fileContent(
+                  'index.html',
+                  `<meta name="description" content="${description}">`);
+              done();
+            });
+      });
+
+  test(
+      'index.html description meta tag contains default without prompt (2.x)',
+      (done) => {
+        const TestGenerator = createApplicationGenerator('polymer-2.x');
         helpers.run(TestGenerator)
             .withPrompts({name: 'foobar'})
             .on('end', (a) => {

--- a/test/unit/init/application_test.js
+++ b/test/unit/init/application_test.js
@@ -52,6 +52,35 @@ suite('init/application', () => {
       });
 
   test(
+      'index.html description meta tag matches description prompt',
+      (done) => {
+        const TestGenerator = createApplicationGenerator('polymer-1.x');
+        const description = 'This is a description entered by the prompt';
+        helpers.run(TestGenerator)
+            .withPrompts({name: 'foobar', description: description})
+            .on('end', (a) => {
+              yoAssert.fileContent(
+                  'index.html',
+                  `<meta name="description" content="${description}">`);
+              done();
+            });
+      });
+
+  test(
+      'index.html description meta tag contains default without prompt',
+      (done) => {
+        const TestGenerator = createApplicationGenerator('polymer-1.x');
+        helpers.run(TestGenerator)
+            .withPrompts({name: 'foobar'})
+            .on('end', (a) => {
+              yoAssert.fileContent(
+                  'index.html',
+                  '<meta name="description" content="foobar description">');
+              done();
+            });
+      });
+
+  test(
       'ignoring filenames with dangling underscores when generating templates',
       (done) => {
         const TestGenerator = createApplicationGenerator('polymer-1.x');


### PR DESCRIPTION
Propagate `description` entered from command line during `polymer init` for either application template to the `<meta name="description">` tag in `index.html`.

If the user doesn't enter a description, fall back to previous template of:
```html
<meta name="description" content="<app-name> description">
```

I wasn't sure of the best way to format this, so will happily change if wanted.

---
 - [x] CHANGELOG.md has been updated