### PR TITLE
Disable bower networking

### DIFF
--- a/src/build/build.ts
+++ b/src/build/build.ts
@@ -70,7 +70,7 @@ export async function build(
   async function getPolymerVersion(): Promise<string> {
     return new Promise<string>(
         (resolve, _reject) =>
-            bower.commands.list()
+            bower.commands.list({offline: true})
                 .on('end',
                     (result: any) => {
                       if (result && result.dependencies &&


### PR DESCRIPTION
By default bower list command attempts to fetch latest package versions from github, this step is not required for polymer build and causes it hang because polymer is not forwarding bower's github api token request.

<!--
  Thanks for the PR!

  If this change has a user visible change (including
  bug fixes, new features, etc) please describe the change in
  CHANGELOG.md.

  If the change is an entirely package-internal reshuffling/refactoring
  should the change not be described in the CHANGELOG.

  Consider also updating the README.

  More info: http://keepachangelog.com/en/0.3.0/
 -->

 - [ ] CHANGELOG.md has been updated
