### PR TITLE
Prevent Warnings from erroring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- `lint` command fails only when error messages are present
+
 ## v0.18.1 [04-25-2017]
 
 - `init` small template fixes.

--- a/src/lint/lint.ts
+++ b/src/lint/lint.ts
@@ -84,6 +84,6 @@ export async function lint(options: Options, config: ProjectConfig) {
       message += ` ${infos.length} ${chalk.green('info')} messages`;
     }
     console.log(`\n\nFound ${message}.`);
-    return new CommandResult(1);
+    return new CommandResult(errors.length ? 1 : 0);
   }
 }

--- a/src/lint/lint.ts
+++ b/src/lint/lint.ts
@@ -84,6 +84,7 @@ export async function lint(options: Options, config: ProjectConfig) {
       message += ` ${infos.length} ${chalk.green('info')} messages`;
     }
     console.log(`\n\nFound ${message}.`);
-    return new CommandResult(errors.length > 0 ? 1 : 0);
+    const shouldLintFail = errors.length > 0;
+    return new CommandResult(shouldLintFail ? 1 : 0);
   }
 }

--- a/src/lint/lint.ts
+++ b/src/lint/lint.ts
@@ -75,15 +75,15 @@ export async function lint(options: Options, config: ProjectConfig) {
     const warnings = filtered.filter((w) => w.severity === Severity.WARNING);
     const infos = filtered.filter((w) => w.severity === Severity.INFO);
     if (errors.length > 0) {
-      message += ` ${errors.length} ${chalk.red('errors')}`;
+      message += ` ${errors.length} ${chalk.red('error(s)')}`;
     }
     if (warnings.length > 0) {
-      message += ` ${warnings.length} ${chalk.yellow('warnings')}`;
+      message += ` ${warnings.length} ${chalk.yellow('warning(s)')}`;
     }
     if (infos.length > 0) {
       message += ` ${infos.length} ${chalk.green('info')} messages`;
     }
-    console.log(`\n\nFound ${message}.`);
+    console.log(`\n\nFound${message}.`);
     const shouldLintFail = errors.length > 0;
     return new CommandResult(shouldLintFail ? 1 : 0);
   }

--- a/src/lint/lint.ts
+++ b/src/lint/lint.ts
@@ -84,6 +84,6 @@ export async function lint(options: Options, config: ProjectConfig) {
       message += ` ${infos.length} ${chalk.green('info')} messages`;
     }
     console.log(`\n\nFound ${message}.`);
-    return new CommandResult(errors.length ? 1 : 0);
+    return new CommandResult(errors.length > 0 ? 1 : 0);
   }
 }

--- a/test/integration/fixtures/lint-with-error/my-elem.html
+++ b/test/integration/fixtures/lint-with-error/my-elem.html
@@ -1,13 +1,19 @@
 <dom-module id="my-elem">
-  <style>
-    /* This should be inside the <template> */
-  </style>
   <template>
-    <div>Hello world</div>
+  <style>
+  /* This should be inside the <template> */
+  </style>
+    <div>[[message]</div>
   </template>
   <script>
     Polymer({
-      is: 'my-elem'
+      is: 'my-elem',
+      properties: {
+        message: {
+          type: String,
+          value: 'Hello world'
+        }
+      }
     });
   </script>
 </dom-module>

--- a/test/integration/fixtures/lint-with-error/my-elem.html
+++ b/test/integration/fixtures/lint-with-error/my-elem.html
@@ -1,8 +1,5 @@
 <dom-module id="my-elem">
   <template>
-  <style>
-  /* This should be inside the <template> */
-  </style>
     <div>[[message]</div>
   </template>
   <script>

--- a/test/integration/fixtures/lint-with-warning/my-elem.html
+++ b/test/integration/fixtures/lint-with-warning/my-elem.html
@@ -1,0 +1,13 @@
+<dom-module id="my-elem">
+  <style>
+    /* This should be inside the <template> */
+  </style>
+  <template>
+    <div>Hello world</div>
+  </template>
+  <script>
+    Polymer({
+      is: 'my-elem'
+    });
+  </script>
+</dom-module>

--- a/test/integration/fixtures/lint-with-warning/polymer.json
+++ b/test/integration/fixtures/lint-with-warning/polymer.json
@@ -1,0 +1,7 @@
+{
+  "lint": {
+    "rules": [
+      "polymer-2-hybrid"
+    ]
+  }
+}

--- a/test/integration/lint_test.js
+++ b/test/integration/lint_test.js
@@ -53,7 +53,7 @@ suite('polymer lint', function() {
       assert.include(
           output, '<style> tags should not be direct children of <dom-module>');
       assert.include(
-          output, 'Found  1 warnings.');
+          output, 'Found 1 warning(s).');
     });
   });
 
@@ -64,7 +64,7 @@ suite('polymer lint', function() {
       assert.include(
           output, 'Invalid polymer expression delimiters.');
       assert.include(
-          output, 'Found  1 errors.');
+          output, 'Found 1 error(s).');
     });
   });
 

--- a/test/integration/lint_test.js
+++ b/test/integration/lint_test.js
@@ -52,6 +52,8 @@ suite('polymer lint', function() {
     return result.then((output) => {
       assert.include(
           output, '<style> tags should not be direct children of <dom-module>');
+      assert.include(
+          output, 'Found  1 warnings.');
     });
   });
 
@@ -61,6 +63,8 @@ suite('polymer lint', function() {
     return invertPromise(result).then((output) => {
       assert.include(
           output, 'Invalid polymer expression delimiters.');
+      assert.include(
+          output, 'Found  1 errors.');
     });
   });
 

--- a/test/integration/lint_test.js
+++ b/test/integration/lint_test.js
@@ -46,12 +46,21 @@ suite('polymer lint', function() {
     return runCommand(binPath, ['lint', '--rules=polymer-2-hybrid'], {cwd});
   });
 
+  test('succeeds when lint warnings are found', () => {
+    const cwd = path.join(fixturePath, 'lint-with-warning');
+    const result = runCommand(binPath, ['lint'], {cwd});
+    return result.then((output) => {
+      assert.include(
+          output, '<style> tags should not be direct children of <dom-module>');
+    });
+  });
+
   test('fails when lint errors are found', () => {
     const cwd = path.join(fixturePath, 'lint-with-error');
     const result = runCommand(binPath, ['lint'], {cwd, failureExpected: true});
     return invertPromise(result).then((output) => {
       assert.include(
-          output, '<style> tags should not be direct children of <dom-module>');
+          output, 'Invalid polymer expression delimiters.');
     });
   });
 


### PR DESCRIPTION
Quick fix to prevent linter from erroring out when warnings and/or info messages are present. 

Ideally would be configurable and I would be happy to take a stab at it. I'm assuming it would be better to make the `minimumSeverity` configurable or add another property for controlling what severity causes failure?

Addresses #699 for the short-term.

<!--
  Thanks for the PR!

  If this change has a user visible change (including
  bug fixes, new features, etc) please describe the change in
  CHANGELOG.md.

  If the change is an entirely package-internal reshuffling/refactoring
  should the change not be described in the CHANGELOG.

  Consider also updating the README.

  More info: http://keepachangelog.com/en/0.3.0/
 -->

 - [x] CHANGELOG.md has been updated
