### PR TITLE
Build: determine Polymer version via bower list using offline option

### DIFF
--- a/custom_typings/bower.d.ts
+++ b/custom_typings/bower.d.ts
@@ -8,12 +8,13 @@ declare module 'bower' {
     directory?: string;
     interactive?: boolean;
     save?: boolean;
+    offline?: boolean;
   }
 
   export const commands: {
     install(packages: string[], installOptions: {}, config: Config):
         NodeJS.EventEmitter;
-    list(): NodeJS.EventEmitter;
+    list(readOptions: {}, config: Config): NodeJS.EventEmitter;
   };
 
   export const config: Config;

--- a/src/build/build.ts
+++ b/src/build/build.ts
@@ -70,7 +70,7 @@ export async function build(
   async function getPolymerVersion(): Promise<string> {
     return new Promise<string>(
         (resolve, _reject) =>
-            bower.commands.list()
+            bower.commands.list({}, { offline: true })
                 .on('end',
                     (result: any) => {
                       if (result && result.dependencies &&


### PR DESCRIPTION
When building, polymer-cli uses 'bower list' to determine the current Polymer version in order to
set the 'rewriteUrlsInTemplates' option. However, 'bower list' by default will attempt to read
from the underlying package source (since it's typically used at the command-line to see if any
package has upgrades available). This behavior is undesirable (and unnecessary), particularly in CI.

I've also updated the TS custom_typing to match the actual bower list command signature

<!--
  Thanks for the PR!

  If this change has a user visible change (including
  bug fixes, new features, etc) please describe the change in
  CHANGELOG.md.

  If the change is an entirely package-internal reshuffling/refactoring
  should the change not be described in the CHANGELOG.

  Consider also updating the README.

  More info: http://keepachangelog.com/en/0.3.0/
 -->

 - [ ] CHANGELOG.md has been updated
