### PR TITLE
Updated package.json and package-lock.json to upgrade web-component-tester

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,43 +28,43 @@
       "integrity": "sha1-jlYnhbqlq9p8BKSfZmXq50MZKNM="
     },
     "@types/babel-core": {
-      "version": "6.7.14",
-      "resolved": "https://registry.npmjs.org/@types/babel-core/-/babel-core-6.7.14.tgz",
-      "integrity": "sha1-oIyQCpjomHwamNLqT6ChgFp9Ex8=",
+      "version": "6.25.0",
+      "resolved": "https://registry.npmjs.org/@types/babel-core/-/babel-core-6.25.0.tgz",
+      "integrity": "sha512-6slGEgitUD2n8UuO0SUxyOrx9eD3+P1GMbeVv5ItftnYn7QJiUktn0YAjzZxsH6ugg/qp88Es7Zvu5QgIwSaFw==",
       "requires": {
-        "@types/babel-template": "6.7.14",
-        "@types/babel-traverse": "6.7.17",
-        "@types/babel-types": "6.25.0"
+        "@types/babel-template": "6.25.0",
+        "@types/babel-traverse": "6.25.1",
+        "@types/babel-types": "6.25.1"
       }
     },
     "@types/babel-template": {
-      "version": "6.7.14",
-      "resolved": "https://registry.npmjs.org/@types/babel-template/-/babel-template-6.7.14.tgz",
-      "integrity": "sha1-gIilb51pfWINPQecPvZgJbegjQI=",
+      "version": "6.25.0",
+      "resolved": "https://registry.npmjs.org/@types/babel-template/-/babel-template-6.25.0.tgz",
+      "integrity": "sha512-TtyfVlrprX92xSuKa8D//7vFz5kBJODBw5IQ1hQXehqO+me26vt1fyNxOZyXhUq2a7jRyT72V8p68IyH4NEZNA==",
       "requires": {
-        "@types/babel-types": "6.25.0",
-        "@types/babylon": "6.16.1"
+        "@types/babel-types": "6.25.1",
+        "@types/babylon": "6.16.2"
       }
     },
     "@types/babel-traverse": {
-      "version": "6.7.17",
-      "resolved": "https://registry.npmjs.org/@types/babel-traverse/-/babel-traverse-6.7.17.tgz",
-      "integrity": "sha512-OjTZPym3oYlXcgXW5nt9vv8y2RPlf/67jwTy7AXonw+ZFyJJSTww9g8Bd5xsoJ2lYSnMOGcTtuw7P7adEKR6qw==",
+      "version": "6.25.1",
+      "resolved": "https://registry.npmjs.org/@types/babel-traverse/-/babel-traverse-6.25.1.tgz",
+      "integrity": "sha512-tac3sdvagKMgAaSUIWkZL72rQDcnaG3Ju++u3p3aeZu1c+xaxYhVm9n6PcP9xEgQ2JJzkVlsoI9agGPB0PiLzQ==",
       "requires": {
-        "@types/babel-types": "6.25.0"
+        "@types/babel-types": "6.25.1"
       }
     },
     "@types/babel-types": {
-      "version": "6.25.0",
-      "resolved": "https://registry.npmjs.org/@types/babel-types/-/babel-types-6.25.0.tgz",
-      "integrity": "sha512-VS26wSCQ3LvKGTezidY0PkKVZl7tm+b8R5fVQaaG3mFhSQrasCt1lYPk4/68kNwX5RhAKLtSgFjDPtBiUjzaAw=="
+      "version": "6.25.1",
+      "resolved": "https://registry.npmjs.org/@types/babel-types/-/babel-types-6.25.1.tgz",
+      "integrity": "sha512-7Z6r20+HE0viAFhsW0d/UrC1K2tTlpXzGpNlYm8MmCv8z5PbAacFIshrM/MjlGRa5SBqxu2socpy8FHntwZKng=="
     },
     "@types/babylon": {
-      "version": "6.16.1",
-      "resolved": "https://registry.npmjs.org/@types/babylon/-/babylon-6.16.1.tgz",
-      "integrity": "sha1-5NEKueQ6c3A6F8b0FDi+3ih2k0A=",
+      "version": "6.16.2",
+      "resolved": "https://registry.npmjs.org/@types/babylon/-/babylon-6.16.2.tgz",
+      "integrity": "sha512-+Jty46mPaWe1VAyZbfvgJM4BAdklLWxrT5tc/RjvCgLrtk6gzRY6AOnoWFv4p6hVxhJshDdr2hGVn56alBp97Q==",
       "requires": {
-        "@types/babel-types": "6.25.0"
+        "@types/babel-types": "6.25.1"
       }
     },
     "@types/bluebird": {
@@ -72,25 +72,17 @@
       "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.8.tgz",
       "integrity": "sha512-rBfrD56OxaqVjghtVqp2EEX0ieHkRk6IefDVrQXIVGvlhDOEBTvZff4Q02uo84ukVkH4k5eB1cPKGDM2NlFL8A=="
     },
-    "@types/body-parser": {
-      "version": "0.0.33",
-      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-0.0.33.tgz",
-      "integrity": "sha1-M8oUmPw35Rxd8MgcrjRWnnBB4CU=",
-      "requires": {
-        "@types/express": "4.0.36"
-      }
-    },
     "@types/chai": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.0.1.tgz",
-      "integrity": "sha512-DWrdkraJO+KvBB7+Jc6AuDd2+fwV6Z9iK8cqEEoYpcurYrH7GiUZmwjFuQIIWj5HhFz6NsSxdN72YMIHT7Fy2Q=="
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.0.2.tgz",
+      "integrity": "sha512-0pHNZTD0SpQhz1kUM4Muhgdn4acxq21kp726pZfWMmKYGbmmv8XkGTt3k/0QDklhTUYBD6hknZ/1YFokyP/G7Q=="
     },
     "@types/chai-subset": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@types/chai-subset/-/chai-subset-1.3.0.tgz",
       "integrity": "sha1-dM7M7zsvwtpzkbcT3rcv6afl94I=",
       "requires": {
-        "@types/chai": "4.0.1"
+        "@types/chai": "4.0.2"
       }
     },
     "@types/chalk": {
@@ -166,13 +158,13 @@
       "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.0.49.tgz",
       "integrity": "sha512-b7mVHoURu1xaP/V6xw1sYwyv9V0EZ7euyi+sdnbnTZxEkAh4/hzPsI6Eflq+ZzHQ/Tgl7l16Jz+0oz8F46MLnA==",
       "requires": {
-        "@types/node": "8.0.14"
+        "@types/node": "8.0.20"
       },
       "dependencies": {
         "@types/node": {
-          "version": "8.0.14",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.14.tgz",
-          "integrity": "sha512-lrtgE/5FeTdcuxgsDbLUIFJ33dTp4TkbKkTDZt/ueUMeqmGYqJRQd908q5Yj9EzzWSMonEhMr1q/CQlgVGEt4w=="
+          "version": "8.0.20",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.20.tgz",
+          "integrity": "sha512-MnB7YEpmLUyEWRVRhKpRs4swwqITnY8BcVFPoTuCl99SCplI/lLUiU5vcJ/OANDqwkpdIg0pDEM38K22KQT2RA=="
         }
       }
     },
@@ -190,17 +182,17 @@
       }
     },
     "@types/form-data": {
-      "version": "0.0.33",
-      "resolved": "https://registry.npmjs.org/@types/form-data/-/form-data-0.0.33.tgz",
-      "integrity": "sha1-yayFsqX9GENbjIXZ7LUObWyJP/g=",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@types/form-data/-/form-data-2.2.0.tgz",
+      "integrity": "sha512-vm5OGsKc61Sx/GTRMQ9d0H0PYCDebT78/bdIBPCoPEHdgp0etaH1RzMmkDygymUmyXTj3rdWQn0sRUpYKZzljA==",
       "requires": {
-        "@types/node": "8.0.14"
+        "@types/node": "8.0.20"
       },
       "dependencies": {
         "@types/node": {
-          "version": "8.0.14",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.14.tgz",
-          "integrity": "sha512-lrtgE/5FeTdcuxgsDbLUIFJ33dTp4TkbKkTDZt/ueUMeqmGYqJRQd908q5Yj9EzzWSMonEhMr1q/CQlgVGEt4w=="
+          "version": "8.0.20",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.20.tgz",
+          "integrity": "sha512-MnB7YEpmLUyEWRVRhKpRs4swwqITnY8BcVFPoTuCl99SCplI/lLUiU5vcJ/OANDqwkpdIg0pDEM38K22KQT2RA=="
         }
       }
     },
@@ -225,13 +217,13 @@
       "integrity": "sha1-ECZAnFYlqGiQdGAoCNCCsoZ7ilE=",
       "requires": {
         "@types/minimatch": "2.0.29",
-        "@types/node": "8.0.14"
+        "@types/node": "8.0.20"
       },
       "dependencies": {
         "@types/node": {
-          "version": "8.0.14",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.14.tgz",
-          "integrity": "sha512-lrtgE/5FeTdcuxgsDbLUIFJ33dTp4TkbKkTDZt/ueUMeqmGYqJRQd908q5Yj9EzzWSMonEhMr1q/CQlgVGEt4w=="
+          "version": "8.0.20",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.20.tgz",
+          "integrity": "sha512-MnB7YEpmLUyEWRVRhKpRs4swwqITnY8BcVFPoTuCl99SCplI/lLUiU5vcJ/OANDqwkpdIg0pDEM38K22KQT2RA=="
         }
       }
     },
@@ -241,45 +233,13 @@
       "integrity": "sha1-uFOZC0Ckz+aoDsDS+t9o2AYPeLE=",
       "requires": {
         "@types/glob": "5.0.30",
-        "@types/node": "8.0.14"
+        "@types/node": "8.0.20"
       },
       "dependencies": {
         "@types/node": {
-          "version": "8.0.14",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.14.tgz",
-          "integrity": "sha512-lrtgE/5FeTdcuxgsDbLUIFJ33dTp4TkbKkTDZt/ueUMeqmGYqJRQd908q5Yj9EzzWSMonEhMr1q/CQlgVGEt4w=="
-        }
-      }
-    },
-    "@types/grunt": {
-      "version": "0.4.21",
-      "resolved": "https://registry.npmjs.org/@types/grunt/-/grunt-0.4.21.tgz",
-      "integrity": "sha1-jgAvw7XWtNC6Ctwkz3fpiMhUdQ4=",
-      "requires": {
-        "@types/node": "8.0.14"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "8.0.14",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.14.tgz",
-          "integrity": "sha512-lrtgE/5FeTdcuxgsDbLUIFJ33dTp4TkbKkTDZt/ueUMeqmGYqJRQd908q5Yj9EzzWSMonEhMr1q/CQlgVGEt4w=="
-        }
-      }
-    },
-    "@types/gulp": {
-      "version": "3.8.33",
-      "resolved": "https://registry.npmjs.org/@types/gulp/-/gulp-3.8.33.tgz",
-      "integrity": "sha512-3UpA2pkKO40cNPe/8bxMQFWSASR9Jx67JfN9Z2Cf6ogfDMwXgEHm2XjKmuLYEtrp1IHYApOWlYMLYNgtTJgSAw==",
-      "requires": {
-        "@types/node": "8.0.14",
-        "@types/orchestrator": "0.3.0",
-        "@types/vinyl": "2.0.0"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "8.0.14",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.14.tgz",
-          "integrity": "sha512-lrtgE/5FeTdcuxgsDbLUIFJ33dTp4TkbKkTDZt/ueUMeqmGYqJRQd908q5Yj9EzzWSMonEhMr1q/CQlgVGEt4w=="
+          "version": "8.0.20",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.20.tgz",
+          "integrity": "sha512-MnB7YEpmLUyEWRVRhKpRs4swwqITnY8BcVFPoTuCl99SCplI/lLUiU5vcJ/OANDqwkpdIg0pDEM38K22KQT2RA=="
         }
       }
     },
@@ -288,14 +248,14 @@
       "resolved": "https://registry.npmjs.org/@types/gulp-if/-/gulp-if-0.0.30.tgz",
       "integrity": "sha1-IaVkrxqryA3/LRlfpmzT+IZK7CE=",
       "requires": {
-        "@types/node": "8.0.14",
+        "@types/node": "8.0.20",
         "@types/vinyl": "2.0.0"
       },
       "dependencies": {
         "@types/node": {
-          "version": "8.0.14",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.14.tgz",
-          "integrity": "sha512-lrtgE/5FeTdcuxgsDbLUIFJ33dTp4TkbKkTDZt/ueUMeqmGYqJRQd908q5Yj9EzzWSMonEhMr1q/CQlgVGEt4w=="
+          "version": "8.0.20",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.20.tgz",
+          "integrity": "sha512-MnB7YEpmLUyEWRVRhKpRs4swwqITnY8BcVFPoTuCl99SCplI/lLUiU5vcJ/OANDqwkpdIg0pDEM38K22KQT2RA=="
         }
       }
     },
@@ -324,23 +284,18 @@
       "integrity": "sha1-NylhCbfyd/bmxf1+DAcGvJGPu1E=",
       "optional": true
     },
-    "@types/lodash": {
-      "version": "4.14.70",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.70.tgz",
-      "integrity": "sha512-uvDjWW3m7SFUhSpohfQvj32gRsVgRxA0Z0OfMJh8m/JuX4YJLHeEwRBuHJgvNgTAVBpJDFKVFeyrREuMwkE9Qw=="
-    },
     "@types/merge-stream": {
       "version": "1.0.28",
       "resolved": "https://registry.npmjs.org/@types/merge-stream/-/merge-stream-1.0.28.tgz",
       "integrity": "sha1-fKv6qrbGTVHjQQ2V4X3ZBh5BNTI=",
       "requires": {
-        "@types/node": "8.0.14"
+        "@types/node": "8.0.20"
       },
       "dependencies": {
         "@types/node": {
-          "version": "8.0.14",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.14.tgz",
-          "integrity": "sha512-lrtgE/5FeTdcuxgsDbLUIFJ33dTp4TkbKkTDZt/ueUMeqmGYqJRQd908q5Yj9EzzWSMonEhMr1q/CQlgVGEt4w=="
+          "version": "8.0.20",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.20.tgz",
+          "integrity": "sha512-MnB7YEpmLUyEWRVRhKpRs4swwqITnY8BcVFPoTuCl99SCplI/lLUiU5vcJ/OANDqwkpdIg0pDEM38K22KQT2RA=="
         }
       }
     },
@@ -354,72 +309,39 @@
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-2.0.29.tgz",
       "integrity": "sha1-UALhT3Xi1x5WQoHfBDHIwbSio2o="
     },
