### PR TITLE
Updated CHANGELOG and package files to update wct to 6.1.5 to fix ie11 issue.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## Unreleased
 <!-- Add new, unreleased items here. -->
 
+## v1.5.4 [08-31-2017]
+- Upgraded web-component-tester to v6.1.5 to address IE11 issues.
+
 ## v1.5.3 [08-31-2017]
 - Upgraded web-component-tester to v6.1.4 to address IE11 issues.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "polymer-cli",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -11022,9 +11022,9 @@
       }
     },
     "web-component-tester": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/web-component-tester/-/web-component-tester-6.1.4.tgz",
-      "integrity": "sha512-yabj8YbjrNjA3pSoLLCSmj2YzDJrBuDrP0CHfeBGnqKI59+a4gB60rRM44NRRdkDpYv/wFXrKUdPYnaLBnMS5w==",
+      "version": "6.1.5",
+      "resolved": "https://registry.npmjs.org/web-component-tester/-/web-component-tester-6.1.5.tgz",
+      "integrity": "sha512-VvJG7l4wDSVMXChfCtCPzyqo0tMV56LtpX0S7XeJCQyCzLgSFdIP6n/md4UjWkvD9UCib1QR6WZd3JzHC4Nxpg==",
       "requires": {
         "@polymer/sinonjs": "1.17.1",
         "@polymer/test-fixture": "0.0.3",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "update-notifier": "^1.0.0",
     "vinyl": "^1.1.1",
     "vinyl-fs": "^2.4.3",
-    "web-component-tester": "^6.1.3",
+    "web-component-tester": "^6.1.5",
     "yeoman-environment": "^1.5.2",
     "yeoman-generator": "^1.0.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -7290,9 +7290,9 @@ wd@^1.2.0:
     underscore.string "3.3.4"
     vargs "0.1.0"
 
-web-component-tester@^6.1.3:
-  version "6.1.4"
-  resolved "https://registry.yarnpkg.com/web-component-tester/-/web-component-tester-6.1.4.tgz#5404ec4f4e6d2f661547449d47835aa75de15c37"
+web-component-tester@^6.1.5:
+  version "6.1.5"
+  resolved "https://registry.yarnpkg.com/web-component-tester/-/web-component-tester-6.1.5.tgz#d88716d15692442af998ff29a6903dbda5f4e622"
   dependencies:
     "@polymer/sinonjs" "^1.14.1"
     "@polymer/test-fixture" "^0.0.3"


### PR DESCRIPTION
 - Upgraded web-component-tester to v6.1.5 to address IE11 issues.
 - [x] CHANGELOG.md has been updated
