### PR TITLE
Fix #827. Merge commandline options with named build configuration options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
     an interactive prompt and the `--edits` flag. See `polymer lint --help` for
     more info.
 - `build` Added a CLI argument for setting the `basePath` option: `--base-path`.
+- `build` When using flag `--name <buildName>`, it will now take the matching named build from `polymer.json` and merge it with the command-line options. This fixes #827.
 <!-- Add new, unreleased items here. -->
 
 ## v1.5.7 [10-11-2017]


### PR DESCRIPTION
This fixes #827 
When building from command line with `--name <buildName>`, it now takes the options from the command line, merges them with the project's options and continues the build.

It's probably fixing #613 as well.
<!--
  Thanks for the PR!

  If this change has a user visible change (including
  bug fixes, new features, etc) please describe the change in
  CHANGELOG.md.

  If the change is an entirely package-internal reshuffling/refactoring
  should the change not be described in the CHANGELOG.

  Consider also updating the README.

  More info: http://keepachangelog.com/en/0.3.0/
 -->

 - [x] CHANGELOG.md has been updated
