### PR TITLE
Exit with explicit status 0 instead of unspecified

### DIFF
--- a/bin/polymer.js
+++ b/bin/polymer.js
@@ -35,3 +35,7 @@ if (!semver.satisfies(process.version, '>=6')) {
 
 // Ok, safe to load ES2015.
 require('../lib/run');
+
+process.on('SIGINT', function() {
+  process.exit(0);
+});


### PR DESCRIPTION
When a node process is just interrupted via a SIGINT, it will report an undefined exit code. [The FAQ of Concurrently](https://www.npmjs.com/package/concurrently#faq) explicitly states that in such a case, it will exit with a non-null status, causing npm's runner to exit with an error. This change fixes that issue.

(We have a use case where we use `concurrently` to start both polymer and a mock server, neither of which returned a zero exit code on exit, causing the error)
