### PR TITLE
Added npm flag to the passed options.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Fixed the `polymer serve --npm` option.
 <!-- Add new, unreleased items here. -->
 
 ## v1.4.0 [08-08-2017]

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -69,6 +69,7 @@ export class ServeCommand implements Command {
       open: options['open'],
       browser: options['browser'],
       openPath: options['open-path'],
+      npm: options['npm'],
       componentDir: options['component-dir'],
       packageName: options['package-name'],
       protocol: options['protocol'],


### PR DESCRIPTION
 - This flag passing is obnoxiously untestable.  I just tried several angles to verify it gets passed to polyserve in the server options, but I'd have to refactor the method altogether to test the flag passing and right now I just want to patch this.
 - [x] CHANGELOG.md has been updated