-    "@types/mocha": {
-      "version": "2.2.41",
-      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-2.2.41.tgz",
-      "integrity": "sha1-4nzwgXFT658nE7LT9saPHhw8pgg="
-    },
-    "@types/multer": {
-      "version": "0.0.32",
-      "resolved": "https://registry.npmjs.org/@types/multer/-/multer-0.0.32.tgz",
-      "integrity": "sha1-+Jx1EifcILfJM8MJo+dGfEmfzew=",
-      "requires": {
-        "@types/express": "4.0.36"
-      }
-    },
     "@types/mz": {
       "version": "0.0.31",
       "resolved": "https://registry.npmjs.org/@types/mz/-/mz-0.0.31.tgz",
       "integrity": "sha1-pNgMCC/v5x5Ap8DwfR5lVbu8e1I=",
       "requires": {
-        "@types/node": "8.0.14"
+        "@types/node": "8.0.20"
       },
       "dependencies": {
         "@types/node": {
-          "version": "8.0.14",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.14.tgz",
-          "integrity": "sha512-lrtgE/5FeTdcuxgsDbLUIFJ33dTp4TkbKkTDZt/ueUMeqmGYqJRQd908q5Yj9EzzWSMonEhMr1q/CQlgVGEt4w=="
+          "version": "8.0.20",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.20.tgz",
+          "integrity": "sha512-MnB7YEpmLUyEWRVRhKpRs4swwqITnY8BcVFPoTuCl99SCplI/lLUiU5vcJ/OANDqwkpdIg0pDEM38K22KQT2RA=="
         }
       }
     },
     "@types/node": {
       "version": "6.0.65",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.65.tgz",
-      "integrity": "sha1-wA+qf/z8mEK13Xv2UIclYlBNVnA="
-    },
-    "@types/nomnom": {
-      "version": "0.0.28",
-      "resolved": "https://registry.npmjs.org/@types/nomnom/-/nomnom-0.0.28.tgz",
-      "integrity": "sha1-LYloUorXqXON0Kaj3+XN/biseXQ="
+      "integrity": "sha1-wA+qf/z8mEK13Xv2UIclYlBNVnA=",
+      "dev": true
     },
     "@types/opn": {
       "version": "3.0.28",
       "resolved": "https://registry.npmjs.org/@types/opn/-/opn-3.0.28.tgz",
       "integrity": "sha1-CX0NHJtXSVc6XZbfEyOHu20CEYo=",
       "requires": {
-        "@types/node": "8.0.14"
+        "@types/node": "8.0.20"
       },
       "dependencies": {
         "@types/node": {
-          "version": "8.0.14",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.14.tgz",
-          "integrity": "sha512-lrtgE/5FeTdcuxgsDbLUIFJ33dTp4TkbKkTDZt/ueUMeqmGYqJRQd908q5Yj9EzzWSMonEhMr1q/CQlgVGEt4w=="
-        }
-      }
-    },
-    "@types/orchestrator": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@types/orchestrator/-/orchestrator-0.3.0.tgz",
-      "integrity": "sha1-v4ShaZyTMNT+ic2BJj6PwJ+zKXg=",
-      "requires": {
-        "@types/node": "8.0.14",
-        "@types/q": "0.0.35"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "8.0.14",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.14.tgz",
-          "integrity": "sha512-lrtgE/5FeTdcuxgsDbLUIFJ33dTp4TkbKkTDZt/ueUMeqmGYqJRQd908q5Yj9EzzWSMonEhMr1q/CQlgVGEt4w=="
+          "version": "8.0.20",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.20.tgz",
+          "integrity": "sha512-MnB7YEpmLUyEWRVRhKpRs4swwqITnY8BcVFPoTuCl99SCplI/lLUiU5vcJ/OANDqwkpdIg0pDEM38K22KQT2RA=="
         }
       }
     },
@@ -428,13 +350,13 @@
       "resolved": "https://registry.npmjs.org/@types/parse5/-/parse5-0.0.31.tgz",
       "integrity": "sha1-6Cekk6RDsVbhtYKi5MO9wAQPLuc=",
       "requires": {
-        "@types/node": "6.0.84"
+        "@types/node": "6.0.85"
       },
       "dependencies": {
         "@types/node": {
-          "version": "6.0.84",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.84.tgz",
-          "integrity": "sha512-1SvEazClhUBRNroJM3oB3xf3u2r6xGmHDGbdigqNPHvNKLl8/BtATgO9eC04ZLuovpSh0B20BF1QJxdi+qmTlg=="
+          "version": "6.0.85",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.85.tgz",
+          "integrity": "sha512-6qLZpfQFO/g5Ns2e7RsW6brk0Q6Xzwiw7kVVU/XiQNOiJXSojhX76GP457PBYIsNMH2WfcGgcnZB4awFDHrwpA=="
         }
       }
     },
@@ -442,11 +364,6 @@
       "version": "1.9.2",
       "resolved": "https://registry.npmjs.org/@types/pem/-/pem-1.9.2.tgz",
       "integrity": "sha1-zQsZXRYd/7ywqoj6n9lLJN0q8Qs="
-    },
-    "@types/q": {
-      "version": "0.0.35",
-      "resolved": "https://registry.npmjs.org/@types/q/-/q-0.0.35.tgz",
-      "integrity": "sha512-Br6c/XFnnYBSOGKadEaXruA71rpUMxMzlSrGmhpoIEWrqRMI/yQjrY+0ORJi52m/JgkxRqatdBJ32fQ/95qtbw=="
     },
     "@types/relateurl": {
       "version": "0.2.28",
@@ -458,14 +375,14 @@
       "resolved": "https://registry.npmjs.org/@types/request/-/request-0.0.39.tgz",
       "integrity": "sha1-FouWz0JTxdVNQD90b4Lueu1Hziw=",
       "requires": {
-        "@types/form-data": "0.0.33",
-        "@types/node": "8.0.14"
+        "@types/form-data": "2.2.0",
+        "@types/node": "8.0.20"
       },
       "dependencies": {
         "@types/node": {
-          "version": "8.0.14",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.14.tgz",
-          "integrity": "sha512-lrtgE/5FeTdcuxgsDbLUIFJ33dTp4TkbKkTDZt/ueUMeqmGYqJRQd908q5Yj9EzzWSMonEhMr1q/CQlgVGEt4w=="
+          "version": "8.0.20",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.20.tgz",
+          "integrity": "sha512-MnB7YEpmLUyEWRVRhKpRs4swwqITnY8BcVFPoTuCl99SCplI/lLUiU5vcJ/OANDqwkpdIg0pDEM38K22KQT2RA=="
         }
       }
     },
@@ -474,13 +391,13 @@
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-0.0.4.tgz",
       "integrity": "sha1-m1htZalH3qiMS8JNoLkF/pUgoNU=",
       "requires": {
-        "@types/node": "8.0.14"
+        "@types/node": "8.0.20"
       },
       "dependencies": {
         "@types/node": {
-          "version": "8.0.14",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.14.tgz",
-          "integrity": "sha512-lrtgE/5FeTdcuxgsDbLUIFJ33dTp4TkbKkTDZt/ueUMeqmGYqJRQd908q5Yj9EzzWSMonEhMr1q/CQlgVGEt4w=="
+          "version": "8.0.20",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.20.tgz",
+          "integrity": "sha512-MnB7YEpmLUyEWRVRhKpRs4swwqITnY8BcVFPoTuCl99SCplI/lLUiU5vcJ/OANDqwkpdIg0pDEM38K22KQT2RA=="
         }
       }
     },
@@ -603,9 +520,9 @@
       }
     },
     "@types/semver": {
-      "version": "5.3.32",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-5.3.32.tgz",
-      "integrity": "sha512-MdbWERx4JWmN4zP+skJy9Kio+Cddvmyn1k8x0S8UAqDoMgOJeobQo7yhlE4BfiimonHirgixWfva/hKUlXBsrw=="
+      "version": "5.3.33",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-5.3.33.tgz",
+      "integrity": "sha512-UwrBgjsRS8BSsckIEdrAhIAmdh0MJidtKTvD3S6tpMq6qHLY3uGaNYcRDUjPxpF4hOAOEbMNSXhhfxmNHB1QNQ=="
     },
     "@types/serve-static": {
       "version": "1.7.31",
@@ -617,60 +534,32 @@
       }
     },
     "@types/shelljs": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/@types/shelljs/-/shelljs-0.7.2.tgz",
-      "integrity": "sha512-NanpA4ybcKXr32Zg7sgHvOfir/AeoOdN7+8TpnWueHkmPhVZLSPWU4LLl7y7d2FG08jaxE18HZjlATjttmjHCQ==",
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@types/shelljs/-/shelljs-0.7.4.tgz",
+      "integrity": "sha512-/RQcPAeUMEz4h2p818OZ4ghBJEliVf2MneJGiKl35guqJ1+CTNu+v1zP1qG9Dym61aktec60riIkja1X+GPS3A==",
       "dev": true,
       "requires": {
+        "@types/glob": "5.0.30",
         "@types/node": "6.0.65"
       }
     },
-    "@types/sinon": {
-      "version": "1.16.36",
-      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-1.16.36.tgz",
-      "integrity": "sha1-dLtu15KFl8Gz+xsAkAXpTcbq41c="
-    },
-    "@types/sinon-chai": {
-      "version": "2.7.28",
-      "resolved": "https://registry.npmjs.org/@types/sinon-chai/-/sinon-chai-2.7.28.tgz",
-      "integrity": "sha512-qh9K/XtXzdHWiUqvFFjw3jQ5ZNrw0wzHaCWTcgBfSn7KwbjZHywinAdinSpUXeHBv+4cojk/9WSrPwVPYiITTA==",
-      "requires": {
-        "@types/chai": "4.0.1",
-        "@types/sinon": "1.16.36"
-      }
-    },
-    "@types/socket.io": {
-      "version": "1.4.29",
-      "resolved": "https://registry.npmjs.org/@types/socket.io/-/socket.io-1.4.29.tgz",
-      "integrity": "sha1-hqazqat4z5qQDO74W5totr6oZxI=",
-      "requires": {
-        "@types/node": "8.0.14"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "8.0.14",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.14.tgz",
-          "integrity": "sha512-lrtgE/5FeTdcuxgsDbLUIFJ33dTp4TkbKkTDZt/ueUMeqmGYqJRQd908q5Yj9EzzWSMonEhMr1q/CQlgVGEt4w=="
-        }
-      }
-    },
     "@types/source-map": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@types/source-map/-/source-map-0.5.0.tgz",
-      "integrity": "sha1-3TS72OMv5OdPLj2KwH+KpbRaR6w="
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@types/source-map/-/source-map-0.5.1.tgz",
+      "integrity": "sha512-/GVAjL1Y8puvZab63n8tsuBiYwZt1bApMdx58/msQ9ID5T05ov+wm/ZV1DvYC/DKKEygpTJViqQvkh5Rhrl4CA=="
     },
     "@types/spdy": {
       "version": "3.4.2",
       "resolved": "https://registry.npmjs.org/@types/spdy/-/spdy-3.4.2.tgz",
       "integrity": "sha512-MfIOcqTpECcKEMEAtpRQJqAdczKk/R55VGRfi5PDUlbpndrPz5t+knh7E3X0MnBMEOpRFY1oubLy81RHa6HrPg==",
       "requires": {
-        "@types/node": "8.0.14"
+        "@types/node": "8.0.20"
       },
       "dependencies": {
         "@types/node": {
-          "version": "8.0.14",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.14.tgz",
-          "integrity": "sha512-lrtgE/5FeTdcuxgsDbLUIFJ33dTp4TkbKkTDZt/ueUMeqmGYqJRQd908q5Yj9EzzWSMonEhMr1q/CQlgVGEt4w=="
+          "version": "8.0.20",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.20.tgz",
+          "integrity": "sha512-MnB7YEpmLUyEWRVRhKpRs4swwqITnY8BcVFPoTuCl99SCplI/lLUiU5vcJ/OANDqwkpdIg0pDEM38K22KQT2RA=="
         }
       }
     },
@@ -679,13 +568,13 @@
       "resolved": "https://registry.npmjs.org/@types/temp/-/temp-0.8.29.tgz",
       "integrity": "sha1-w83BE+PBOPkOXpcNUeQbC39iZ40=",
       "requires": {
-        "@types/node": "8.0.14"
+        "@types/node": "8.0.20"
       },
       "dependencies": {
         "@types/node": {
-          "version": "8.0.14",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.14.tgz",
-          "integrity": "sha512-lrtgE/5FeTdcuxgsDbLUIFJ33dTp4TkbKkTDZt/ueUMeqmGYqJRQd908q5Yj9EzzWSMonEhMr1q/CQlgVGEt4w=="
+          "version": "8.0.20",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.20.tgz",
+          "integrity": "sha512-MnB7YEpmLUyEWRVRhKpRs4swwqITnY8BcVFPoTuCl99SCplI/lLUiU5vcJ/OANDqwkpdIg0pDEM38K22KQT2RA=="
         }
       }
     },
@@ -694,13 +583,13 @@
       "resolved": "https://registry.npmjs.org/@types/through/-/through-0.0.28.tgz",
       "integrity": "sha1-Hv+pptAPtIVytMyfRN8lsBANt/w=",
       "requires": {
-        "@types/node": "8.0.14"
+        "@types/node": "8.0.20"
       },
       "dependencies": {
         "@types/node": {
-          "version": "8.0.14",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.14.tgz",
-          "integrity": "sha512-lrtgE/5FeTdcuxgsDbLUIFJ33dTp4TkbKkTDZt/ueUMeqmGYqJRQd908q5Yj9EzzWSMonEhMr1q/CQlgVGEt4w=="
+          "version": "8.0.20",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.20.tgz",
+          "integrity": "sha512-MnB7YEpmLUyEWRVRhKpRs4swwqITnY8BcVFPoTuCl99SCplI/lLUiU5vcJ/OANDqwkpdIg0pDEM38K22KQT2RA=="
         }
       }
     },
@@ -714,7 +603,7 @@
       "resolved": "https://registry.npmjs.org/@types/uglify-js/-/uglify-js-2.6.29.tgz",
       "integrity": "sha512-BdFLCZW0GTl31AbqXSak8ss/MqEZ3DN2MH9rkAyGoTuzK7ifGUlX+u0nfbWeTsa7IPcZhtn8BlpYBXSV+vqGhQ==",
       "requires": {
-        "@types/source-map": "0.5.0"
+        "@types/source-map": "0.5.1"
       }
     },
     "@types/update-notifier": {
@@ -727,13 +616,13 @@
       "resolved": "https://registry.npmjs.org/@types/vinyl/-/vinyl-2.0.0.tgz",
       "integrity": "sha1-/SE79/QTbd4h/hiVUAsSwYb4wmg=",
       "requires": {
-        "@types/node": "8.0.14"
+        "@types/node": "8.0.20"
       },
       "dependencies": {
         "@types/node": {
-          "version": "8.0.14",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.14.tgz",
-          "integrity": "sha512-lrtgE/5FeTdcuxgsDbLUIFJ33dTp4TkbKkTDZt/ueUMeqmGYqJRQd908q5Yj9EzzWSMonEhMr1q/CQlgVGEt4w=="
+          "version": "8.0.20",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.20.tgz",
+          "integrity": "sha512-MnB7YEpmLUyEWRVRhKpRs4swwqITnY8BcVFPoTuCl99SCplI/lLUiU5vcJ/OANDqwkpdIg0pDEM38K22KQT2RA=="
         }
       }
     },
