### PR TITLE
Updated CHANGELOG for 1.5.2 release.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Changelog
 
 ## Unreleased
-- Upgraded web-component-tester to v6.1.3 to address yarn installation issues.
 <!-- Add new, unreleased items here. -->
+
+## v1.5.2 [08-26-2017]
+- Upgraded web-component-tester to v6.1.3 to address yarn installation issues.
 
 ## v1.5.1 [08-22-2017]
 - Upgraded web-component-tester to v6.1.2.


### PR DESCRIPTION
## 1.5.2 [08-26-2017]
 - Upgraded web-component-tester to v6.1.3 to address yarn installation issues.
 - [x] CHANGELOG.md has been updated
 