### PR TITLE
Use a single polymerproject for build, add support for build presets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- `build` Support build configuration "presets".
+- `build` Performance improvements.
+
 ## v0.18.1 [04-25-2017]
 
 - `init` small template fixes.

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "polymer-analyzer": "2.0.0-alpha.34",
     "polymer-build": "1.1.0",
     "polymer-linter": "1.0.1",
-    "polymer-project-config": "^2.1.0",
+    "polymer-project-config": "^3.0.0",
     "polyserve": "^0.18.0",
     "request": "^2.72.0",
     "semver": "^5.3.0",

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -163,20 +163,20 @@ export class BuildCommand implements Command {
     const hasCliArgumentsPassed =
         this.args.some((arg) => typeof options[arg.name] !== 'undefined');
     if (hasCliArgumentsPassed) {
-      return build(commandOptionsToBuildOptions(options), polymerProject);
+      await build(commandOptionsToBuildOptions(options), polymerProject);
+      return;
     }
 
     // If no build flags were passed but 1+ polymer.json build configuration(s)
     // exist, generate a build for each configuration found.
     if (config.builds) {
-      return Promise
-          .all(config.builds.map((buildOptions: ProjectBuildOptions) => {
-            return build(buildOptions, polymerProject);
-          }))
-          .then(() => undefined);
+      await Promise.all(config.builds.map((buildOptions) => {
+        return build(buildOptions, polymerProject);
+      }));
+      return;
     }
 
     // If no builds were defined, just generate a default build.
-    return build({}, polymerProject);
+    await build({}, polymerProject);
   }
 }

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -20,7 +20,8 @@
 import * as delTypeOnly from 'del';
 import * as pathTypeOnly from 'path';
 import * as logging from 'plylog';
-import {ProjectBuildOptions, ProjectConfig} from 'polymer-project-config';
+import {PolymerProject} from 'polymer-build';
+import {applyBuildPreset, ProjectBuildOptions, ProjectConfig} from 'polymer-project-config';
 
 import * as buildLibTypeOnly from '../build/build';
 
@@ -28,6 +29,33 @@ import {Command, CommandOptions} from './command';
 
 
 const logger = logging.getLogger('cli.command.build');