@@ -743,14 +632,14 @@
       "integrity": "sha1-RmMBe8gCxlcOrk80Cf1cq/l8v94=",
       "requires": {
         "@types/glob-stream": "3.1.30",
-        "@types/node": "8.0.14",
+        "@types/node": "8.0.20",
         "@types/vinyl": "2.0.0"
       },
       "dependencies": {
         "@types/node": {
-          "version": "8.0.14",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.14.tgz",
-          "integrity": "sha512-lrtgE/5FeTdcuxgsDbLUIFJ33dTp4TkbKkTDZt/ueUMeqmGYqJRQd908q5Yj9EzzWSMonEhMr1q/CQlgVGEt4w=="
+          "version": "8.0.20",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.20.tgz",
+          "integrity": "sha512-MnB7YEpmLUyEWRVRhKpRs4swwqITnY8BcVFPoTuCl99SCplI/lLUiU5vcJ/OANDqwkpdIg0pDEM38K22KQT2RA=="
         }
       }
     },
@@ -760,17 +649,17 @@
       "integrity": "sha1-AW44dim4gXvtZT/jLqtdESecjfY="
     },
     "@types/winston": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/@types/winston/-/winston-2.3.3.tgz",
-      "integrity": "sha512-Ar6qDl0MK8ZKruAngkuZqaAnI20k68buemvKhizxfj1783u2UzYnTb5gLizIJjQ/60h/5Of92ztZnn35AywjqA==",
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/@types/winston/-/winston-2.3.4.tgz",
+      "integrity": "sha512-lUhWIhgSpk4GHoa/hUuvkueAdP0a4NG9BRDjKX9r6pSYo1xSKKYXu+WatBwTzX96wJgeQdzrlGeUF9f2iOjSKA==",
       "requires": {
-        "@types/node": "8.0.14"
+        "@types/node": "8.0.20"
       },
       "dependencies": {
         "@types/node": {
-          "version": "8.0.14",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.14.tgz",
-          "integrity": "sha512-lrtgE/5FeTdcuxgsDbLUIFJ33dTp4TkbKkTDZt/ueUMeqmGYqJRQd908q5Yj9EzzWSMonEhMr1q/CQlgVGEt4w=="
+          "version": "8.0.20",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.20.tgz",
+          "integrity": "sha512-MnB7YEpmLUyEWRVRhKpRs4swwqITnY8BcVFPoTuCl99SCplI/lLUiU5vcJ/OANDqwkpdIg0pDEM38K22KQT2RA=="
         }
       }
     },
@@ -793,7 +682,7 @@
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
       "integrity": "sha1-w8p0NJOGSMPg2cHjKN1otiLChMo=",
       "requires": {
-        "mime-types": "2.1.15",
+        "mime-types": "2.1.16",
         "negotiator": "0.6.1"
       }
     },
@@ -917,14 +806,14 @@
       "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8="
     },
     "anymatch": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
-      "integrity": "sha1-o+Uvo5FoyCX/V7AkgSbOWo/5VQc=",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
+      "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
       "dev": true,
       "optional": true,
       "requires": {
-        "arrify": "1.0.1",
-        "micromatch": "2.3.11"
+        "micromatch": "2.3.11",
+        "normalize-path": "2.1.1"
       }
     },
     "append-field": {
@@ -1126,9 +1015,9 @@
         "babel-core": "6.25.0",
         "babel-polyfill": "6.23.0",
         "babel-register": "6.24.1",
-        "babel-runtime": "6.23.0",
+        "babel-runtime": "6.25.0",
         "chokidar": "1.7.0",
-        "commander": "2.9.0",
+        "commander": "2.11.0",
         "convert-source-map": "1.5.0",
         "fs-readdir-recursive": "1.0.0",
         "glob": "7.1.2",
@@ -1160,7 +1049,7 @@
         "babel-helpers": "6.24.1",
         "babel-messages": "6.23.0",
         "babel-register": "6.24.1",
-        "babel-runtime": "6.23.0",
+        "babel-runtime": "6.25.0",
         "babel-template": "6.25.0",
         "babel-traverse": "6.25.0",
         "babel-types": "6.25.0",
@@ -1182,7 +1071,7 @@
       "integrity": "sha1-M6GvcNXyiQrrRlpKd5PB32qeqfw=",
       "requires": {
         "babel-messages": "6.23.0",
-        "babel-runtime": "6.23.0",
+        "babel-runtime": "6.25.0",
         "babel-types": "6.25.0",
         "detect-indent": "4.0.0",
         "jsesc": "1.3.0",
@@ -1197,7 +1086,7 @@
       "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
       "requires": {
         "babel-helper-hoist-variables": "6.24.1",
-        "babel-runtime": "6.23.0",
+        "babel-runtime": "6.25.0",
         "babel-traverse": "6.25.0",
         "babel-types": "6.25.0"
       }
@@ -1208,7 +1097,7 @@
       "integrity": "sha1-epdH8ljYlH0y1RX2qhx70CIEoIA=",
       "requires": {
         "babel-helper-function-name": "6.24.1",
-        "babel-runtime": "6.23.0",
+        "babel-runtime": "6.25.0",
         "babel-types": "6.25.0",
         "lodash": "4.17.4"
       }
@@ -1229,7 +1118,7 @@
       "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
       "requires": {
         "babel-helper-get-function-arity": "6.24.1",
-        "babel-runtime": "6.23.0",
+        "babel-runtime": "6.25.0",
         "babel-template": "6.25.0",
         "babel-traverse": "6.25.0",
         "babel-types": "6.25.0"
@@ -1240,7 +1129,7 @@
       "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
       "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
       "requires": {
-        "babel-runtime": "6.23.0",
+        "babel-runtime": "6.25.0",
         "babel-types": "6.25.0"
       }
     },
@@ -1249,7 +1138,7 @@
       "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
       "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
       "requires": {
-        "babel-runtime": "6.23.0",
+        "babel-runtime": "6.25.0",
         "babel-types": "6.25.0"
       }
     },
@@ -1273,7 +1162,7 @@
       "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
       "integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
       "requires": {
-        "babel-runtime": "6.23.0",
+        "babel-runtime": "6.25.0",
         "babel-types": "6.25.0"
       }
     },
@@ -1282,7 +1171,7 @@
       "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.24.1.tgz",
       "integrity": "sha1-024i+rEAjXnYhkjjIRaGgShFbOg=",
       "requires": {
-        "babel-runtime": "6.23.0",
+        "babel-runtime": "6.25.0",
         "babel-types": "6.25.0",
         "lodash": "4.17.4"
       }
@@ -1299,7 +1188,7 @@
       "requires": {
         "babel-helper-optimise-call-expression": "6.24.1",
         "babel-messages": "6.23.0",
-        "babel-runtime": "6.23.0",
+        "babel-runtime": "6.25.0",
         "babel-template": "6.25.0",
         "babel-traverse": "6.25.0",
         "babel-types": "6.25.0"
@@ -1315,7 +1204,7 @@
       "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
       "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
       "requires": {
-        "babel-runtime": "6.23.0",
+        "babel-runtime": "6.25.0",
         "babel-template": "6.25.0"
       }
     },
@@ -1324,7 +1213,7 @@
       "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
       "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
       "requires": {
-        "babel-runtime": "6.23.0"
+        "babel-runtime": "6.25.0"
       }
     },
     "babel-plugin-check-es2015-constants": {
@@ -1332,7 +1221,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
       "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
       "requires": {
-        "babel-runtime": "6.23.0"
+        "babel-runtime": "6.25.0"
       }
     },
     "babel-plugin-external-helpers": {
@@ -1340,7 +1229,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-external-helpers/-/babel-plugin-external-helpers-6.22.0.tgz",
       "integrity": "sha1-IoX0iwK9Xe3oUXXK+MYuhq3M76E=",
       "requires": {
-        "babel-runtime": "6.23.0"
+        "babel-runtime": "6.25.0"
       }
     },
     "babel-plugin-minify-builtins": {
@@ -1429,7 +1318,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
       "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
       "requires": {
-        "babel-runtime": "6.23.0"
+        "babel-runtime": "6.25.0"
       }
     },
     "babel-plugin-transform-es2015-block-scoped-functions": {
@@ -1437,7 +1326,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
       "integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
       "requires": {
-        "babel-runtime": "6.23.0"
+        "babel-runtime": "6.25.0"
       }
     },
     "babel-plugin-transform-es2015-block-scoping": {
@@ -1445,7 +1334,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.24.1.tgz",
       "integrity": "sha1-dsKV3DpHQbFmWt/TFnIV3P8ypXY=",
       "requires": {
-        "babel-runtime": "6.23.0",
+        "babel-runtime": "6.25.0",
         "babel-template": "6.25.0",
         "babel-traverse": "6.25.0",
         "babel-types": "6.25.0",
@@ -1462,7 +1351,7 @@
         "babel-helper-optimise-call-expression": "6.24.1",
         "babel-helper-replace-supers": "6.24.1",
         "babel-messages": "6.23.0",
-        "babel-runtime": "6.23.0",
+        "babel-runtime": "6.25.0",
         "babel-template": "6.25.0",
         "babel-traverse": "6.25.0",
         "babel-types": "6.25.0"
@@ -1473,7 +1362,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
       "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
       "requires": {
-        "babel-runtime": "6.23.0",
+        "babel-runtime": "6.25.0",
         "babel-template": "6.25.0"
       }
     },
@@ -1482,7 +1371,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
       "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
       "requires": {
-        "babel-runtime": "6.23.0"
+        "babel-runtime": "6.25.0"
       }
     },
     "babel-plugin-transform-es2015-duplicate-keys": {
@@ -1490,7 +1379,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
       "integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
       "requires": {
-        "babel-runtime": "6.23.0",
+        "babel-runtime": "6.25.0",
         "babel-types": "6.25.0"
       }
     },
@@ -1499,7 +1388,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
       "integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
       "requires": {
-        "babel-runtime": "6.23.0"
+        "babel-runtime": "6.25.0"
       }
     },
     "babel-plugin-transform-es2015-function-name": {
@@ -1508,7 +1397,7 @@
       "integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
       "requires": {
         "babel-helper-function-name": "6.24.1",
-        "babel-runtime": "6.23.0",
+        "babel-runtime": "6.25.0",
         "babel-types": "6.25.0"
       }
     },
@@ -1517,7 +1406,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
       "integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
       "requires": {
-        "babel-runtime": "6.23.0"
+        "babel-runtime": "6.25.0"
       }
     },
     "babel-plugin-transform-es2015-modules-amd": {
@@ -1526,7 +1415,7 @@
       "integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
       "requires": {
         "babel-plugin-transform-es2015-modules-commonjs": "6.24.1",
-        "babel-runtime": "6.23.0",
+        "babel-runtime": "6.25.0",
         "babel-template": "6.25.0"
       }
     },
@@ -1536,7 +1425,7 @@
       "integrity": "sha1-0+MQtA72ZKNmIiAAl8bUQCmPK/4=",
       "requires": {
         "babel-plugin-transform-strict-mode": "6.24.1",
-        "babel-runtime": "6.23.0",
+        "babel-runtime": "6.25.0",
         "babel-template": "6.25.0",
         "babel-types": "6.25.0"
       }
@@ -1547,7 +1436,7 @@
       "integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
       "requires": {
         "babel-helper-hoist-variables": "6.24.1",
-        "babel-runtime": "6.23.0",
+        "babel-runtime": "6.25.0",
         "babel-template": "6.25.0"
       }
     },
@@ -1557,7 +1446,7 @@
       "integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
       "requires": {
         "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-        "babel-runtime": "6.23.0",
+        "babel-runtime": "6.25.0",
         "babel-template": "6.25.0"
       }
     },
@@ -1567,7 +1456,7 @@
       "integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
       "requires": {
         "babel-helper-replace-supers": "6.24.1",
-        "babel-runtime": "6.23.0"
+        "babel-runtime": "6.25.0"
       }
     },
     "babel-plugin-transform-es2015-parameters": {
@@ -1577,7 +1466,7 @@
       "requires": {
         "babel-helper-call-delegate": "6.24.1",
         "babel-helper-get-function-arity": "6.24.1",
-        "babel-runtime": "6.23.0",
+        "babel-runtime": "6.25.0",
         "babel-template": "6.25.0",
         "babel-traverse": "6.25.0",
         "babel-types": "6.25.0"
@@ -1588,7 +1477,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
       "integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
       "requires": {
-        "babel-runtime": "6.23.0",
+        "babel-runtime": "6.25.0",
         "babel-types": "6.25.0"
       }
     },
@@ -1597,7 +1486,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
       "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
       "requires": {
-        "babel-runtime": "6.23.0"
+        "babel-runtime": "6.25.0"
       }
     },
     "babel-plugin-transform-es2015-sticky-regex": {
@@ -1606,7 +1495,7 @@
       "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
       "requires": {
         "babel-helper-regex": "6.24.1",
-        "babel-runtime": "6.23.0",
+        "babel-runtime": "6.25.0",
         "babel-types": "6.25.0"
       }
     },
@@ -1615,7 +1504,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
       "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
       "requires": {
-        "babel-runtime": "6.23.0"
+        "babel-runtime": "6.25.0"
       }
     },
     "babel-plugin-transform-es2015-typeof-symbol": {
@@ -1623,7 +1512,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
       "integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
       "requires": {
-        "babel-runtime": "6.23.0"
+        "babel-runtime": "6.25.0"
       }
     },
     "babel-plugin-transform-es2015-unicode-regex": {
@@ -1632,7 +1521,7 @@
       "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
       "requires": {
         "babel-helper-regex": "6.24.1",
-        "babel-runtime": "6.23.0",
+        "babel-runtime": "6.25.0",
         "regexpu-core": "2.0.0"
       }
     },
@@ -1702,7 +1591,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
       "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
       "requires": {
-        "babel-runtime": "6.23.0",
+        "babel-runtime": "6.25.0",
         "babel-types": "6.25.0"
       }
     },
@@ -1717,8 +1606,8 @@
       "integrity": "sha1-g2TKYt+Or7gwSZ9pkXdGbDsDSZ0=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.23.0",
-        "core-js": "2.4.1",
+        "babel-runtime": "6.25.0",
+        "core-js": "2.5.0",
         "regenerator-runtime": "0.10.5"
       }
     },
@@ -1788,8 +1677,8 @@
       "integrity": "sha1-fhDhOi9xBlvfrVoXh7pFvKbe118=",
       "requires": {
         "babel-core": "6.25.0",
-        "babel-runtime": "6.23.0",
-        "core-js": "2.4.1",
+        "babel-runtime": "6.25.0",
+        "core-js": "2.5.0",
         "home-or-tmp": "2.0.0",
         "lodash": "4.17.4",
         "mkdirp": "0.5.1",
@@ -1797,11 +1686,11 @@
       }
     },
     "babel-runtime": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-      "integrity": "sha1-CpSJ8UTecO+zzkMArM2zKeL8VDs=",
+      "version": "6.25.0",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.25.0.tgz",
+      "integrity": "sha1-M7mOql1IK7AajRqmtDetKwGuxBw=",
       "requires": {
-        "core-js": "2.4.1",
+        "core-js": "2.5.0",
         "regenerator-runtime": "0.10.5"
       }
     },
