### PR TITLE
New: Add aliases for commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- **New Command Aliases**: Commands now support aliases. `polymer install` has been aliased under `polymer i`.
+
 ## v0.18.1 [04-25-2017]
 
 - `init` small template fixes.

--- a/src/commands/analyze.ts
+++ b/src/commands/analyze.ts
@@ -25,6 +25,7 @@ import {Command, CommandOptions} from './command';
 
 export class AnalyzeCommand implements Command {
   name = 'analyze';
+  aliases = [];
 
   description = 'Writes analysis metadata in JSON format to standard out';
 

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -32,6 +32,7 @@ const logger = logging.getLogger('cli.command.build');
 
 export class BuildCommand implements Command {
   name = 'build';
+  aliases = [];
 
   description = 'Builds an application-style project';
 

--- a/src/commands/command.ts
+++ b/src/commands/command.ts
@@ -22,6 +22,7 @@ export type CommandOptions = {
 
 export interface Command {
   name: string;
+  aliases: string[];
   description: string;
   args: ArgDescriptor[];
   run(options: CommandOptions,

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -96,7 +96,7 @@ export class HelpCommand implements Command {
       {header: 'Global Options', optionList: globalArguments},
     ];
 
-    if (command.aliases.length) {
+    if (command.aliases.length > 0) {
       usageGroups.splice(1, 0, {header: 'Alias(es)', content: command.aliases});
     }
 

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -47,7 +47,7 @@ ${b('\\  /\\')}  ${m('/\\  /')}   ${b('/\\  /')}
 
 export class HelpCommand implements Command {
   name = 'help';
-  aliases = ['h'];
+  aliases = [];
 
   description = 'Shows this help message, or help for a specific command';
 

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -47,6 +47,7 @@ ${b('\\  /\\')}  ${m('/\\  /')}   ${b('/\\  /')}
 
 export class HelpCommand implements Command {
   name = 'help';
+  aliases = ['h'];
 
   description = 'Shows this help message, or help for a specific command';
 
@@ -70,7 +71,7 @@ export class HelpCommand implements Command {
       },
       {
         header: 'Available Commands',
-        content: Array.from(this.commands.values()).map((command) => {
+        content: Array.from(new Set(this.commands.values())).map((command) => {
           return {name: command.name, summary: command.description};
         }),
       },
@@ -94,6 +95,11 @@ export class HelpCommand implements Command {
       {header: 'Command Options', optionList: command.args},
       {header: 'Global Options', optionList: globalArguments},
     ];
+
+    if (command.aliases.length) {
+      usageGroups.splice(1, 0, {header: 'Alias(es)', content: command.aliases});
+    }
+
     return commandLineUsage(usageGroups.concat(extraUsageGroups));
   }
 

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -29,6 +29,7 @@ const logger = logging.getLogger('cli.command.init');
 
 export class InitCommand implements Command {
   name = 'init';
+  aliases = [];
 
   description = 'Initializes a Polymer project';
 

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -25,6 +25,7 @@ import {Command, CommandOptions} from './command';
 
 export class InstallCommand implements Command {
   name = 'install';
+  aliases = ['i'];
 
   // TODO(justinfagnani): Expand and link to eventual doc on variants.
   description = 'installs Bower dependencies, optionally installing "variants"';

--- a/src/commands/lint.ts
+++ b/src/commands/lint.ts
@@ -32,8 +32,6 @@ export interface Options {
 }
 
 export class LintCommand implements Command {
-  // TODO(rictic): rename to 'lint' here and elsewhere, delete
-  // legacy-lint.ts. Also update the README.
   name = 'lint';
   aliases = [];
 

--- a/src/commands/lint.ts
+++ b/src/commands/lint.ts
@@ -35,6 +35,7 @@ export class LintCommand implements Command {
   // TODO(rictic): rename to 'lint' here and elsewhere, delete
   // legacy-lint.ts. Also update the README.
   name = 'lint';
+  aliases = [];
 
   description = 'Identifies potential errors in your code.';
 

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -32,6 +32,7 @@ const logger = logging.getLogger('cli.command.serve');
 
 export class ServeCommand implements Command {
   name = 'serve';
+  aliases = [];
 
   description = 'Runs the polyserve development server';
 

--- a/src/commands/test.ts
+++ b/src/commands/test.ts
@@ -24,6 +24,7 @@ import {Command, CommandOptions} from './command';
 
 export class TestCommand implements Command {
   name = 'test';
+  aliases = [];
 
   description = 'Runs web-component-tester';
 

--- a/src/polymer-cli.ts
+++ b/src/polymer-cli.ts
@@ -127,6 +127,11 @@ export class PolymerCli {
   addCommand(command: Command) {
     logger.debug('adding command', command.name);
     this.commands.set(command.name, command);
+
+    command.aliases.forEach((alias) => {
+      logger.debug('adding alias', alias);
+      this.commands.set(alias, command);
+    });
   }
 
   async run() {

--- a/test/unit/commands/help_test.js
+++ b/test/unit/commands/help_test.js
@@ -28,11 +28,12 @@ suite('help', () => {
         let cli = new PolymerCli(['help', 'build']);
         let helpCommand = cli.commands.get('help');
         let helpCommandSpy = sinon.spy(helpCommand, 'run');
-        cli.run();
-        assert.isOk(helpCommandSpy.calledOnce);
-        assert.deepEqual(
-            helpCommandSpy.firstCall.args,
-            [{command: 'build'}, expectedDefaultConfig]);
+        return cli.run().then(() => {
+          assert.isOk(helpCommandSpy.calledOnce);
+          assert.deepEqual(
+              helpCommandSpy.firstCall.args,
+              [{command: 'build'}, expectedDefaultConfig]);
+        });
       });
 
   test(
@@ -41,10 +42,12 @@ suite('help', () => {
         let cli = new PolymerCli(['help']);
         let helpCommand = cli.commands.get('help');
         let helpCommandSpy = sinon.spy(helpCommand, 'run');
-        cli.run();
-        assert.isOk(helpCommandSpy.calledOnce);
-        assert.deepEqual(
-            helpCommandSpy.firstCall.args, [{}, expectedDefaultConfig]);
+        return cli.run().then(() => {
+          assert.isOk(helpCommandSpy.calledOnce);
+          assert.deepEqual(
+              helpCommandSpy.firstCall.args, [{}, expectedDefaultConfig]);
+        });
+
       });
 
 });

--- a/test/unit/commands/init_test.js
+++ b/test/unit/commands/init_test.js
@@ -30,11 +30,12 @@ suite('init', () => {
     let runGeneratorStub =
         sandbox.stub(polymerInit, 'runGenerator').returns(Promise.resolve());
     let cli = new PolymerCli(['init', 'shop'], null);
-    cli.run();
-    assert.isOk(runGeneratorStub.calledOnce);
-    assert.isOk(runGeneratorStub.calledWith(`polymer-init-shop:app`, {
-      name: 'shop',
-    }));
+    return cli.run().then(() => {
+      assert.isOk(runGeneratorStub.calledOnce);
+      assert.isOk(runGeneratorStub.calledWith(`polymer-init-shop:app`, {
+        name: 'shop',
+      }));
+    });
   });
 
   test(
@@ -44,8 +45,9 @@ suite('init', () => {
             sandbox.stub(polymerInit, 'promptGeneratorSelection')
                 .returns(Promise.resolve());
         let cli = new PolymerCli(['init'], null);
-        cli.run();
-        assert.isOk(promptSelectionStub.calledOnce);
+        return cli.run().then(() => {
+          assert.isOk(promptSelectionStub.calledOnce);
+        });
       });
 
 });

--- a/test/unit/commands/install_test.js
+++ b/test/unit/commands/install_test.js
@@ -1,0 +1,61 @@
+/**
+ * @license
+ * Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt The complete set of authors may be found
+ * at http://polymer.github.io/AUTHORS.txt The complete set of contributors may
+ * be found at http://polymer.github.io/CONTRIBUTORS.txt Code distributed by
+ * Google as part of the polymer project is also subject to an additional IP
+ * rights grant found at http://polymer.github.io/PATENTS.txt
+ */
+
+'use strict';
+
+const path = require('path');
+const assert = require('chai').assert;
+const ProjectConfig = require('polymer-project-config').ProjectConfig;
+const PolymerCli = require('../../../lib/polymer-cli').PolymerCli;
+const sinon = require('sinon');
+
+suite('install', () => {
+  const expectedDefaultConfig = new ProjectConfig({
+    extraDependencies: [path.resolve('bower_components/webcomponentsjs/*.js')],
+  });
+
+  test('runs using full command name', () => {
+    let cli = new PolymerCli(['install']);
+    let installCommand = cli.commands.get('install');
+    let installCommandSpy = sinon.stub(installCommand, 'run');
+    return cli.run().then(() => {
+      assert.isOk(installCommandSpy.calledOnce);
+      assert.deepEqual(
+          installCommandSpy.firstCall.args,
+          [{offline: false, variants: false}, expectedDefaultConfig]);
+    });
+  });
+
+  test('runs using aliased command name', () => {
+    let cli = new PolymerCli(['i']);
+    let installCommand = cli.commands.get('install');
+    let installCommandSpy = sinon.stub(installCommand, 'run');
+    return cli.run().then(() => {
+      assert.isOk(installCommandSpy.calledOnce);
+      assert.deepEqual(
+          installCommandSpy.firstCall.args,
+          [{offline: false, variants: false}, expectedDefaultConfig]);
+    });
+  });
+
+  test('runs using aliased command name with argument', () => {
+    let cli = new PolymerCli(['i', '--variants']);
+    let installCommand = cli.commands.get('install');
+    let installCommandSpy = sinon.stub(installCommand, 'run');
+    return cli.run().then(() => {
+      assert.isOk(installCommandSpy.calledOnce);
+      assert.deepEqual(
+          installCommandSpy.firstCall.args,
+          [{offline: false, variants: true}, expectedDefaultConfig]);
+    });
+  });
+
+});

--- a/test/unit/install/install_test.js
+++ b/test/unit/install/install_test.js
@@ -10,59 +10,11 @@
  */
 'use strict';
 
-const path = require('path');
-const sinon = require('sinon');
 const assert = require('chai').assert;
-const ProjectConfig = require('polymer-project-config').ProjectConfig;
-const PolymerCli = require('../../../lib/polymer-cli').PolymerCli;
 
 const polymerInstall = require('../../../lib/install/install');
 
 suite('install', () => {
-
-  suite('runs command', () => {
-
-    const expectedDefaultConfig = new ProjectConfig({
-      extraDependencies: [path.resolve('bower_components/webcomponentsjs/*.js')],
-    });
-
-    test('using full command name', () => {
-      let cli = new PolymerCli(['install']);
-      let installCommand = cli.commands.get('install');
-      let installCommandSpy = sinon.stub(installCommand, 'run');
-      return cli.run().then(() => {
-        assert.isOk(installCommandSpy.calledOnce);
-        assert.deepEqual(
-            installCommandSpy.firstCall.args,
-            [{offline: false, variants: false}, expectedDefaultConfig]);
-      });
-    });
-
-    test('using aliased command name', () => {
-      let cli = new PolymerCli(['i']);
-      let installCommand = cli.commands.get('install');
-      let installCommandSpy = sinon.stub(installCommand, 'run');
-      return cli.run().then(() => {
-        assert.isOk(installCommandSpy.calledOnce);
-        assert.deepEqual(
-            installCommandSpy.firstCall.args,
-            [{offline: false, variants: false}, expectedDefaultConfig]);
-      });
-    });
-
-    test('using aliased command name with argument', () => {
-      let cli = new PolymerCli(['i', '--variants']);
-      let installCommand = cli.commands.get('install');
-      let installCommandSpy = sinon.stub(installCommand, 'run');
-      return cli.run().then(() => {
-        assert.isOk(installCommandSpy.calledOnce);
-        assert.deepEqual(
-            installCommandSpy.firstCall.args,
-            [{offline: false, variants: true}, expectedDefaultConfig]);
-      });
-    });
-
-  });
 
   suite('_mergeJson', () => {
 

--- a/test/unit/install/install_test.js
+++ b/test/unit/install/install_test.js
@@ -10,11 +10,59 @@
  */
 'use strict';
 
+const path = require('path');
+const sinon = require('sinon');
 const assert = require('chai').assert;
+const ProjectConfig = require('polymer-project-config').ProjectConfig;
+const PolymerCli = require('../../../lib/polymer-cli').PolymerCli;
 
 const polymerInstall = require('../../../lib/install/install');
 
 suite('install', () => {
+
+  suite('runs command', () => {
+
+    const expectedDefaultConfig = new ProjectConfig({
+      extraDependencies: [path.resolve('bower_components/webcomponentsjs/*.js')],
+    });
+
+    test('using full command name', () => {
+      let cli = new PolymerCli(['install']);
+      let installCommand = cli.commands.get('install');
+      let installCommandSpy = sinon.stub(installCommand, 'run');
+      return cli.run().then(() => {
+        assert.isOk(installCommandSpy.calledOnce);
+        assert.deepEqual(
+            installCommandSpy.firstCall.args,
+            [{offline: false, variants: false}, expectedDefaultConfig]);
+      });
+    });
+
+    test('using aliased command name', () => {
+      let cli = new PolymerCli(['i']);
+      let installCommand = cli.commands.get('install');
+      let installCommandSpy = sinon.stub(installCommand, 'run');
+      return cli.run().then(() => {
+        assert.isOk(installCommandSpy.calledOnce);
+        assert.deepEqual(
+            installCommandSpy.firstCall.args,
+            [{offline: false, variants: false}, expectedDefaultConfig]);
+      });
+    });
+
+    test('using aliased command name with argument', () => {
+      let cli = new PolymerCli(['i', '--variants']);
+      let installCommand = cli.commands.get('install');
+      let installCommandSpy = sinon.stub(installCommand, 'run');
+      return cli.run().then(() => {
+        assert.isOk(installCommandSpy.calledOnce);
+        assert.deepEqual(
+            installCommandSpy.firstCall.args,
+            [{offline: false, variants: true}, expectedDefaultConfig]);
+      });
+    });
+
+  });
 
   suite('_mergeJson', () => {
 


### PR DESCRIPTION
<!--
  Thanks for the PR!

  If this change has a user visible change (including
  bug fixes, new features, etc) please describe the change in
  CHANGELOG.md.

  If the change is an entirely package-internal reshuffling/refactoring
  should the change not be described in the CHANGELOG.

  Consider also updating the README.

  More info: http://keepachangelog.com/en/0.3.0/
 -->

Adds aliases to commands to accomplish things like `polymer i` for `polymer install`. Apologies if there is somethings wrong with the TypeScript. Haven't used it before.

### Example Implementation

```
$ polymer install -h

polymer install

  installs Bower dependencies, optionally installing "variants" 

Alias(es)

  i 

Command Options

  --variants    Whether to install variants 
  --offline     Don't hit the network       

Global Options

  --env type                      The environment to use to specialize certain commands, like build     
  --entrypoint                    The main HTML file that will be requested for all routes.             
  --shell string                  The app shell HTML import                                             
  --fragment string[]             HTML imports that are loaded on-demand.                               
  --root string                   The root directory of your project. Defaults to the current working   
                                  directory                                                             
  --sources string[]              Glob(s) that match your project source files. Defaults to `src/**/*`. 
  --extra-dependencies string[]   Glob(s) that match any additional dependencies not caught by the      
                                  analyzer to include with your build.                                  
  -v, --verbose                   turn on debugging output                                              
  -h, --help                      print out helpful usage information                                   
  -q, --quiet                     silence output                                                        
```

### Aliases

- `i` - install (npm supports `isntall` as an alias, not sure if that would be something we would want)


### Not Currently Implemented

In parens just random shots at what could be aliases

- analyze (`a`?)
- build (`b`?)
- help ( `h`?)
- init (`n`?)
- lint (`l`?)
- test (`t`?)
- serve (`s`? `start`?)


Addresses #687 

@FredKSchott @rictic 

### Tasks 

 - [x] CHANGELOG.md has been updated
 - [x] Tests

Taking suggestions for Changelog entry...