### PR TITLE
Update to latest @types/request

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@types/inquirer": "0.0.32",
     "@types/merge-stream": "^1.0.28",
     "@types/mz": "^0.0.31",
-    "@types/request": "0.0.39",
+    "@types/request": "2.0.3",
     "@types/resolve": "0.0.4",
     "@types/rimraf": "^0.0.28",
     "@types/semver": "^5.3.30",


### PR DESCRIPTION
package.json is currently requiring `"request": "^2.72.0"` but only `"@types/request": "0.0.39"` along with it. (https://www.npmjs.com/package/@types/request lists 2.0.3 as the latest.)

I believe this can cause typescript error TS2430 for projects that depend on `polymer-cli`, see https://github.com/DefinitelyTyped/DefinitelyTyped/issues/17171 for an example. At least, I just hit this, and updating to the latest `@types/request` fixes it for me.