@@ -1810,7 +1699,7 @@
       "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
       "integrity": "sha1-ZlJBFmt8KqTGGdceGSlpVSsQwHE=",
       "requires": {
-        "babel-runtime": "6.23.0",
+        "babel-runtime": "6.25.0",
         "babel-traverse": "6.25.0",
         "babel-types": "6.25.0",
         "babylon": "6.17.4",
@@ -1824,7 +1713,7 @@
       "requires": {
         "babel-code-frame": "6.22.0",
         "babel-messages": "6.23.0",
-        "babel-runtime": "6.23.0",
+        "babel-runtime": "6.25.0",
         "babel-types": "6.25.0",
         "babylon": "6.17.4",
         "debug": "2.6.8",
@@ -1838,7 +1727,7 @@
       "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
       "integrity": "sha1-cK+ySNVmDl0Y+BHZHIMDtUE0oY4=",
       "requires": {
-        "babel-runtime": "6.23.0",
+        "babel-runtime": "6.25.0",
         "esutils": "2.0.2",
         "lodash": "4.17.4",
         "to-fast-properties": "1.0.3"
@@ -2011,9 +1900,9 @@
       }
     },
     "binary-extensions": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.8.0.tgz",
-      "integrity": "sha1-SOyNFt9Dd+rl+liEaCSAr02Vx3Q=",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.9.0.tgz",
+      "integrity": "sha1-ZlBsFs5vTWkopbPNajPKQelB43s=",
       "dev": true,
       "optional": true
     },
@@ -2043,8 +1932,8 @@
         "bytes": "2.4.0",
         "content-type": "1.0.2",
         "debug": "2.6.7",
-        "depd": "1.1.0",
-        "http-errors": "1.6.1",
+        "depd": "1.1.1",
+        "http-errors": "1.6.2",
         "iconv-lite": "0.4.15",
         "on-finished": "2.3.0",
         "qs": "6.4.0",
@@ -2064,6 +1953,11 @@
           "requires": {
             "ms": "2.0.0"
           }
+        },
+        "qs": {
+          "version": "6.4.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
+          "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM="
         }
       }
     },
@@ -2302,7 +2196,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "anymatch": "1.3.0",
+        "anymatch": "1.3.2",
         "async-each": "1.0.1",
         "fsevents": "1.1.2",
         "glob-parent": "2.0.0",
@@ -2319,9 +2213,9 @@
       "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE="
     },
     "circular-json": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.1.tgz",
-      "integrity": "sha1-vos2rvzN6LPKeqLWr8B6NyQsDS0=",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
+      "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
       "dev": true
     },
     "clang-format": {
@@ -2332,7 +2226,7 @@
       "requires": {
         "async": "1.5.2",
         "glob": "7.1.2",
-        "resolve": "1.3.3"
+        "resolve": "1.4.0"
       },
       "dependencies": {
         "async": {
@@ -2504,12 +2398,9 @@
       }
     },
     "commander": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-      "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
-      "requires": {
-        "graceful-readlink": "1.0.1"
-      }
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+      "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ=="
     },
     "commondir": {
       "version": "1.0.1",
@@ -2543,9 +2434,9 @@
       }
     },
     "compressible": {
-      "version": "2.0.10",
-      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.10.tgz",
-      "integrity": "sha1-/tocf3YXkScyspv4zyYlKiC57s0=",
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.11.tgz",
+      "integrity": "sha1-FnGKdd4oPtjmBAQWJaIGRYZ5fYo=",
       "requires": {
         "mime-db": "1.29.0"
       }
@@ -2557,7 +2448,7 @@
       "requires": {
         "accepts": "1.3.3",
         "bytes": "2.5.0",
-        "compressible": "2.0.10",
+        "compressible": "2.0.11",
         "debug": "2.6.8",
         "on-headers": "1.0.1",
         "safe-buffer": "5.1.1",
@@ -2621,9 +2512,9 @@
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
     },
     "core-js": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
-      "integrity": "sha1-TekR5mew6ukSTjQlS1OupvxhjT4="
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.0.tgz",
+      "integrity": "sha1-VpwFCRi+ZIazg3VSAorgRmtxcIY="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -2666,7 +2557,7 @@
       "requires": {
         "lru-cache": "4.1.1",
         "shebang-command": "1.2.0",
-        "which": "1.2.14"
+        "which": "1.3.0"
       }
     },
     "cryptiles": {
@@ -2718,7 +2609,7 @@
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
       "dev": true,
       "requires": {
-        "es5-ext": "0.10.24"
+        "es5-ext": "0.10.26"
       }
     },
     "dargs": {
@@ -2833,7 +2724,7 @@
         "builtin-modules": "1.1.1",
         "deprecate": "1.0.0",
         "deps-regex": "0.1.4",
-        "js-yaml": "3.9.0",
+        "js-yaml": "3.9.1",
         "lodash": "4.17.4",
         "minimatch": "3.0.4",
         "require-package-name": "2.0.1",
@@ -2842,9 +2733,9 @@
       }
     },
     "depd": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz",
-      "integrity": "sha1-4b2Cxqq2ztlluXuIsX7T5SjKGMM="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
+      "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k="
     },
     "deprecate": {
       "version": "1.0.0",
@@ -2946,7 +2837,7 @@
       "resolved": "https://registry.npmjs.org/dom-urls/-/dom-urls-1.1.0.tgz",
       "integrity": "sha1-AB3fgWKM0ecGElxxdvU8zsVdkY4=",
       "requires": {
-        "urijs": "1.18.10"
+        "urijs": "1.18.11"
       }
     },
     "dom5": {
@@ -2955,16 +2846,16 @@
       "integrity": "sha1-pwiKn8XzsI3J9u2kx6uuskGUXg0=",
       "requires": {
         "@types/clone": "0.1.30",
-        "@types/node": "4.2.15",
+        "@types/node": "4.2.16",
         "@types/parse5": "0.0.31",
         "clone": "1.0.2",
         "parse5": "1.5.1"
       },
       "dependencies": {
         "@types/node": {
-          "version": "4.2.15",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-4.2.15.tgz",
-          "integrity": "sha512-CVNvOojxIYHDVqYF1hCa5y1IybpoKY8EXT/GUXtXEVTyF/ipld3eqWvIcyyNagpLPcZCcdswbfpOzdskSVwhWQ=="
+          "version": "4.2.16",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-4.2.16.tgz",
+          "integrity": "sha512-goVnbj0oGmXXGYjXviARHjgxj/rEyizBy3q0kYI/kb1yKDVaNrj0/vaFcYzfBQvFEbd3K+1SNru432et3/ys6w=="
         }
       }
     },
@@ -2990,11 +2881,11 @@
       "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
     },
     "duplexify": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.0.tgz",
-      "integrity": "sha1-GqdzAC4VeEV+nZ1KULDMquvL1gQ=",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.1.tgz",
+      "integrity": "sha512-j5goxHTwVED1Fpe5hh3q9R93Kip0Bg2KVAt4f8CEYM3UEwYcPSvWbXaUQOzdX/HtiNomipv+gU7ASQPDbV7pGQ==",
       "requires": {
-        "end-of-stream": "1.0.0",
+        "end-of-stream": "1.4.0",
         "inherits": "2.0.3",
         "readable-stream": "2.3.3",
         "stream-shift": "1.0.0"
@@ -3020,9 +2911,9 @@
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "ejs": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.5.6.tgz",
-      "integrity": "sha1-R5Y2v6P+Ox3r1SCH8KyyBLTxnIg="
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.5.7.tgz",
+      "integrity": "sha1-zIcsFoiArjxxiXYv1f/ACJbJUYo="
     },
     "encodeurl": {
       "version": "1.0.1",
@@ -3030,21 +2921,11 @@
       "integrity": "sha1-eePVhlU0aQn+bw9Fpd5oEDspTSA="
     },
     "end-of-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
-      "integrity": "sha1-1FlucCc0qT5A6a+GQxnqvZn/Lw4=",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
+      "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
       "requires": {
-        "once": "1.3.3"
-      },
-      "dependencies": {
-        "once": {
-          "version": "1.3.3",
-          "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-          "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
-          "requires": {
-            "wrappy": "1.0.2"
-          }
-        }
+        "once": "1.4.0"
       }
     },
     "ends-with": {
@@ -3159,13 +3040,14 @@
       }
     },
     "es-abstract": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.7.0.tgz",
-      "integrity": "sha1-363ndOAb/Nl/lhgCmMRJyGI/uUw=",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.8.0.tgz",
+      "integrity": "sha512-Cf9/h5MrXtExM20gSS55YFrGKCyPrRBjIVBtVyy8vmlsDfe0NPKMWj65tPLgzyfPuapWxh5whpXCtW4+AW5mRg==",
       "dev": true,
       "requires": {
         "es-to-primitive": "1.1.1",
         "function-bind": "1.1.0",
+        "has": "1.0.1",
         "is-callable": "1.1.3",
         "is-regex": "1.0.4"
       }
@@ -3182,9 +3064,9 @@
       }
     },
     "es5-ext": {
-      "version": "0.10.24",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.24.tgz",
-      "integrity": "sha1-pVh3yZJLwMjZvTwsvhdJWsFwmxQ=",
+      "version": "0.10.26",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.26.tgz",
+      "integrity": "sha1-UbISilMbcMT2dkCTpzy+u4IYY3I=",
       "dev": true,
       "requires": {
         "es6-iterator": "2.0.1",
@@ -3198,7 +3080,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.24",
+        "es5-ext": "0.10.26",
         "es6-symbol": "3.1.1"
       }
     },
@@ -3209,7 +3091,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.24",
+        "es5-ext": "0.10.26",
         "es6-iterator": "2.0.1",
         "es6-set": "0.1.5",
         "es6-symbol": "3.1.1",
@@ -3228,7 +3110,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.24",
+        "es5-ext": "0.10.26",
         "es6-iterator": "2.0.1",
         "es6-symbol": "3.1.1",
         "event-emitter": "0.3.5"
@@ -3241,7 +3123,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.24"
+        "es5-ext": "0.10.26"
       }
     },
     "es6-weak-map": {
@@ -3251,7 +3133,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.24",
+        "es5-ext": "0.10.26",
         "es6-iterator": "2.0.1",
         "es6-symbol": "3.1.1"
       }
@@ -3318,7 +3200,7 @@
         "debug": "2.6.8",
         "doctrine": "2.0.0",
         "escope": "3.6.0",
-        "espree": "3.4.3",
+        "espree": "3.5.0",
         "esquery": "1.0.0",
         "estraverse": "4.2.0",
         "esutils": "2.0.2",
@@ -3330,7 +3212,7 @@
         "inquirer": "0.12.0",
         "is-my-json-valid": "2.16.0",
         "is-resolvable": "1.0.0",
-        "js-yaml": "3.9.0",
+        "js-yaml": "3.9.1",
         "json-stable-stringify": "1.0.1",
         "levn": "0.3.0",
         "lodash": "4.17.4",
@@ -3388,9 +3270,9 @@
       }
     },
     "espree": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-3.4.3.tgz",
-      "integrity": "sha1-KRC1zNSc6JPC//+qtP2LOjG4I3Q=",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.0.tgz",
+      "integrity": "sha1-mDWGJb3QVYYeon4oZ+pyn69GPY0=",
       "requires": {
         "acorn": "5.1.1",
         "acorn-jsx": "3.0.1"
@@ -3442,7 +3324,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.24"
+        "es5-ext": "0.10.26"
       }
     },
     "eventemitter3": {
@@ -3495,9 +3377,9 @@
       }
     },
     "express": {
-      "version": "4.15.3",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.15.3.tgz",
-      "integrity": "sha1-urZdDwOqgMNYQIly/HAPkWlEtmI=",
+      "version": "4.15.4",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.15.4.tgz",
+      "integrity": "sha1-Ay4iU0ic+PzgJma+yj0R7XotrtE=",
       "requires": {
         "accepts": "1.3.3",
         "array-flatten": "1.1.1",
@@ -3505,23 +3387,23 @@
         "content-type": "1.0.2",
         "cookie": "0.3.1",
         "cookie-signature": "1.0.6",
-        "debug": "2.6.7",
-        "depd": "1.1.0",
+        "debug": "2.6.8",
+        "depd": "1.1.1",
         "encodeurl": "1.0.1",
         "escape-html": "1.0.3",
         "etag": "1.8.0",
-        "finalhandler": "1.0.3",
+        "finalhandler": "1.0.4",
         "fresh": "0.5.0",
         "merge-descriptors": "1.0.1",
         "methods": "1.1.2",
         "on-finished": "2.3.0",
         "parseurl": "1.3.1",
         "path-to-regexp": "0.1.7",
-        "proxy-addr": "1.1.4",
-        "qs": "6.4.0",
+        "proxy-addr": "1.1.5",
+        "qs": "6.5.0",
         "range-parser": "1.2.0",
-        "send": "0.15.3",
-        "serve-static": "1.12.3",
+        "send": "0.15.4",
+        "serve-static": "1.12.4",
         "setprototypeof": "1.0.3",
         "statuses": "1.3.1",
         "type-is": "1.6.15",
@@ -3529,14 +3411,6 @@
         "vary": "1.1.1"
       },
       "dependencies": {
-        "debug": {
-          "version": "2.6.7",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.7.tgz",
-          "integrity": "sha1-krrR9tBbu2u6Isyoi80OyJTChh4=",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
         "mime": {
           "version": "1.3.4",
           "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
@@ -3548,18 +3422,18 @@
           "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
         },
         "send": {
-          "version": "0.15.3",
-          "resolved": "https://registry.npmjs.org/send/-/send-0.15.3.tgz",
-          "integrity": "sha1-UBP5+ZAj31DRvZiSwZ4979HVMwk=",
+          "version": "0.15.4",
+          "resolved": "https://registry.npmjs.org/send/-/send-0.15.4.tgz",
+          "integrity": "sha1-mF+qPihLAnPHkzZKNcZze9k5Bbk=",
           "requires": {
-            "debug": "2.6.7",
-            "depd": "1.1.0",
+            "debug": "2.6.8",
+            "depd": "1.1.1",
             "destroy": "1.0.4",
             "encodeurl": "1.0.1",
             "escape-html": "1.0.3",
             "etag": "1.8.0",
             "fresh": "0.5.0",
-            "http-errors": "1.6.1",
+            "http-errors": "1.6.2",
             "mime": "1.3.4",
             "ms": "2.0.0",
             "on-finished": "2.3.0",
@@ -3630,9 +3504,9 @@
       }
     },
     "extsprintf": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
-      "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA="
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
     },
     "eyes": {
       "version": "0.1.8",
@@ -3713,27 +3587,17 @@
       "integrity": "sha1-w8T2xmO5I0WamqKZEtLQMfFQf4Q="
     },
     "finalhandler": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.0.3.tgz",
-      "integrity": "sha1-70fneVDpmXgOhgIqVg4yF+DQzIk=",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.0.4.tgz",
+      "integrity": "sha512-16l/r8RgzlXKmFOhZpHBztvye+lAhC5SU7hXavnerC9UfZqZxxXl3BzL8MhffPT3kF61lj9Oav2LKEzh0ei7tg==",
       "requires": {
-        "debug": "2.6.7",
+        "debug": "2.6.8",
         "encodeurl": "1.0.1",
         "escape-html": "1.0.3",
         "on-finished": "2.3.0",
         "parseurl": "1.3.1",
         "statuses": "1.3.1",
         "unpipe": "1.0.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.7",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.7.tgz",
-          "integrity": "sha1-krrR9tBbu2u6Isyoi80OyJTChh4=",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
       }
     },
     "find-index": {
@@ -3827,7 +3691,7 @@
       "integrity": "sha1-+oZxTnLCHbiGAXYezy9VXRq8a5Y=",
       "dev": true,
       "requires": {
-        "circular-json": "0.3.1",
+        "circular-json": "0.3.3",
         "del": "2.2.2",
         "graceful-fs": "4.1.11",
         "write": "0.2.1"
@@ -3878,7 +3742,7 @@
       "requires": {
         "asynckit": "0.4.0",
         "combined-stream": "1.0.5",
-        "mime-types": "2.1.15"
+        "mime-types": "2.1.16"
       }
     },
     "formatio": {
@@ -5093,7 +4957,7 @@
         "homedir-polyfill": "1.0.1",
         "ini": "1.3.4",
         "is-windows": "0.2.0",
-        "which": "1.2.14"
+        "which": "1.3.0"
       }
     },
     "globals": {
@@ -5429,7 +5293,7 @@
       "dev": true,
       "requires": {
         "gulp-util": "3.0.8",
-        "mocha": "3.4.2",
+        "mocha": "3.5.0",
         "plur": "2.1.2",
         "req-cwd": "1.0.1",
         "temp": "0.8.3",
@@ -5449,9 +5313,9 @@
       }
     },
     "gulp-spawn-mocha": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/gulp-spawn-mocha/-/gulp-spawn-mocha-3.3.0.tgz",
-      "integrity": "sha1-0KkwFhuSQrlbe2CwWuLHUoODlFQ=",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/gulp-spawn-mocha/-/gulp-spawn-mocha-3.3.1.tgz",
+      "integrity": "sha512-0DoyYQ4+MmARhs6N0Yr5+Sm8K8aN0SwJoxpRl6YfWPP2nZhMLHtDx7grm7Bw5cr0VR2urkG/p36rRAbCqzaP2A==",
       "dev": true,
       "requires": {
         "gulp-util": "3.0.8",
@@ -5490,7 +5354,7 @@
       "requires": {
         "through2": "2.0.3",
         "typings-core": "1.6.1",
-        "typings-global": "1.0.19"
+        "typings-global": "1.0.20"
       }
     },
     "gulp-util": {
@@ -5854,18 +5718,18 @@
       }
     },
     "html-minifier": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.5.2.tgz",
