### PR TITLE
Bump polymer-build version to 1.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "parse5": "^2.2.3",
     "plylog": "^0.4.0",
     "polymer-analyzer": "^2.0.0",
-    "polymer-build": "^1.2.5",
+    "polymer-build": "^1.3.0",
     "polymer-linter": "^2.0.2",
     "polymer-project-config": "^3.0.0",
     "polyserve": "^0.19.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -248,11 +248,11 @@
   version "6.0.65"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-6.0.65.tgz#c00faa7ffcfc9842b5dd7bf650872562504d5670"
 
-"@types/node@4.0.30":
+"@types/node@4.0.30", "@types/node@^4.0.30":
   version "4.0.30"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-4.0.30.tgz#553f490ed3030311620f88003e7abfc0edcb301e"
 
-"@types/node@^4.0.30", "@types/node@^4.2.3":
+"@types/node@^4.2.3":
   version "4.2.8"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-4.2.8.tgz#26fd8fbc5b5ec7822614d950e237956ee92b88cd"
 
@@ -5372,7 +5372,34 @@ polymer-analyzer@^2.0.0:
     strip-indent "^2.0.0"
     typescript "^2.2.0"
 
-polymer-build@^1.1.0, polymer-build@^1.2.5:
+polymer-analyzer@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/polymer-analyzer/-/polymer-analyzer-2.0.1.tgz#37d1556ab55814833677302f65c583960fa44232"
+  dependencies:
+    "@types/chai-subset" "^1.3.0"
+    "@types/chalk" "^0.4.30"
+    "@types/clone" "^0.1.30"
+    "@types/cssbeautify" "^0.3.1"
+    "@types/doctrine" "^0.0.1"
+    "@types/escodegen" "^0.0.2"
+    "@types/estree" "^0.0.34"
+    "@types/node" "^6.0.0"
+    "@types/parse5" "^2.2.34"
+    chalk "^1.1.3"
+    clone "^2.0.0"
+    cssbeautify "^0.3.1"
+    doctrine "^2.0.0"
+    dom5 "^2.1.0"
+    escodegen "^1.7.0"
+    espree "^3.1.7"
+    estraverse "^4.2.0"
+    jsonschema "^1.1.0"
+    parse5 "^2.2.1"
+    shady-css-parser "0.0.8"
+    strip-indent "^2.0.0"
+    typescript "^2.2.0"
+
+polymer-build@^1.1.0:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/polymer-build/-/polymer-build-1.2.5.tgz#0d238429582492250bba8171352b9d96535dc4a7"
   dependencies:
@@ -5385,6 +5412,25 @@ polymer-build@^1.1.0, polymer-build@^1.2.5:
     parse5 "^2.2.2"
     plylog "^0.5.0"
     polymer-analyzer "^2.0.0"
+    polymer-bundler "2.0.0-pre.18"
+    polymer-project-config "^2.0.0"
+    sw-precache "^5.1.1"
+    vinyl "^1.1.1"
+    vinyl-fs "^2.4.3"
+
+polymer-build@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/polymer-build/-/polymer-build-1.3.0.tgz#3c9a2791e0c879c52147ef3a17970979078880f2"
+  dependencies:
+    "@types/node" "^4.2.3"
+    "@types/parse5" "^2.2.32"
+    "@types/vinyl" "^2.0.0"
+    "@types/vinyl-fs" "0.0.28"
+    dom5 "^2.2.0"
+    multipipe "^1.0.2"
+    parse5 "^2.2.2"
+    plylog "^0.5.0"
+    polymer-analyzer "^2.0.1"
     polymer-bundler "2.0.0-pre.18"
     polymer-project-config "^2.0.0"
     sw-precache "^5.1.1"
@@ -6626,9 +6672,9 @@ ternary-stream@^2.0.1:
     merge-stream "^1.0.0"
     through2 "^2.0.1"
 
-"test-fixture@github:polymerelements/test-fixture":
+test-fixture@PolymerElements/test-fixture:
   version "3.0.0-rc.1"
