### PR TITLE
Add --auto-base-path flag to build.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Unreleased
 - Added `--fix` option to `polymer lint`. When passed, some warnings with simple mechanical solutions will be fixed.
-- `build` Added a CLI argument for setting the `basePath` option: `--base-path`.
+- `build` Added `--base-path` flag. Sets the entrypoint `<base>` of the single one-off build to the specified value.
+- `build` Added `--auto-base-path` flag. Sets the entrypoint `<base>` tag for all builds to match the name of that build. Unlike other flags, does not necessarily trigger a single one-off build.
 <!-- Add new, unreleased items here. -->
 
 ## v1.5.7 [10-11-2017]


### PR DESCRIPTION
This new flag sets the entrypoint `<base>` tag for all builds to match the name of that build. Unlike the other flags, it does not necessarily trigger a single one-off build. Instead, it switches the option on for *all* builds (including a one-off, if another flag triggered one).

The idea is to make building for prpl-server easier. See https://github.com/Polymer/prpl-server-node/issues/24 for motivation. Right now you need need to annotate each build in your `polymer.json` with `basePath: true` to make prpl-server work. The problem with this is that:

1) It's kind of unintuitive/odd ergonomically because you would almost always want this option all-or-nothing. Setting it in every build feels weird, especially with presets (we used to have this option on for the presets, but that broke the non-prpl-server use case by default).
2) It's something you would typically want to switch on/off for development vs deployment (since you can't directly serve a build when it's on), so having to update `polymer.json` makes this cumbersome.

 - [x] CHANGELOG.md has been updated