-      "integrity": "sha1-1zvD/0SJQkCIGM5gm/P7DqfvTrc=",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.5.3.tgz",
+      "integrity": "sha512-iKRzQQDuTCsq0Ultbi/mfJJnR0D3AdZKTq966Gsp92xkmAPCV4Xi08qhJ0Dl3ZAWemSgJ7qZK+UsZc0gFqK6wg==",
       "requires": {
         "camel-case": "3.0.0",
         "clean-css": "4.1.7",
-        "commander": "2.9.0",
+        "commander": "2.11.0",
         "he": "1.1.1",
         "ncname": "1.0.0",
         "param-case": "2.1.1",
         "relateurl": "0.2.7",
-        "uglify-js": "3.0.25"
+        "uglify-js": "3.0.27"
       }
     },
     "http-deceiver": {
@@ -5874,11 +5738,11 @@
       "integrity": "sha1-+nFolEq5pRnTN8sL7HKE3D5yPYc="
     },
     "http-errors": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.1.tgz",
-      "integrity": "sha1-X4uO2YrKVFZWv1cplzh/kEpyIlc=",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
+      "integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
       "requires": {
-        "depd": "1.1.0",
+        "depd": "1.1.1",
         "inherits": "2.0.3",
         "setprototypeof": "1.0.3",
         "statuses": "1.3.1"
@@ -5936,7 +5800,7 @@
       "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
       "requires": {
         "assert-plus": "0.2.0",
-        "jsprim": "1.4.0",
+        "jsprim": "1.4.1",
         "sshpk": "1.13.1"
       }
     },
@@ -6050,9 +5914,9 @@
       "dev": true
     },
     "ipaddr.js": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.3.0.tgz",
-      "integrity": "sha1-HgOlL9rYOou7KyXL9JmLTP/NPew="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.4.0.tgz",
+      "integrity": "sha1-KWrKh4qCGBbluF0KKFqZvP9FgvA="
     },
     "irregular-plurals": {
       "version": "1.3.0",
@@ -6081,7 +5945,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "binary-extensions": "1.8.0"
+        "binary-extensions": "1.9.0"
       }
     },
     "is-buffer": {
@@ -6376,13 +6240,13 @@
         "esprima": "2.7.3",
         "glob": "5.0.15",
         "handlebars": "4.0.10",
-        "js-yaml": "3.9.0",
+        "js-yaml": "3.9.1",
         "mkdirp": "0.5.1",
         "nopt": "3.0.6",
         "once": "1.4.0",
         "resolve": "1.1.7",
         "supports-color": "3.2.3",
-        "which": "1.2.14",
+        "which": "1.3.0",
         "wordwrap": "1.0.0"
       },
       "dependencies": {
@@ -6447,9 +6311,9 @@
       "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
     },
     "js-yaml": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.9.0.tgz",
-      "integrity": "sha512-0LoUNELX4S+iofCT8f4uEHIiRBR+c2AINyC8qRWfC6QNruLtxVZRJaPcu/xwMgFIgDxF25tGHaDjvxzJCNE9yw==",
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.9.1.tgz",
+      "integrity": "sha512-CbcG379L1e+mWBnLvHWWeLs8GyV/EMw862uLI3c+GxVyDHWZcjZinwuBd3iW2pgxgIlksW/1vNJa4to+RvDOww==",
       "dev": true,
       "requires": {
         "argparse": "1.0.9",
@@ -6471,9 +6335,9 @@
       "optional": true
     },
     "jschardet": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/jschardet/-/jschardet-1.5.0.tgz",
-      "integrity": "sha512-+Q8JsoEQbrdE+a/gg1F9XO92gcKXgpE5UACqr0sIubjDmBEkd+OOWPGzQeMrWSLxd73r4dHxBeRW7edHu5LmJQ==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/jschardet/-/jschardet-1.5.1.tgz",
+      "integrity": "sha512-vE2hT1D0HLZCLLclfBSfkfTTedhVj0fubHpJBHKwwUWX0nSbhPAfk+SG9rTX95BYNmau8rGFfCeaT6T5OW1C2A==",
       "dev": true
     },
     "jsesc": {
@@ -6534,14 +6398,14 @@
       "integrity": "sha1-PO3o4+QR03eHLu+8n98mODy8Ptk="
     },
     "jsprim": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
-      "integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
       "requires": {
         "assert-plus": "1.0.0",
-        "extsprintf": "1.0.2",
+        "extsprintf": "1.3.0",
         "json-schema": "0.2.3",
-        "verror": "1.3.6"
+        "verror": "1.10.0"
       },
       "dependencies": {
         "assert-plus": {
@@ -6650,7 +6514,7 @@
         "lodash.isstring": "4.0.1",
         "lodash.mapvalues": "4.6.0",
         "rechoir": "0.6.2",
-        "resolve": "1.3.3"
+        "resolve": "1.4.0"
       }
     },
     "listify": {
@@ -6974,7 +6838,7 @@
       "requires": {
         "commondir": "1.0.1",
         "deep-extend": "0.4.2",
-        "ejs": "2.5.6",
+        "ejs": "2.5.7",
         "glob": "7.1.2",
         "globby": "6.1.0",
         "mkdirp": "0.5.1",
@@ -7134,18 +6998,11 @@
       "integrity": "sha1-SNJtI1WJZRcErFkWygYAGRQmaHg="
     },
     "mime-types": {
-      "version": "2.1.15",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
-      "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
+      "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.16.tgz",
+      "integrity": "sha1-K4WKUuXs1RbbiXrCvodIeDBpjiM=",
       "requires": {
-        "mime-db": "1.27.0"
-      },
-      "dependencies": {
-        "mime-db": {
-          "version": "1.27.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
-          "integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE="
-        }
+        "mime-db": "1.29.0"
       }
     },
     "mimic-fn": {
@@ -7189,13 +7046,13 @@
       }
     },
     "mocha": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.4.2.tgz",
-      "integrity": "sha1-0O9NMyEm2/GNDWQMmzgt1IvpdZQ=",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.5.0.tgz",
+      "integrity": "sha512-pIU2PJjrPYvYRqVpjXzj76qltO9uBYI7woYAMoxbSefsa+vqAfptjoeevd6bUgwD0mPIO+hv9f7ltvsNreL2PA==",
       "requires": {
         "browser-stdout": "1.3.0",
         "commander": "2.9.0",
-        "debug": "2.6.0",
+        "debug": "2.6.8",
         "diff": "3.2.0",
         "escape-string-regexp": "1.0.5",
         "glob": "7.1.1",
@@ -7206,12 +7063,12 @@
         "supports-color": "3.1.2"
       },
       "dependencies": {
-        "debug": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.0.tgz",
-          "integrity": "sha1-vFlryr52F/Edn6FTYe3tVgi4SZs=",
+        "commander": {
+          "version": "2.9.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+          "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
           "requires": {
-            "ms": "0.7.2"
+            "graceful-readlink": "1.0.1"
           }
         },
         "glob": {
@@ -7226,11 +7083,6 @@
             "once": "1.4.0",
             "path-is-absolute": "1.0.1"
           }
-        },
-        "ms": {
-          "version": "0.7.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
-          "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U="
         },
         "supports-color": {
           "version": "3.1.2",
@@ -7415,7 +7267,7 @@
       "requires": {
         "hosted-git-info": "2.5.0",
         "is-builtin-module": "1.0.0",
-        "semver": "5.3.0",
+        "semver": "5.4.1",
         "validate-npm-package-license": "3.0.1"
       }
     },
@@ -7498,7 +7350,7 @@
       "dev": true,
       "requires": {
         "define-properties": "1.1.2",
-        "es-abstract": "1.7.0"
+        "es-abstract": "1.8.0"
       }
     },
     "object.omit": {
@@ -7705,7 +7557,7 @@
         "got": "5.7.1",
         "registry-auth-token": "3.3.1",
         "registry-url": "3.1.0",
-        "semver": "5.3.0"
+        "semver": "5.4.1"
       }
     },
     "pako": {
@@ -7890,7 +7742,7 @@
       "resolved": "https://registry.npmjs.org/peek-stream/-/peek-stream-1.1.2.tgz",
       "integrity": "sha1-l+t2NlvP2MieKH9VyLadTD6bzFI=",
       "requires": {
-        "duplexify": "3.5.0",
+        "duplexify": "3.5.1",
         "through2": "2.0.3"
       }
     },
@@ -7900,7 +7752,7 @@
       "integrity": "sha1-04f5lvKSx8nepjmlNYBedMtQMWE=",
       "requires": {
         "os-tmpdir": "1.0.2",
-        "which": "1.2.14"
+        "which": "1.3.0"
       }
     },
     "pend": {
@@ -7967,9 +7819,9 @@
       }
     },
     "polymer-analyzer": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/polymer-analyzer/-/polymer-analyzer-2.2.1.tgz",
