### PR TITLE
Added support for optional polymer-project-config provision of bundler options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Added support for optional polymer-project-config provision of bundler options instead of only boolean value for the `bundle` property of build definitions.
 <!-- Add new, unreleased items here. -->
 
 ## v1.2.0 [06-12-2017]

--- a/src/build/build.ts
+++ b/src/build/build.ts
@@ -58,7 +58,10 @@ export async function build(
     htmlSplitter.rejoin()
   ]);
 
-  if (options.bundle) {
+  const bundled = !!(options.bundle);
+  if (bundled && typeof options.bundle === 'object') {
+    buildStream = buildStream.pipe(polymerProject.bundler(options.bundle));
+  } else if (bundled) {
     buildStream = buildStream.pipe(polymerProject.bundler());
   }
 
@@ -121,7 +124,7 @@ export async function build(
       buildRoot: buildDirectory,
       project: polymerProject,
       swPrecacheConfig: swConfig || undefined,
-      bundled: options.bundle,
+      bundled: bundled,
     });
   }
 


### PR DESCRIPTION
 - One half of the fix to https://github.com/Polymer/polymer-cli/issues/788
 - Previously the `bundle` property of a build definition was limited to `true|false`.  Now it can also be a bag of the options for bundler, so we can support 1.x projects that need `rewriteUrlsInTemplates` behavior or turn off script inlining or css inlining etc.
 - Side note: The compiled JS code in this PR will function fine without the update to polymer-project-config and the existing polymer-cli will accept new polymer-project-config values, fortunately, due to the truthiness of objects.
 - I did not bump the required polymer-project-config version number in the package.json, we can do that when prepping the release.
 - https://github.com/Polymer/polymer-project-config/pull/36 is the PR that gets the new type def into polymer-project-config.
 - [x] CHANGELOG.md has been updated