-  resolved "https://codeload.github.com/polymerelements/test-fixture/tar.gz/26118ef0467501c33c02316e7016a2837baba10f"
+  resolved "https://codeload.github.com/PolymerElements/test-fixture/tar.gz/26118ef0467501c33c02316e7016a2837baba10f"
 
 test-value@^2.1.0:
   version "2.1.0"
@@ -6993,13 +7039,9 @@ upper-case@^1.1.1:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/upper-case/-/upper-case-1.1.3.tgz#f6b4501c2ec4cdd26ba78be7222961de77621598"
 
-urijs@1.16.1:
+urijs@1.16.1, urijs@^1.16.1:
   version "1.16.1"
   resolved "https://registry.yarnpkg.com/urijs/-/urijs-1.16.1.tgz#859ad31890f5f9528727be89f1932c94fb4731e2"
-
-urijs@^1.16.1:
-  version "1.18.10"
-  resolved "https://registry.yarnpkg.com/urijs/-/urijs-1.18.10.tgz#b94463eaba59a1a796036a467bb633c667f221ab"
 
 url-parse-lax@^1.0.0:
   version "1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -248,11 +248,11 @@
   version "6.0.65"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-6.0.65.tgz#c00faa7ffcfc9842b5dd7bf650872562504d5670"
 
-"@types/node@4.0.30", "@types/node@^4.0.30":
+"@types/node@4.0.30":
   version "4.0.30"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-4.0.30.tgz#553f490ed3030311620f88003e7abfc0edcb301e"
 
-"@types/node@^4.2.3":
+"@types/node@^4.0.30", "@types/node@^4.2.3":
   version "4.2.8"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-4.2.8.tgz#26fd8fbc5b5ec7822614d950e237956ee92b88cd"
 
@@ -2356,7 +2356,11 @@ dom5@^2.0.0, dom5@^2.0.1, dom5@^2.1.0, dom5@^2.2.0, dom5@^2.3.0:
     clone "^2.1.0"
     parse5 "^2.2.2"
 
-domelementtype@1, domelementtype@~1.1.1:
+domelementtype@1:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-1.3.0.tgz#b17aed82e8ab59e52dd9c19b1756e0fc187204c2"
+
+domelementtype@~1.1.1:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-1.1.3.tgz#bd28773e2642881aec51544924299c5cd822185b"
 
@@ -5345,34 +5349,7 @@ plylog@^0.5.0:
     "@types/winston" "^2.2.0"
     winston "^2.2.0"
 
-polymer-analyzer@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/polymer-analyzer/-/polymer-analyzer-2.0.0.tgz#70c3071e98ba2bd447885eaf987d23287dd8ef0c"
-  dependencies:
-    "@types/chai-subset" "^1.3.0"
-    "@types/chalk" "^0.4.30"
-    "@types/clone" "^0.1.30"
-    "@types/cssbeautify" "^0.3.1"
-    "@types/doctrine" "^0.0.1"
-    "@types/escodegen" "^0.0.2"
-    "@types/estree" "^0.0.34"
-    "@types/node" "^6.0.0"
-    "@types/parse5" "^2.2.34"
-    chalk "^1.1.3"
-    clone "^2.0.0"
-    cssbeautify "^0.3.1"
-    doctrine "^2.0.0"
-    dom5 "^2.1.0"
-    escodegen "^1.7.0"
-    espree "^3.1.7"
-    estraverse "^4.2.0"
-    jsonschema "^1.1.0"
-    parse5 "^2.2.1"
-    shady-css-parser "0.0.8"
-    strip-indent "^2.0.0"
-    typescript "^2.2.0"
-
-polymer-analyzer@^2.0.1:
+polymer-analyzer@^2.0.0, polymer-analyzer@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/polymer-analyzer/-/polymer-analyzer-2.0.1.tgz#37d1556ab55814833677302f65c583960fa44232"
   dependencies:
@@ -5399,26 +5376,7 @@ polymer-analyzer@^2.0.1:
     strip-indent "^2.0.0"
     typescript "^2.2.0"
 