-      "integrity": "sha512-fL0DhAzGWyyFBX4VbkWSAlR9OrAzchCQJTZ8EI7l+QJwQmBg58K4UKojT9ASCc8+6QMZFNHDjzrmxDI8u/+GJA==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/polymer-analyzer/-/polymer-analyzer-2.2.2.tgz",
+      "integrity": "sha512-8kwxAAx95AMJbDQ1x6vKyCkTDnowG5q1nn8gPf91PP+GNgQhgVRPBeLZQzpPyHY7dplvOyEoBhtjZvaQDg5teA==",
       "requires": {
         "@types/chai-subset": "1.3.0",
         "@types/chalk": "0.4.31",
@@ -7978,7 +7830,7 @@
         "@types/doctrine": "0.0.1",
         "@types/escodegen": "0.0.2",
         "@types/estree": "0.0.34",
-        "@types/node": "6.0.84",
+        "@types/node": "6.0.85",
         "@types/parse5": "2.2.34",
         "chalk": "1.1.3",
         "clone": "2.1.1",
@@ -7986,7 +7838,7 @@
         "doctrine": "2.0.0",
         "dom5": "2.3.0",
         "escodegen": "1.8.1",
-        "espree": "3.4.3",
+        "espree": "3.5.0",
         "estraverse": "4.2.0",
         "jsonschema": "1.1.1",
         "parse5": "2.2.3",
@@ -7995,16 +7847,16 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "6.0.84",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.84.tgz",
-          "integrity": "sha512-1SvEazClhUBRNroJM3oB3xf3u2r6xGmHDGbdigqNPHvNKLl8/BtATgO9eC04ZLuovpSh0B20BF1QJxdi+qmTlg=="
+          "version": "6.0.85",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.85.tgz",
+          "integrity": "sha512-6qLZpfQFO/g5Ns2e7RsW6brk0Q6Xzwiw7kVVU/XiQNOiJXSojhX76GP457PBYIsNMH2WfcGgcnZB4awFDHrwpA=="
         },
         "@types/parse5": {
           "version": "2.2.34",
           "resolved": "https://registry.npmjs.org/@types/parse5/-/parse5-2.2.34.tgz",
           "integrity": "sha1-44cKEOgnNacg9i1x3NGDunjvOp0=",
           "requires": {
-            "@types/node": "6.0.84"
+            "@types/node": "6.0.85"
           }
         },
         "clone": {
@@ -8018,7 +7870,7 @@
           "integrity": "sha1-+CBJdb0NrLvltYqKk//B/tD/zSo=",
           "requires": {
             "@types/clone": "0.1.30",
-            "@types/node": "6.0.84",
+            "@types/node": "6.0.85",
             "@types/parse5": "2.2.34",
             "clone": "2.1.1",
             "parse5": "2.2.3"
@@ -8042,7 +7894,7 @@
       "integrity": "sha512-3m5BiEBZBYV3+tHk5OBgxypfQBkP3MuYpp8UbdQblf2uR1JopyWsLw55xbxdCpHqbjG0/KqSE9FcHx+ZGRKpkQ==",
       "requires": {
         "@types/mz": "0.0.31",
-        "@types/node": "6.0.84",
+        "@types/node": "6.0.85",
         "@types/parse5": "2.2.34",
         "@types/vinyl": "2.0.0",
         "@types/vinyl-fs": "0.0.28",
@@ -8051,7 +7903,7 @@
         "mz": "2.6.0",
         "parse5": "2.2.3",
         "plylog": "0.5.0",
-        "polymer-analyzer": "2.2.1",
+        "polymer-analyzer": "2.2.2",
         "polymer-bundler": "3.0.1",
         "polymer-project-config": "3.4.0",
         "sw-precache": "5.2.0",
@@ -8060,16 +7912,16 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "6.0.84",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.84.tgz",
-          "integrity": "sha512-1SvEazClhUBRNroJM3oB3xf3u2r6xGmHDGbdigqNPHvNKLl8/BtATgO9eC04ZLuovpSh0B20BF1QJxdi+qmTlg=="
+          "version": "6.0.85",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.85.tgz",
+          "integrity": "sha512-6qLZpfQFO/g5Ns2e7RsW6brk0Q6Xzwiw7kVVU/XiQNOiJXSojhX76GP457PBYIsNMH2WfcGgcnZB4awFDHrwpA=="
         },
         "@types/parse5": {
           "version": "2.2.34",
           "resolved": "https://registry.npmjs.org/@types/parse5/-/parse5-2.2.34.tgz",
           "integrity": "sha1-44cKEOgnNacg9i1x3NGDunjvOp0=",
           "requires": {
-            "@types/node": "6.0.84"
+            "@types/node": "6.0.85"
           }
         },
         "clone": {
@@ -8083,7 +7935,7 @@
           "integrity": "sha1-+CBJdb0NrLvltYqKk//B/tD/zSo=",
           "requires": {
             "@types/clone": "0.1.30",
-            "@types/node": "6.0.84",
+            "@types/node": "6.0.85",
             "@types/parse5": "2.2.34",
             "clone": "2.1.1",
             "parse5": "2.2.3"
@@ -8099,15 +7951,15 @@
           "resolved": "https://registry.npmjs.org/plylog/-/plylog-0.5.0.tgz",
           "integrity": "sha1-yXbrodgNLdmRAF18EQ2vh0FUeI8=",
           "requires": {
-            "@types/node": "4.2.15",
-            "@types/winston": "2.3.3",
+            "@types/node": "4.2.16",
+            "@types/winston": "2.3.4",
             "winston": "2.3.1"
           },
           "dependencies": {
             "@types/node": {
-              "version": "4.2.15",
-              "resolved": "https://registry.npmjs.org/@types/node/-/node-4.2.15.tgz",
-              "integrity": "sha512-CVNvOojxIYHDVqYF1hCa5y1IybpoKY8EXT/GUXtXEVTyF/ipld3eqWvIcyyNagpLPcZCcdswbfpOzdskSVwhWQ=="
+              "version": "4.2.16",
+              "resolved": "https://registry.npmjs.org/@types/node/-/node-4.2.16.tgz",
+              "integrity": "sha512-goVnbj0oGmXXGYjXviARHjgxj/rEyizBy3q0kYI/kb1yKDVaNrj0/vaFcYzfBQvFEbd3K+1SNru432et3/ys6w=="
             }
           }
         }
@@ -8122,19 +7974,24 @@
         "command-line-args": "3.0.5",
         "command-line-usage": "3.0.8",
         "dom5": "2.3.0",
-        "espree": "3.4.3",
+        "espree": "3.5.0",
         "mkdirp": "0.5.1",
         "parse5": "2.2.3",
-        "polymer-analyzer": "2.2.1",
+        "polymer-analyzer": "2.2.2",
         "source-map": "0.5.6"
       },
       "dependencies": {
+        "@types/node": {
+          "version": "6.0.85",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.85.tgz",
+          "integrity": "sha512-6qLZpfQFO/g5Ns2e7RsW6brk0Q6Xzwiw7kVVU/XiQNOiJXSojhX76GP457PBYIsNMH2WfcGgcnZB4awFDHrwpA=="
+        },
         "@types/parse5": {
           "version": "2.2.34",
           "resolved": "https://registry.npmjs.org/@types/parse5/-/parse5-2.2.34.tgz",
           "integrity": "sha1-44cKEOgnNacg9i1x3NGDunjvOp0=",
           "requires": {
-            "@types/node": "6.0.65"
+            "@types/node": "6.0.85"
           }
         },
         "clone": {
@@ -8148,7 +8005,7 @@
           "integrity": "sha1-+CBJdb0NrLvltYqKk//B/tD/zSo=",
           "requires": {
             "@types/clone": "0.1.30",
-            "@types/node": "6.0.65",
+            "@types/node": "6.0.85",
             "@types/parse5": "2.2.34",
             "clone": "2.1.1",
             "parse5": "2.2.3"
@@ -8168,27 +8025,27 @@
       "requires": {
         "@types/estree": "0.0.34",
         "@types/fast-levenshtein": "0.0.1",
-        "@types/node": "6.0.84",
+        "@types/node": "6.0.85",
         "@types/parse5": "2.2.34",
         "dom5": "2.3.0",
         "estraverse": "4.2.0",
         "fast-levenshtein": "2.0.6",
         "parse5": "2.2.3",
-        "polymer-analyzer": "2.2.1",
+        "polymer-analyzer": "2.2.2",
         "strip-indent": "2.0.0"
       },
       "dependencies": {
         "@types/node": {
-          "version": "6.0.84",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.84.tgz",
-          "integrity": "sha512-1SvEazClhUBRNroJM3oB3xf3u2r6xGmHDGbdigqNPHvNKLl8/BtATgO9eC04ZLuovpSh0B20BF1QJxdi+qmTlg=="
+          "version": "6.0.85",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.85.tgz",
+          "integrity": "sha512-6qLZpfQFO/g5Ns2e7RsW6brk0Q6Xzwiw7kVVU/XiQNOiJXSojhX76GP457PBYIsNMH2WfcGgcnZB4awFDHrwpA=="
         },
         "@types/parse5": {
           "version": "2.2.34",
           "resolved": "https://registry.npmjs.org/@types/parse5/-/parse5-2.2.34.tgz",
           "integrity": "sha1-44cKEOgnNacg9i1x3NGDunjvOp0=",
           "requires": {
-            "@types/node": "6.0.84"
+            "@types/node": "6.0.85"
           }
         },
         "clone": {
@@ -8202,7 +8059,7 @@
           "integrity": "sha1-+CBJdb0NrLvltYqKk//B/tD/zSo=",
           "requires": {
             "@types/clone": "0.1.30",
-            "@types/node": "6.0.84",
+            "@types/node": "6.0.85",
             "@types/parse5": "2.2.34",
             "clone": "2.1.1",
             "parse5": "2.2.3"
@@ -8225,49 +8082,49 @@
       "resolved": "https://registry.npmjs.org/polymer-project-config/-/polymer-project-config-3.4.0.tgz",
       "integrity": "sha512-MhrStBi1lZvrk9Ia2ePGp8kHHiXO5Pjif6uznHp4iv1d3dVrrRRvCtgI7Wbv/wJAimZuJ+xdhLIsqB5HZT+Sfg==",
       "requires": {
-        "@types/node": "6.0.84",
+        "@types/node": "6.0.85",
         "jsonschema": "1.1.1",
         "minimatch-all": "1.1.0",
         "plylog": "0.5.0"
       },
       "dependencies": {
         "@types/node": {
-          "version": "6.0.84",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.84.tgz",
-          "integrity": "sha512-1SvEazClhUBRNroJM3oB3xf3u2r6xGmHDGbdigqNPHvNKLl8/BtATgO9eC04ZLuovpSh0B20BF1QJxdi+qmTlg=="
+          "version": "6.0.85",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.85.tgz",
+          "integrity": "sha512-6qLZpfQFO/g5Ns2e7RsW6brk0Q6Xzwiw7kVVU/XiQNOiJXSojhX76GP457PBYIsNMH2WfcGgcnZB4awFDHrwpA=="
         },
         "plylog": {
           "version": "0.5.0",
           "resolved": "https://registry.npmjs.org/plylog/-/plylog-0.5.0.tgz",
           "integrity": "sha1-yXbrodgNLdmRAF18EQ2vh0FUeI8=",
           "requires": {
-            "@types/node": "4.2.15",
-            "@types/winston": "2.3.3",
+            "@types/node": "4.2.16",
+            "@types/winston": "2.3.4",
             "winston": "2.3.1"
           },
           "dependencies": {
             "@types/node": {
-              "version": "4.2.15",
-              "resolved": "https://registry.npmjs.org/@types/node/-/node-4.2.15.tgz",
-              "integrity": "sha512-CVNvOojxIYHDVqYF1hCa5y1IybpoKY8EXT/GUXtXEVTyF/ipld3eqWvIcyyNagpLPcZCcdswbfpOzdskSVwhWQ=="
+              "version": "4.2.16",
+              "resolved": "https://registry.npmjs.org/@types/node/-/node-4.2.16.tgz",
+              "integrity": "sha512-goVnbj0oGmXXGYjXviARHjgxj/rEyizBy3q0kYI/kb1yKDVaNrj0/vaFcYzfBQvFEbd3K+1SNru432et3/ys6w=="
             }
           }
         }
       }
     },
     "polyserve": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/polyserve/-/polyserve-0.19.1.tgz",
-      "integrity": "sha1-drKNwHaGbWz4ZXeW9louHpVoEqU=",
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/polyserve/-/polyserve-0.20.0.tgz",
+      "integrity": "sha512-i99n2lHz2Xuje7dRZAFx4DhLPLhZyDiiBz6QLaq0TmWEjqoDYsf/EFikemD2SEz8Cf4Q03Tn0E6EZ742KuXGhw==",
       "requires": {
         "@types/assert": "0.0.29",
-        "@types/babel-core": "6.7.14",
+        "@types/babel-core": "6.25.0",
         "@types/compression": "0.0.33",
         "@types/content-type": "1.1.0",
         "@types/express": "4.0.36",
         "@types/mime": "0.0.29",
         "@types/mz": "0.0.29",
-        "@types/node": "6.0.84",
+        "@types/node": "8.0.20",
         "@types/opn": "3.0.28",
         "@types/parse5": "2.2.34",
         "@types/pem": "1.9.2",
@@ -8299,7 +8156,7 @@
         "compression": "1.7.0",
         "content-type": "1.0.2",
         "dom5": "2.3.0",
-        "express": "4.15.3",
+        "express": "4.15.4",
         "find-port": "1.0.1",
         "http-proxy-middleware": "0.17.4",
         "lru-cache": "4.1.1",
@@ -8308,11 +8165,11 @@
         "opn": "3.0.3",
         "parse5": "2.2.3",
         "pem": "1.9.7",
-        "polymer-build": "1.6.0",
-        "resolve": "1.3.3",
+        "polymer-build": "2.0.0",
+        "resolve": "1.4.0",
         "send": "0.14.2",
         "spdy": "3.4.7",
-        "ua-parser-js": "0.7.13"
+        "ua-parser-js": "0.7.14"
       },
       "dependencies": {
         "@types/mz": {
@@ -8321,20 +8178,20 @@
           "integrity": "sha1-vCRyjGSZc/HHhR6QM/nOUlZowns=",
           "requires": {
             "@types/bluebird": "3.5.8",
-            "@types/node": "6.0.84"
+            "@types/node": "8.0.20"
           }
         },
         "@types/node": {
-          "version": "6.0.84",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.84.tgz",
-          "integrity": "sha512-1SvEazClhUBRNroJM3oB3xf3u2r6xGmHDGbdigqNPHvNKLl8/BtATgO9eC04ZLuovpSh0B20BF1QJxdi+qmTlg=="
+          "version": "8.0.20",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.20.tgz",
+          "integrity": "sha512-MnB7YEpmLUyEWRVRhKpRs4swwqITnY8BcVFPoTuCl99SCplI/lLUiU5vcJ/OANDqwkpdIg0pDEM38K22KQT2RA=="
         },
         "@types/parse5": {
           "version": "2.2.34",
           "resolved": "https://registry.npmjs.org/@types/parse5/-/parse5-2.2.34.tgz",
           "integrity": "sha1-44cKEOgnNacg9i1x3NGDunjvOp0=",
           "requires": {
-            "@types/node": "6.0.84"
+            "@types/node": "8.0.20"
           }
         },
         "clone": {
@@ -8348,82 +8205,23 @@
           "integrity": "sha1-+CBJdb0NrLvltYqKk//B/tD/zSo=",
           "requires": {
             "@types/clone": "0.1.30",
-            "@types/node": "6.0.84",
+            "@types/node": "6.0.85",
             "@types/parse5": "2.2.34",
             "clone": "2.1.1",
             "parse5": "2.2.3"
+          },
+          "dependencies": {
+            "@types/node": {
+              "version": "6.0.85",
+              "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.85.tgz",
+              "integrity": "sha512-6qLZpfQFO/g5Ns2e7RsW6brk0Q6Xzwiw7kVVU/XiQNOiJXSojhX76GP457PBYIsNMH2WfcGgcnZB4awFDHrwpA=="
+            }
           }
         },
         "parse5": {
           "version": "2.2.3",
           "resolved": "https://registry.npmjs.org/parse5/-/parse5-2.2.3.tgz",
           "integrity": "sha1-DE/EHBAAxea5PUiwP4CDg3g06fY="
-        },
-        "plylog": {
-          "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/plylog/-/plylog-0.5.0.tgz",
-          "integrity": "sha1-yXbrodgNLdmRAF18EQ2vh0FUeI8=",
-          "requires": {
-            "@types/node": "4.2.15",
-            "@types/winston": "2.3.3",
-            "winston": "2.3.1"
-          },
-          "dependencies": {
-            "@types/node": {
-              "version": "4.2.15",
-              "resolved": "https://registry.npmjs.org/@types/node/-/node-4.2.15.tgz",
-              "integrity": "sha512-CVNvOojxIYHDVqYF1hCa5y1IybpoKY8EXT/GUXtXEVTyF/ipld3eqWvIcyyNagpLPcZCcdswbfpOzdskSVwhWQ=="
-            }
-          }
-        },
-        "polymer-build": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/polymer-build/-/polymer-build-1.6.0.tgz",
-          "integrity": "sha512-XN4KLx87NTpgIdOobTmGYxvaKjObc2Rmu1/b6Tp2uAOUH0hPeaxHXSOH+ZS+gDBXA71KMcnNcWLESosSE3XUOA==",
-          "requires": {
-            "@types/mz": "0.0.31",
-            "@types/node": "6.0.84",
-            "@types/parse5": "2.2.34",
-            "@types/vinyl": "2.0.0",
-            "@types/vinyl-fs": "0.0.28",
-            "dom5": "2.3.0",
-            "multipipe": "1.0.2",
-            "mz": "2.6.0",
-            "parse5": "2.2.3",
-            "plylog": "0.5.0",
-            "polymer-analyzer": "2.2.1",
-            "polymer-bundler": "2.3.1",
-            "polymer-project-config": "3.4.0",
-            "sw-precache": "5.2.0",
-            "vinyl": "1.2.0",
-            "vinyl-fs": "2.4.4"
-          },
-          "dependencies": {
-            "@types/mz": {
-              "version": "0.0.31",
-              "resolved": "https://registry.npmjs.org/@types/mz/-/mz-0.0.31.tgz",
-              "integrity": "sha1-pNgMCC/v5x5Ap8DwfR5lVbu8e1I=",
-              "requires": {
-                "@types/node": "6.0.84"
-              }
-            }
-          }
-        },
-        "polymer-bundler": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/polymer-bundler/-/polymer-bundler-2.3.1.tgz",
-          "integrity": "sha512-QCpcmFKQwq8sAJeN1JEuWnd4Jc4Gk/tE6L1ALF79f5VenRDz9kOf++ACZ+R/+eeF+PnYXXzjpWgMdWwsWXBkDw==",
-          "requires": {
-            "clone": "2.1.1",
-            "command-line-args": "3.0.5",
-            "command-line-usage": "3.0.8",
-            "dom5": "2.3.0",
-            "espree": "3.4.3",
-            "mkdirp": "0.5.1",
-            "parse5": "2.2.3",
-            "polymer-analyzer": "2.2.1",
-            "source-map": "0.5.6"
-          }
         }
       }
     },
@@ -8535,12 +8333,12 @@
       }
     },
     "proxy-addr": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.4.tgz",
-      "integrity": "sha1-J+VF9pYKRKYn2bREZ+NcG2tM4vM=",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.5.tgz",
+      "integrity": "sha1-ccDuOxAt4/IC87ZPYI0XP8uhqRg=",
       "requires": {
         "forwarded": "0.1.0",
-        "ipaddr.js": "1.3.0"
+        "ipaddr.js": "1.4.0"
       }
     },
     "pseudomap": {
@@ -8555,16 +8353,6 @@
       "requires": {
         "end-of-stream": "1.4.0",
         "once": "1.4.0"
-      },
-      "dependencies": {
-        "end-of-stream": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
-          "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
-          "requires": {
-            "once": "1.4.0"
-          }
-        }
       }
     },
     "pumpify": {
@@ -8572,7 +8360,7 @@
       "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.3.5.tgz",
       "integrity": "sha1-G2ccYZlAq8rqwK0OOjwWS+dgmTs=",
       "requires": {
-        "duplexify": "3.5.0",
+        "duplexify": "3.5.1",
         "inherits": "2.0.3",
         "pump": "1.0.2"
       }
@@ -8589,9 +8377,9 @@
       "optional": true
     },
     "qs": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
