### PR TITLE
fix(build): Check if asyncIterator is already assigned.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 - Fix the CLI preset flag.
+- Fix `build` as streams where not working anymore. 
 
 ## v0.18.2 [05-10-2017]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 - Fix the CLI preset flag.
-- Fix `build` as streams where not working anymore. 
+- Fix an issue where compiling JS would crash in versions of node with native async iterators.
 
 ## v0.18.2 [05-10-2017]
 

--- a/src/build/streams.ts
+++ b/src/build/streams.ts
@@ -17,7 +17,9 @@ import * as stream from 'stream';
 
 import File = require('vinyl');
 
-(Symbol as any).asyncIterator = Symbol.asyncIterator || Symbol('asyncIterator');
+if (typeof (Symbol as any).asyncIterator  === 'undefined') {
+  (Symbol as any).asyncIterator = Symbol.asyncIterator || Symbol('asyncIterator');
+}
 
 /**
  * Returns the string contents of a Vinyl File object, waiting for

--- a/src/build/streams.ts
+++ b/src/build/streams.ts
@@ -17,8 +17,8 @@ import * as stream from 'stream';
 
 import File = require('vinyl');
 
-if (typeof (Symbol as any).asyncIterator  === 'undefined') {
-  (Symbol as any).asyncIterator = Symbol.asyncIterator || Symbol('asyncIterator');
+if ((Symbol as any).asyncIterator !== 'undefined') {
+  (Symbol as any).asyncIterator = Symbol('asyncIterator');
 }
 
 /**


### PR DESCRIPTION
Check if the asynIterator is already defined, if not define it.
This fixes my issue in the case that it is already defined somewhere apparently.

closes: #728

 - [x] CHANGELOG.md has been updated