-polymer-build@^1.1.0:
-  version "1.2.5"
-  resolved "https://registry.yarnpkg.com/polymer-build/-/polymer-build-1.2.5.tgz#0d238429582492250bba8171352b9d96535dc4a7"
-  dependencies:
-    "@types/node" "^4.2.3"
-    "@types/parse5" "^2.2.32"
-    "@types/vinyl" "^2.0.0"
-    "@types/vinyl-fs" "0.0.28"
-    dom5 "^2.2.0"
-    multipipe "^1.0.2"
-    parse5 "^2.2.2"
-    plylog "^0.5.0"
-    polymer-analyzer "^2.0.0"
-    polymer-bundler "2.0.0-pre.18"
-    polymer-project-config "^2.0.0"
-    sw-precache "^5.1.1"
-    vinyl "^1.1.1"
-    vinyl-fs "^2.4.3"
-
-polymer-build@^1.3.0:
+polymer-build@^1.1.0, polymer-build@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/polymer-build/-/polymer-build-1.3.0.tgz#3c9a2791e0c879c52147ef3a17970979078880f2"
   dependencies:
@@ -6420,8 +6378,8 @@ sshpk@^1.7.0:
     tweetnacl "~0.14.0"
 
 stack-trace@0.0.x:
-  version "0.0.9"
-  resolved "https://registry.yarnpkg.com/stack-trace/-/stack-trace-0.0.9.tgz#a8f6eaeca90674c333e7c43953f275b451510695"
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/stack-trace/-/stack-trace-0.0.10.tgz#547c70b347e8d32b4e108ea1a2a159e5fdde19c0"
 
 stacky@^1.3.1:
   version "1.3.1"
@@ -6672,9 +6630,9 @@ ternary-stream@^2.0.1:
     merge-stream "^1.0.0"
     through2 "^2.0.1"
 
-test-fixture@PolymerElements/test-fixture:
+"test-fixture@github:polymerelements/test-fixture":
   version "3.0.0-rc.1"
-  resolved "https://codeload.github.com/PolymerElements/test-fixture/tar.gz/26118ef0467501c33c02316e7016a2837baba10f"
+  resolved "https://codeload.github.com/polymerelements/test-fixture/tar.gz/26118ef0467501c33c02316e7016a2837baba10f"
 
 test-value@^2.1.0:
   version "2.1.0"
@@ -6928,15 +6886,15 @@ ua-parser-js@^0.7.12:
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.12.tgz#04c81a99bdd5dc52263ea29d24c6bf8d4818a4bb"
 
 uglify-js@3.0.x:
-  version "3.0.5"
-  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.0.5.tgz#585f5540a991edce566be734d235b71eed7e7146"
+  version "3.0.7"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.0.7.tgz#5cca9c14abae2dd60ceccdf7da3c672cc8069cec"
   dependencies:
     commander "~2.9.0"
     source-map "~0.5.1"
 
 uglify-js@^2.4.10, uglify-js@^2.6:
-  version "2.8.25"
-  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-2.8.25.tgz#11b776e7c3925802853e4c3dd6d0ffad8eb72336"
+  version "2.8.26"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-2.8.26.tgz#3a1db8ae0a0aba7f92e1ddadadbd0293d549f90e"
   dependencies:
     source-map "~0.5.1"
     yargs "~3.10.0"
@@ -7039,9 +6997,13 @@ upper-case@^1.1.1:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/upper-case/-/upper-case-1.1.3.tgz#f6b4501c2ec4cdd26ba78be7222961de77621598"
 
-urijs@1.16.1, urijs@^1.16.1:
+urijs@1.16.1:
   version "1.16.1"
   resolved "https://registry.yarnpkg.com/urijs/-/urijs-1.16.1.tgz#859ad31890f5f9528727be89f1932c94fb4731e2"
+
+urijs@^1.16.1:
+  version "1.18.10"
+  resolved "https://registry.yarnpkg.com/urijs/-/urijs-1.18.10.tgz#b94463eaba59a1a796036a467bb633c667f221ab"
 
 url-parse-lax@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
This is failing in integration test. It looks like the test fragment file foo.html is appearing in the output, where it used to be omitted. Expected change?