-      "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM="
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.0.tgz",
+      "integrity": "sha512-fjVFjW9yhqMhVGwRExCXLhJKrLlkYSaxNWdyc9rmHlrVZbk35YHH312dFd7191uQeXkI3mKLZTIbSvIeFwFemg=="
     },
     "randomatic": {
       "version": "1.1.7",
@@ -8680,11 +8468,19 @@
       }
     },
     "read-chunk": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/read-chunk/-/read-chunk-2.0.0.tgz",
-      "integrity": "sha1-Mkbod4KRFs7AWWdMTV8wD3qSYfM=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/read-chunk/-/read-chunk-2.1.0.tgz",
+      "integrity": "sha1-agTAkoAF7Z1C4aasVgDhnLx/9lU=",
       "requires": {
-        "pify": "2.3.0"
+        "pify": "3.0.0",
+        "safe-buffer": "5.1.1"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+        }
       }
     },
     "read-pkg": {
@@ -8757,7 +8553,7 @@
       "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
       "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
       "requires": {
-        "resolve": "1.3.3"
+        "resolve": "1.4.0"
       }
     },
     "redent": {
@@ -8789,7 +8585,7 @@
       "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.9.11.tgz",
       "integrity": "sha1-On0GdSDLe3F2dp61/4aGkb7+EoM=",
       "requires": {
-        "babel-runtime": "6.23.0",
+        "babel-runtime": "6.25.0",
         "babel-types": "6.25.0",
         "private": "0.1.7"
       }
@@ -8927,7 +8723,7 @@
         "is-typedarray": "1.0.0",
         "isstream": "0.1.2",
         "json-stringify-safe": "5.0.1",
-        "mime-types": "2.1.15",
+        "mime-types": "2.1.16",
         "oauth-sign": "0.8.2",
         "performance-now": "0.2.0",
         "qs": "6.4.0",
@@ -8938,6 +8734,11 @@
         "uuid": "3.1.0"
       },
       "dependencies": {
+        "qs": {
+          "version": "6.4.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
+          "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM="
+        },
         "uuid": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
@@ -8979,9 +8780,9 @@
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
     },
     "resolve": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz",
-      "integrity": "sha1-ZVkHw0aahoDcLeOidaj91paR8OU=",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.4.0.tgz",
+      "integrity": "sha512-aW7sVKPufyHqOmyyLzg/J+8606v5nevBgaliIlV7nUpVMsDnoBGV/cbSLNjZAg9q0Cfd/+easKVKQ8vOu8fn1Q==",
       "requires": {
         "path-parse": "1.0.5"
       }
@@ -9222,7 +9023,7 @@
             "is-typedarray": "1.0.0",
             "isstream": "0.1.2",
             "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.15",
+            "mime-types": "2.1.16",
             "oauth-sign": "0.8.2",
             "qs": "6.3.2",
             "stringstream": "0.0.5",
@@ -9238,7 +9039,7 @@
           "optional": true,
           "requires": {
             "bl": "1.2.1",
-            "end-of-stream": "1.0.0",
+            "end-of-stream": "1.4.0",
             "readable-stream": "2.3.3",
             "xtend": "4.0.1"
           }
@@ -9273,16 +9074,16 @@
       }
     },
     "semver": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-      "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8="
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
     },
     "semver-diff": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
       "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
       "requires": {
-        "semver": "5.3.0"
+        "semver": "5.4.1"
       }
     },
     "send": {
@@ -9291,7 +9092,7 @@
       "integrity": "sha1-ObBDiz9RC+Xcb2Z6EfcWiTaM3u8=",
       "requires": {
         "debug": "2.2.0",
-        "depd": "1.1.0",
+        "depd": "1.1.1",
         "destroy": "1.0.4",
         "encodeurl": "1.0.1",
         "escape-html": "1.0.3",
@@ -9364,42 +9165,34 @@
       "dev": true
     },
     "serve-static": {
-      "version": "1.12.3",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.12.3.tgz",
-      "integrity": "sha1-n0uhni8wMMVH+K+ZEHg47DjVseI=",
+      "version": "1.12.4",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.12.4.tgz",
+      "integrity": "sha1-m2qpjutyU8Tu3Ewfb9vKYJkBqWE=",
       "requires": {
         "encodeurl": "1.0.1",
         "escape-html": "1.0.3",
         "parseurl": "1.3.1",
-        "send": "0.15.3"
+        "send": "0.15.4"
       },
       "dependencies": {
-        "debug": {
-          "version": "2.6.7",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.7.tgz",
-          "integrity": "sha1-krrR9tBbu2u6Isyoi80OyJTChh4=",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
         "mime": {
           "version": "1.3.4",
           "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
           "integrity": "sha1-EV+eO2s9rylZmDyzjxSaLUDrXVM="
         },
         "send": {
-          "version": "0.15.3",
-          "resolved": "https://registry.npmjs.org/send/-/send-0.15.3.tgz",
-          "integrity": "sha1-UBP5+ZAj31DRvZiSwZ4979HVMwk=",
+          "version": "0.15.4",
+          "resolved": "https://registry.npmjs.org/send/-/send-0.15.4.tgz",
+          "integrity": "sha1-mF+qPihLAnPHkzZKNcZze9k5Bbk=",
           "requires": {
-            "debug": "2.6.7",
-            "depd": "1.1.0",
+            "debug": "2.6.8",
+            "depd": "1.1.1",
             "destroy": "1.0.4",
             "encodeurl": "1.0.1",
             "escape-html": "1.0.3",
             "etag": "1.8.0",
             "fresh": "0.5.0",
-            "http-errors": "1.6.1",
+            "http-errors": "1.6.2",
             "mime": "1.3.4",
             "ms": "2.0.0",
             "on-finished": "2.3.0",
@@ -9514,22 +9307,22 @@
       "integrity": "sha512-W7vTj4kSqN8kHVq+Q6BJTr/UGc36TnO0pzKNU8B4cr7TXG4N98eyubWaaCHPSjCUqDgmUPPru929WXzetai97A==",
       "dev": true,
       "requires": {
-        "typings-global": "1.0.19",
+        "typings-global": "1.0.20",
         "util.promisify": "1.0.0"
       }
     },
     "smartshell": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/smartshell/-/smartshell-1.0.12.tgz",
-      "integrity": "sha512-DSRctrbGyOSsgyOGMYZ1S58Iv3pI/VpjoOmvATWalrgUtAsvZAVRireQaF6BtjJq+JneKh2dzXhooW5ah5BCgg==",
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/smartshell/-/smartshell-1.0.13.tgz",
+      "integrity": "sha512-WJqtRb3x6OKlAg1PGl47XwBAV5NYp6NC8N8rpJzcQn0BMp2TAzVXKUMRSh7a5fvmY71qZ2UadOP6qFvibtE8vA==",
       "dev": true,
       "requires": {
-        "@types/shelljs": "0.7.2",
+        "@types/shelljs": "0.7.4",
         "@types/which": "1.0.28",
         "shelljs": "0.7.8",
         "smartq": "1.1.6",
-        "typings-global": "1.0.19",
-        "which": "1.2.14"
+        "typings-global": "1.0.20",
+        "which": "1.3.0"
       }
     },
     "sntp": {
@@ -9980,7 +9773,7 @@
       "integrity": "sha1-buINxIPbNxs+XIf3BO0vfHmdLJo=",
       "requires": {
         "array-back": "1.0.4",
-        "core-js": "2.4.1",
+        "core-js": "2.5.0",
         "deep-extend": "0.4.2",
         "feature-detect-es6": "1.3.1",
         "typical": "2.6.1",
@@ -10004,7 +9797,7 @@
       "integrity": "sha1-NlSc8E7RrumyowwBQyUiONr5QBY=",
       "requires": {
         "bl": "1.2.1",
-        "end-of-stream": "1.0.0",
+        "end-of-stream": "1.4.0",
         "readable-stream": "2.3.3",
         "xtend": "4.0.1"
       }
@@ -10039,14 +9832,11 @@
       "resolved": "https://registry.npmjs.org/ternary-stream/-/ternary-stream-2.0.1.tgz",
       "integrity": "sha1-Bk5Im0tb9gumpre8fy9cJ07Pgmk=",
       "requires": {
-        "duplexify": "3.5.0",
+        "duplexify": "3.5.1",
         "fork-stream": "0.0.4",
         "merge-stream": "1.0.1",
         "through2": "2.0.3"
       }
-    },
-    "test-fixture": {
-      "version": "github:PolymerElements/test-fixture#26118ef0467501c33c02316e7016a2837baba10f"
     },
     "test-value": {
       "version": "2.1.0",
@@ -10219,7 +10009,7 @@
         "findup-sync": "0.3.0",
         "glob": "7.1.2",
         "optimist": "0.6.1",
-        "resolve": "1.3.3",
+        "resolve": "1.4.0",
         "tsutils": "1.9.1",
         "update-notifier": "2.2.0"
       },
@@ -10240,23 +10030,23 @@
           "dev": true
         },
         "ansi-styles": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.1.0.tgz",
-          "integrity": "sha1-CcIC1ckX7CMYjKpcnLkXnNlUd1A=",
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
           "dev": true,
           "requires": {
             "color-convert": "1.9.0"
           }
         },
         "boxen": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.2.0.tgz",
-          "integrity": "sha512-tfKK3nq0qXXOxvXEYW1k1XNRrDuQzO2oFPvLD3Fs1I58n0leuTNlftBmu3seUCyZvDfiqgRaxlqZs9WJAbSA7g==",
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.2.1.tgz",
+          "integrity": "sha1-DxHn/jRO25OXl3/BPt5/ZNlWSB0=",
           "dev": true,
           "requires": {
             "ansi-align": "2.0.0",
             "camelcase": "4.1.0",
-            "chalk": "2.0.1",
+            "chalk": "2.1.0",
             "cli-boxes": "1.0.0",
             "string-width": "2.1.1",
             "term-size": "1.2.0",
@@ -10264,14 +10054,14 @@
           },
           "dependencies": {
             "chalk": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.0.1.tgz",
-              "integrity": "sha512-Mp+FXEI+FrwY/XYV45b2YD3E8i3HwnEAoFcM0qlZzq/RZ9RwWitt2Y/c7cqRAz70U7hfekqx6qNYthuKFO6K0g==",
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
+              "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
               "dev": true,
               "requires": {
-                "ansi-styles": "3.1.0",
+                "ansi-styles": "3.2.0",
                 "escape-string-regexp": "1.0.5",
-                "supports-color": "4.2.0"
+                "supports-color": "4.2.1"
               }
             }
           }
@@ -10289,12 +10079,12 @@
           "dev": true
         },
         "configstore": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.0.tgz",
-          "integrity": "sha1-Rd+QcHPibfoc9LLVL1tgVF6qEdE=",
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.1.tgz",
+          "integrity": "sha512-5oNkD/L++l0O6xGXxb1EWS7SivtjfGQlRyxJsYgE0Z495/L81e2h4/d3r969hoPXuFItzNOKMtsXgYG4c7dYvw==",
           "dev": true,
           "requires": {
-            "dot-prop": "4.1.1",
+            "dot-prop": "4.2.0",
             "graceful-fs": "4.1.11",
             "make-dir": "1.0.0",
             "unique-string": "1.0.0",
@@ -10303,9 +10093,9 @@
           }
         },
         "dot-prop": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.1.1.tgz",
-          "integrity": "sha1-qEk/C3te7sglJbXHWH+n3nyoWcE=",
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
+          "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
           "dev": true,
           "requires": {
             "is-obj": "1.0.1"
@@ -10384,7 +10174,7 @@
             "got": "6.7.1",
             "registry-auth-token": "3.3.1",
             "registry-url": "3.1.0",
-            "semver": "5.3.0"
+            "semver": "5.4.1"
           }
         },
         "string-width": {
@@ -10407,9 +10197,9 @@
           }
         },
         "supports-color": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.2.0.tgz",
