### PR TITLE
Update for release of 0.18.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## Unreleased
+<!-- ## Unreleased -->
+<!-- Add new, unreleased items here. -->
+
+## v0.18.3 [05-12-2017]
 - Fix the CLI preset flag.
 - Fix an issue where compiling JS would crash in versions of node with native async iterators.
+- `bundle` no longer emits any JS or CSS files which have been inlined into bundles.
 
 ## v0.18.2 [05-10-2017]
 

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "parse5": "^2.2.3",
     "plylog": "^0.4.0",
     "polymer-analyzer": "2.0.0-alpha.42",
-    "polymer-build": "1.2.3",
+    "polymer-build": "1.2.4",
     "polymer-linter": "2.0.1",
     "polymer-project-config": "^3.0.0",
     "polyserve": "^0.19.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2201,8 +2201,8 @@ deep-eql@^0.1.3:
     type-detect "0.1.1"
 
 deep-extend@^0.4.0, deep-extend@~0.4.0, deep-extend@~0.4.1:
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.4.1.tgz#efe4113d08085f4e6f9687759810f807469e2253"
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.4.2.tgz#48b699c27e334bf89f10892be432f6e4c7d34a7f"
 
 deep-is@~0.1.3:
   version "0.1.3"
@@ -4689,9 +4689,13 @@ mime@1.2.11:
   version "1.2.11"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.2.11.tgz#58203eed86e3a5ef17aed2b7d9ebd47f0a60dd10"
 
-mime@1.3.4, mime@^1.2.11, mime@^1.3.4:
+mime@1.3.4:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.3.4.tgz#115f9e3b6b3daf2959983cb38f149a2d40eb5d53"
+
+mime@^1.2.11, mime@^1.3.4:
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-1.3.6.tgz#591d84d3653a6b0b4a3b9df8de5aa8108e72e5e0"
 
 minimalistic-assert@^1.0.0:
   version "1.0.0"
@@ -5368,9 +5372,9 @@ polymer-analyzer@2.0.0-alpha.42:
     strip-indent "^2.0.0"
     typescript "^2.2.0"
 
-polymer-build@1.2.3, polymer-build@^1.1.0:
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/polymer-build/-/polymer-build-1.2.3.tgz#3ad2c49c6596917d09b84fed7252bf272b6074b5"
+polymer-build@1.2.4, polymer-build@^1.1.0:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/polymer-build/-/polymer-build-1.2.4.tgz#731df80b922750a6a4591f7a0f99119914ecd1bc"
   dependencies:
     "@types/node" "^4.2.3"
     "@types/parse5" "^2.2.32"
@@ -5381,15 +5385,15 @@ polymer-build@1.2.3, polymer-build@^1.1.0:
     parse5 "^2.2.2"
     plylog "^0.5.0"
     polymer-analyzer "2.0.0-alpha.42"
-    polymer-bundler "2.0.0-pre.16"
+    polymer-bundler "^2.0.0-pre.17"
     polymer-project-config "^2.0.0"
     sw-precache "^5.1.1"
     vinyl "^1.1.1"
     vinyl-fs "^2.4.3"
 
-polymer-bundler@2.0.0-pre.16:
-  version "2.0.0-pre.16"
-  resolved "https://registry.yarnpkg.com/polymer-bundler/-/polymer-bundler-2.0.0-pre.16.tgz#ee704dcff2d240df14c8941720234c86893f4926"
+polymer-bundler@^2.0.0-pre.17:
+  version "2.0.0-pre.17"
+  resolved "https://registry.yarnpkg.com/polymer-bundler/-/polymer-bundler-2.0.0-pre.17.tgz#e9e16bb80b1eb68dbc067afa5cea0abdba16d047"
   dependencies:
     clone "^2.1.0"
     command-line-args "^3.0.1"
@@ -6634,9 +6638,18 @@ tar-pack@^3.4.0:
     tar "^2.2.1"
     uid-number "^0.0.6"
 
-tar-stream@1.5.2, tar-stream@^1.1.2, tar-stream@^1.5.0:
+tar-stream@1.5.2:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/tar-stream/-/tar-stream-1.5.2.tgz#fbc6c6e83c1a19d4cb48c7d96171fc248effc7bf"
+  dependencies:
+    bl "^1.0.0"
+    end-of-stream "^1.0.0"
+    readable-stream "^2.0.0"
+    xtend "^4.0.0"
+
+tar-stream@^1.1.2, tar-stream@^1.5.0:
+  version "1.5.4"
+  resolved "https://registry.yarnpkg.com/tar-stream/-/tar-stream-1.5.4.tgz#36549cf04ed1aee9b2a30c0143252238daf94016"
   dependencies:
     bl "^1.0.0"
     end-of-stream "^1.0.0"
@@ -7042,9 +7055,13 @@ upper-case@^1.1.1:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/upper-case/-/upper-case-1.1.3.tgz#f6b4501c2ec4cdd26ba78be7222961de77621598"
 
-urijs@1.16.1, urijs@^1.16.1:
+urijs@1.16.1:
   version "1.16.1"
   resolved "https://registry.yarnpkg.com/urijs/-/urijs-1.16.1.tgz#859ad31890f5f9528727be89f1932c94fb4731e2"
+
+urijs@^1.16.1:
+  version "1.18.10"
+  resolved "https://registry.yarnpkg.com/urijs/-/urijs-1.18.10.tgz#b94463eaba59a1a796036a467bb633c667f221ab"
 
 url-parse-lax@^1.0.0:
   version "1.0.0"
@@ -7326,10 +7343,10 @@ which@^1.0.8, which@^1.1.1, which@^1.2.12, which@^1.2.4, which@^1.2.8, which@^1.
     isexe "^2.0.0"
 
 wide-align@^1.1.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/wide-align/-/wide-align-1.1.1.tgz#d2ea8aa2db2e66467e8b60cc3e897de3bc4429e6"
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/wide-align/-/wide-align-1.1.2.tgz#571e0f1b0604636ebc0dfc21b0339bbe31341710"
   dependencies:
-    string-width "^2.0.0"
+    string-width "^1.0.2"
 
 widest-line@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
- Fix the CLI preset flag.
- Fix an issue where compiling JS would crash in versions of node with native async iterators.
- `bundle` no longer emits any JS or CSS files which have been inlined into bundles.
- [x] CHANGELOG.md has been updated
