### PR TITLE
Fix #906: redirect url to demo page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Added `--watch` (shorthand `-w`) option to `polymer lint`. When passed, we will watch the filesystem for changes and rerun the linter immediately afterwards.
   - Also works with `--fix` to automatically fix and report warnings as you work!
 - `build` Added a CLI argument for setting the `basePath` option: `--base-path`.
+- Corrected the redirect URL to the demo page of generated elements.
 <!-- Add new, unreleased items here. -->
 
 ## v1.5.7 [10-11-2017]

--- a/src/init/element/templates/polymer-2.x/index.html
+++ b/src/init/element/templates/polymer-2.x/index.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <meta http-equiv="refresh" content="0;url=demo/" />
+    <meta http-equiv="refresh" content="0;url=components/<%= name %>/demo/" />
     <title><%= name %></title>
   </head>
   <body>


### PR DESCRIPTION
This pull request fixes #906 
When initializing and serving a new polymer-2-element, the _index.html_ page redirects to the demo page, but the redirect URL differed from the one, _polymer serve_ shows for elements on the cli output.
<!--
  Thanks for the PR!

  If this change has a user visible change (including
  bug fixes, new features, etc) please describe the change in
  CHANGELOG.md.

  If the change is an entirely package-internal reshuffling/refactoring
  should the change not be described in the CHANGELOG.

  Consider also updating the README.

  More info: http://keepachangelog.com/en/0.3.0/
 -->

 - [x] CHANGELOG.md has been updated