+
+/**
+ * Converts command-line build arguments to the `ProjectBuildOptions` format
+ * that our build understands, applying the preset if one was given.
+ */
+function commandOptionsToBuildOptions(options: CommandOptions):
+    ProjectBuildOptions {
+  return applyBuildPreset({
+    name: options['name'],
+    preset: options['preset'],
+    addServiceWorker: !!options['add-service-worker'],
+    addPushManifest: !!options['add-push-manifest'],
+    swPrecacheConfig: options['sw-precache-config'],
+    insertPrefetchLinks: !!options['insert-prefetch-links'],
+    bundle: !!options['bundle'],
+    html: {
+      minify: !!options['html-minify'],
+    },
+    css: {
+      minify: !!options['css-minify'],
+    },
+    js: {
+      minify: !!options['js-minify'],
+      compile: !!options['js-compile'],
+    },
+  });
+}
 
 
 export class BuildCommand implements Command {
@@ -37,25 +65,37 @@ export class BuildCommand implements Command {
 
   args = [
     {
+      name: 'name',
+      type: String,
+      description: 'The build name. Defaults to "default".',
+    },
+    {
+      name: 'preset',
+      type: String,
+      description: 'A preset configuration to base your build on. ' +
+          'User-defined options will override preset options. Optional. ' +
+          'Available presets: "es5-bundled", "es6-bundled", "es6-unbundled". '
+    },
+    {
       name: 'js-compile',
       type: Boolean,
-      description: 'compile ES2015 JavaScript features down to ES5 for ' +
+      description: 'Compile ES2015 JavaScript features down to ES5 for ' +
           'older browsers.'
     },
     {
       name: 'js-minify',
       type: Boolean,
-      description: 'minify inlined and external JavaScript.'
+      description: 'Minify inlined and external JavaScript.'
     },
     {
       name: 'css-minify',
       type: Boolean,
-      description: 'minify inlined and external CSS.'
+      description: 'Minify inlined and external CSS.'
     },
     {
       name: 'html-minify',
       type: Boolean,
-      description: 'minify HTML by removing comments and whitespace.'
+      description: 'Minify HTML by removing comments and whitespace.'
     },
     {
       name: 'bundle',
@@ -116,50 +156,27 @@ export class BuildCommand implements Command {
     logger.info(`Clearing ${mainBuildDirectoryName}${path.sep} directory...`);
     await del([mainBuildDirectoryName]);
 
+    const polymerProject = new PolymerProject(config);
+
     // If any the build command flags were passed as CLI arguments, generate
     // a single build based on those flags alone.
     const hasCliArgumentsPassed =
         this.args.some((arg) => typeof options[arg.name] !== 'undefined');
     if (hasCliArgumentsPassed) {
-      return build(
-          {
-            addServiceWorker: !!options['add-service-worker'],
-            addPushManifest: !!options['add-push-manifest'],
-            swPrecacheConfig: options['sw-precache-config'],
-            insertPrefetchLinks: !!options['insert-prefetch-links'],
-            bundle: !!options['bundle'],
-            html: {
-              minify: !!options['html-minify'],
-            },
-            css: {
-              minify: !!options['css-minify'],
-            },
-            js: {
-              minify: !!options['js-minify'],
-              compile: !!options['js-compile'],
-            },
-          },
-          config);
+      return build(commandOptionsToBuildOptions(options), polymerProject);
     }
 
-    // If no build configurations were passed via CLI flags or the polymer.json
-    // file, generate a default build.
-    if (!config.builds) {
-      return build({}, config);
+    // If no build flags were passed but 1+ polymer.json build configuration(s)
+    // exist, generate a build for each configuration found.
+    if (config.builds) {
+      return Promise
+          .all(config.builds.map((buildOptions: ProjectBuildOptions) => {
+            return build(buildOptions, polymerProject);
+          }))
+          .then(() => undefined);
     }
 
-    // If a single build was defined or configured via the project config,
-    // generate a build for that configuration.
-    if (config.builds.length === 1) {
-      return build(config.builds[0], config);
-    }
-
-    // If multiple builds were defined or configured via the project config,
-    // generate a build for each configuration.
-    return Promise
-        .all(config.builds.map((buildOptions: ProjectBuildOptions) => {
-          return build(buildOptions, config);
-        }))
-        .then(() => undefined);
+    // If no builds were defined, just generate a default build.
+    return build({}, polymerProject);
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -238,11 +238,11 @@
   version "6.0.65"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-6.0.65.tgz#c00faa7ffcfc9842b5dd7bf650872562504d5670"
 
-"@types/node@4.0.30", "@types/node@^4.0.30":
+"@types/node@4.0.30":
   version "4.0.30"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-4.0.30.tgz#553f490ed3030311620f88003e7abfc0edcb301e"
 
-"@types/node@^4.2.3":
+"@types/node@^4.0.30", "@types/node@^4.2.3":
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-4.2.3.tgz#4405d19dcabae1fb0dfc9f267c8de5c114d47ce9"
 
@@ -5223,9 +5223,18 @@ polymer-linter@1.0.1:
     polymer-analyzer "2.0.0-alpha.34"
     strip-indent "^2.0.0"
 
-polymer-project-config@^2.0.0, polymer-project-config@^2.1.0:
+polymer-project-config@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/polymer-project-config/-/polymer-project-config-2.1.0.tgz#8ee3fea5bcb38ca945fa5688e6ccd751e4f942c0"
+  dependencies:
+    "@types/node" "^6.0.41"
+    jsonschema "^1.1.1"
+    minimatch-all "^1.1.0"
+    plylog "^0.5.0"
+
+polymer-project-config@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/polymer-project-config/-/polymer-project-config-3.0.0.tgz#367edffd95d77353475c672dd6f84881873f3d83"
   dependencies:
     "@types/node" "^6.0.41"
     jsonschema "^1.1.1"


### PR DESCRIPTION
~~*Note: Tests will fail until https://github.com/Polymer/polymer-project-config/pull/17 is merged and released. Checkout locally and `npm link` until then.*~~

- Add support for build configuration "presets" (Design: #714)
- Improves build performance by using a single PolymerProject instance to read sources/deps
- [X] CHANGELOG.md has been updated