-          "integrity": "sha512-Ts0Mu/A1S1aZxEJNG88I4Oc9rcZSBFNac5e27yh4j2mqbhZSSzR1Ah79EYwSn9Zuh7lrlGD2cVGzw1RKGzyLSg==",
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.2.1.tgz",
+          "integrity": "sha512-qxzYsob3yv6U+xMzPrv170y8AwGP7i74g+pbixCfD6rgso8BscLT2qXIuz6TpOaiJZ3mFgT5O9lyT9nMU4LfaA==",
           "dev": true,
           "requires": {
             "has-flag": "2.0.0"
@@ -10433,9 +10223,9 @@
           "integrity": "sha1-G1g3z5DAc22IYncytmHBOPht5y8=",
           "dev": true,
           "requires": {
-            "boxen": "1.2.0",
+            "boxen": "1.2.1",
             "chalk": "1.1.3",
-            "configstore": "3.1.0",
+            "configstore": "3.1.1",
             "import-lazy": "2.1.0",
             "is-npm": "1.0.0",
             "latest-version": "3.1.0",
@@ -10501,7 +10291,7 @@
       "integrity": "sha1-yrEPtJCeRByChC6v4a1kbIGARBA=",
       "requires": {
         "media-typer": "0.3.0",
-        "mime-types": "2.1.15"
+        "mime-types": "2.1.16"
       }
     },
     "typedarray": {
@@ -10510,9 +10300,9 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "typescript": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.4.1.tgz",
-      "integrity": "sha1-w8yxbdqgsjFN4DHn5v7onlujRrw=",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.4.2.tgz",
+      "integrity": "sha1-+DlfhdRZJ2BnyYiqQYN6j4KHCEQ=",
       "dev": true
     },
     "typical": {
@@ -10555,7 +10345,7 @@
         "thenify": "3.3.0",
         "throat": "3.2.0",
         "touch": "1.0.0",
-        "typescript": "2.4.1",
+        "typescript": "2.4.2",
         "xtend": "4.0.1",
         "zip-object": "0.1.0"
       },
@@ -10588,26 +10378,26 @@
       }
     },
     "typings-global": {
-      "version": "1.0.19",
-      "resolved": "https://registry.npmjs.org/typings-global/-/typings-global-1.0.19.tgz",
-      "integrity": "sha512-Yzm7IVhTZq6q/9V0N+eBnpb0neqXVLkyvR859KIf6WOXDI9jxk/kfpd2GjRzVGqZ+tUMbbjJSjP8zS/sWJlimQ==",
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/typings-global/-/typings-global-1.0.20.tgz",
+      "integrity": "sha512-m3s4wlDTQ1HaGNMNaoWj/N0OjGCzMfU1x+FrPisDLj7DnL6GxdC/nVk9pl0szGwgniDbzoHB0T1C5L/vMUm61w==",
       "dev": true,
       "requires": {
-        "semver": "5.3.0",
-        "smartshell": "1.0.12"
+        "semver": "5.4.1",
+        "smartshell": "1.0.13"
       }
     },
     "ua-parser-js": {
-      "version": "0.7.13",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.13.tgz",
-      "integrity": "sha1-zZ3S+GSTs/RNvu7zeA/adMXuFL4="
+      "version": "0.7.14",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.14.tgz",
+      "integrity": "sha1-EQ1T+kw/MmwSEpK76skE0uAzh8o="
     },
     "uglify-js": {
-      "version": "3.0.25",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.0.25.tgz",
-      "integrity": "sha512-JO1XE0WZ9m6UpDkN7WCyPNAWI6EN3K0g40ekcoJKejViYmryJ0BaLxXjvra1IsAeIlJfq72scTbhl0jknsT2GA==",
+      "version": "3.0.27",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.0.27.tgz",
+      "integrity": "sha512-HD8CmxPXUI62v5tweiulMcP/apAtx1DXGcNZkhKQZyC+MTrTsoCBb8yPAwVrbvpgw3EpRU76bRe6axjIiCYcQg==",
       "requires": {
-        "commander": "2.9.0",
+        "commander": "2.11.0",
         "source-map": "0.5.6"
       }
     },
@@ -10700,9 +10490,9 @@
       "integrity": "sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg="
     },
     "urijs": {
-      "version": "1.18.10",
-      "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.18.10.tgz",
-      "integrity": "sha1-uURj6rpZoaeWA2pGe7YzxmfyIas="
+      "version": "1.18.11",
+      "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.18.11.tgz",
+      "integrity": "sha512-eLUNiNiK4anTRt6fzwbhu4V88Yy3HdeYCc5jCf5UUHa7O4kW50a+IGwi0kZE2qoZ5dcEPW0TEOzz/FW5FNOe7g=="
     },
     "url-parse-lax": {
       "version": "1.0.0",
@@ -10802,11 +10592,20 @@
       "integrity": "sha1-Z1Neu2lMHVIldFeYRmUyP1h+jTc="
     },
     "verror": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
-      "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "requires": {
-        "extsprintf": "1.0.2"
+        "assert-plus": "1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "1.3.0"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+        }
       }
     },
     "vinyl": {
@@ -10856,7 +10655,7 @@
       "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.4.tgz",
       "integrity": "sha1-vm/zJwy1Xf19MGNkDegfJddTIjk=",
       "requires": {
-        "duplexify": "3.5.0",
+        "duplexify": "3.5.1",
         "glob-stream": "5.3.5",
         "graceful-fs": "4.1.11",
         "gulp-sourcemaps": "1.6.0",
@@ -11043,7 +10842,7 @@
         "@types/express": "4.0.36",
         "@types/freeport": "1.0.21",
         "@types/launchpad": "0.6.0",
-        "@types/node": "6.0.84",
+        "@types/node": "6.0.85",
         "@types/which": "1.0.28",
         "chalk": "1.1.3",
         "cleankill": "1.0.3",
@@ -11051,13 +10850,13 @@
         "launchpad": "0.6.0",
         "promisify-node": "0.4.0",
         "selenium-standalone": "5.11.2",
-        "which": "1.2.14"
+        "which": "1.3.0"
       },
       "dependencies": {
         "@types/node": {
-          "version": "6.0.84",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.84.tgz",
-          "integrity": "sha512-1SvEazClhUBRNroJM3oB3xf3u2r6xGmHDGbdigqNPHvNKLl8/BtATgO9eC04ZLuovpSh0B20BF1QJxdi+qmTlg==",
+          "version": "6.0.85",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.85.tgz",
+          "integrity": "sha512-6qLZpfQFO/g5Ns2e7RsW6brk0Q6Xzwiw7kVVU/XiQNOiJXSojhX76GP457PBYIsNMH2WfcGgcnZB4awFDHrwpA==",
           "optional": true
         }
       }
@@ -11119,7 +10918,7 @@
           "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
           "requires": {
             "chalk": "1.1.3",
-            "commander": "2.9.0",
+            "commander": "2.11.0",
             "is-my-json-valid": "2.16.0",
             "pinkie-promise": "2.0.1"
           }
@@ -11157,7 +10956,7 @@
             "is-typedarray": "1.0.0",
             "isstream": "0.1.2",
             "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.15",
+            "mime-types": "2.1.16",
             "oauth-sign": "0.8.2",
             "qs": "6.3.2",
             "stringstream": "0.0.5",
@@ -11179,68 +10978,39 @@
       }
     },
     "web-component-tester": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/web-component-tester/-/web-component-tester-6.0.0.tgz",
-      "integrity": "sha1-arwI6v1xE6nM94c8Il6cz/0gdSM=",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/web-component-tester/-/web-component-tester-6.0.1.tgz",
+      "integrity": "sha512-viy1V/XAbkuDP6N0EZWmyBvfeZwQXEfnzSZs66ur/8iu07QBHsp9lIAFlUswfsEkUHMQHqiuncsp7EA5AgCDvA==",
       "requires": {
-        "@types/body-parser": "0.0.33",
-        "@types/chai": "3.5.2",
-        "@types/chalk": "0.4.31",
-        "@types/express": "4.0.36",
-        "@types/glob": "5.0.30",
-        "@types/grunt": "0.4.21",
-        "@types/gulp": "3.8.33",
-        "@types/lodash": "4.14.70",
-        "@types/mime": "0.0.29",
-        "@types/minimatch": "2.0.29",
-        "@types/mocha": "2.2.41",
-        "@types/multer": "0.0.32",
-        "@types/node": "4.0.30",
-        "@types/nomnom": "0.0.28",
-        "@types/semver": "5.3.32",
-        "@types/sinon": "1.16.36",
-        "@types/sinon-chai": "2.7.28",
-        "@types/socket.io": "1.4.29",
         "accessibility-developer-tools": "2.12.0",
         "async": "1.5.2",
         "body-parser": "1.17.2",
         "chai": "3.5.0",
         "chalk": "1.1.3",
         "cleankill": "1.0.3",
-        "express": "4.15.3",
+        "express": "4.15.4",
         "findup-sync": "0.4.3",
         "glob": "7.1.2",
         "lodash": "3.10.1",
-        "mocha": "3.4.2",
+        "mocha": "3.5.0",
         "multer": "1.3.0",
         "nomnom": "1.8.1",
-        "polyserve": "0.19.1",
+        "polyserve": "0.20.0",
         "promisify-node": "0.4.0",
-        "resolve": "1.3.3",
-        "semver": "5.3.0",
+        "resolve": "1.4.0",
+        "semver": "5.4.1",
         "send": "0.11.1",
         "server-destroy": "1.0.1",
         "sinon": "1.17.7",
         "sinon-chai": "2.12.0",
         "socket.io": "1.7.4",
         "stacky": "1.3.1",
-        "test-fixture": "github:PolymerElements/test-fixture#26118ef0467501c33c02316e7016a2837baba10f",
         "update-notifier": "1.0.3",
         "wct-local": "2.0.15",
         "wct-sauce": "2.0.0-pre.1",
         "wd": "1.4.0"
       },
       "dependencies": {
-        "@types/chai": {
-          "version": "3.5.2",
-          "resolved": "https://registry.npmjs.org/@types/chai/-/chai-3.5.2.tgz",
-          "integrity": "sha1-wRzSgX06QBt7oPWkIPNcVhObHB4="
-        },
-        "@types/node": {
-          "version": "4.0.30",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-4.0.30.tgz",
-          "integrity": "sha1-VT9JDtMDAxFiD4gAPnq/wO3LMB4="
-        },
         "async": {
           "version": "1.5.2",
           "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
@@ -11335,9 +11105,9 @@
       }
     },
     "which": {
-      "version": "1.2.14",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
-      "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
+      "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
       "requires": {
         "isexe": "2.0.0"
       }
@@ -11630,7 +11400,7 @@
         "path-exists": "3.0.0",
         "path-is-absolute": "1.0.1",
         "pretty-bytes": "4.0.2",
-        "read-chunk": "2.0.0",
+        "read-chunk": "2.1.0",
         "read-pkg-up": "2.0.0",
         "rimraf": "2.6.1",
         "run-async": "2.3.0",
@@ -11718,13 +11488,13 @@
       "integrity": "sha512-vJeg2gpWfhbq0HvQ7/yqmsQpYmADBfo9kaW+J6uJASkI7ChLBXNLIBQqaXCA65kWtHXOco+nBm0Km/O9YWk25Q==",
       "dev": true,
       "requires": {
-        "inquirer": "3.2.0",
+        "inquirer": "3.2.1",
         "lodash": "4.17.4",
         "mkdirp": "0.5.1",
         "pinkie-promise": "2.0.1",
         "rimraf": "2.6.1",
-        "sinon": "2.3.8",
-        "yeoman-environment": "2.0.0",
+        "sinon": "2.4.1",
+        "yeoman-environment": "2.0.1",
         "yeoman-generator": "1.1.1"
       },
       "dependencies": {
@@ -11741,23 +11511,23 @@
           "dev": true
         },
         "ansi-styles": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.1.0.tgz",
-          "integrity": "sha1-CcIC1ckX7CMYjKpcnLkXnNlUd1A=",
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
           "dev": true,
           "requires": {
             "color-convert": "1.9.0"
           }
         },
         "chalk": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.0.1.tgz",
-          "integrity": "sha512-Mp+FXEI+FrwY/XYV45b2YD3E8i3HwnEAoFcM0qlZzq/RZ9RwWitt2Y/c7cqRAz70U7hfekqx6qNYthuKFO6K0g==",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
+          "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.1.0",
+            "ansi-styles": "3.2.0",
             "escape-string-regexp": "1.0.5",
-            "supports-color": "4.2.0"
+            "supports-color": "4.2.1"
           }
         },
         "cli-cursor": {
@@ -11776,7 +11546,7 @@
           "dev": true,
           "requires": {
             "iconv-lite": "0.4.18",
-            "jschardet": "1.5.0",
+            "jschardet": "1.5.1",
             "tmp": "0.0.31"
           }
         },
@@ -11824,13 +11594,13 @@
           "dev": true
         },
         "inquirer": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.2.0.tgz",
-          "integrity": "sha512-4CyUYMP7lOBkiUU1rR24WGrfRX6SucwbY2Mqb1PdApU24wnTIk4TsnkQwV72dDdIKZ2ycLP+fWCV+tA7wwgoew==",
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.2.1.tgz",
+          "integrity": "sha512-QgW3eiPN8gpj/K5vVpHADJJgrrF0ho/dZGylikGX7iqAdRgC9FVKYKWFLx6hZDBFcOLEoSqINYrVPeFAeG/PdA==",
           "dev": true,
           "requires": {
             "ansi-escapes": "2.0.0",
-            "chalk": "2.0.1",
+            "chalk": "2.1.0",
             "cli-cursor": "2.1.0",
             "cli-width": "2.1.0",
             "external-editor": "2.0.4",
@@ -11895,9 +11665,9 @@
           "dev": true
         },
         "sinon": {
-          "version": "2.3.8",
-          "resolved": "https://registry.npmjs.org/sinon/-/sinon-2.3.8.tgz",
-          "integrity": "sha1-Md4G/tj7o6Zx5XbdltClhjeW8lw=",
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/sinon/-/sinon-2.4.1.tgz",
+          "integrity": "sha512-vFTrO9Wt0ECffDYIPSP/E5bBugt0UjcBQOfQUMh66xzkyPEnhl/vM2LRZi2ajuTdkH07sA6DzrM6KvdvGIH8xw==",
           "dev": true,
           "requires": {
             "diff": "3.2.0",
@@ -11930,9 +11700,9 @@
           }
         },
         "supports-color": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.2.0.tgz",
-          "integrity": "sha512-Ts0Mu/A1S1aZxEJNG88I4Oc9rcZSBFNac5e27yh4j2mqbhZSSzR1Ah79EYwSn9Zuh7lrlGD2cVGzw1RKGzyLSg==",
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.2.1.tgz",
+          "integrity": "sha512-qxzYsob3yv6U+xMzPrv170y8AwGP7i74g+pbixCfD6rgso8BscLT2qXIuz6TpOaiJZ3mFgT5O9lyT9nMU4LfaA==",
           "dev": true,
           "requires": {
             "has-flag": "2.0.0"
@@ -11951,9 +11721,9 @@
           "dev": true
         },
         "yeoman-environment": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/yeoman-environment/-/yeoman-environment-2.0.0.tgz",
-          "integrity": "sha1-2vovxRLBaMuDE0U+UxjmRzEmWRU=",
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/yeoman-environment/-/yeoman-environment-2.0.1.tgz",
+          "integrity": "sha512-UN+IYz4huNeB+kaZn/6NBaZ23p5PBVG+WiOHenvB+pQFWkLgoYvncmYhbrmxwaAvwuB3+HHjjQ9McQ9Uz7u4ng==",
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
@@ -11962,7 +11732,7 @@
             "escape-string-regexp": "1.0.5",
             "globby": "6.1.0",
             "grouped-queue": "0.3.3",
-            "inquirer": "3.2.0",
+            "inquirer": "3.2.1",
             "is-scoped": "1.0.0",
             "lodash": "4.17.4",
             "log-symbols": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "polymer-build": "^2.0.0",
     "polymer-linter": "^2.0.2",
     "polymer-project-config": "^3.4.0",
-    "polyserve": "^0.19.0",
+    "polyserve": "^0.20.0",
     "request": "^2.72.0",
     "rimraf": "^2.6.1",
     "semver": "^5.3.0",
@@ -77,7 +77,7 @@
     "update-notifier": "^1.0.0",
     "vinyl": "^1.1.1",
     "vinyl-fs": "^2.4.3",
-    "web-component-tester": "^6.0.0",
+    "web-component-tester": "^6.0.1",
     "yeoman-environment": "^1.5.2",
     "yeoman-generator": "^1.0.1"
   },


### PR DESCRIPTION
 - Brings web-component-tester, polyserve and polymer-build all up-to-date so we have only one version of each.
 - CHANGELOG.md was actually updated in a previous PR mentioning update of polymer-build to 2.0.0
