### PR TITLE
Reduce the amount of noise in test output.

### DIFF
--- a/src/test/unit/commands/cli_test.ts
+++ b/src/test/unit/commands/cli_test.ts
@@ -15,6 +15,7 @@ import * as logging from 'plylog';
 import * as sinon from 'sinon';
 
 import {PolymerCli} from '../../../polymer-cli';
+import {interceptOutput} from '../../util';
 
 const packageJSON = require('../../../../package.json');
 
@@ -24,9 +25,12 @@ suite('The general CLI', () => {
     const cli = new PolymerCli([]);
     const helpCommand = cli.commands.get('help');
     const helpCommandSpy = sinon.spy(helpCommand!, 'run');
+    const getOutput = interceptOutput();
     await cli.run();
+    const output = getOutput();
     assert.isOk(helpCommandSpy.calledOnce);
     assert.deepEqual(helpCommandSpy.firstCall.args[0], {command: null});
+    assert.include(output, 'Usage: `polymer <command>');
   });
 
   let testName =
@@ -35,47 +39,63 @@ suite('The general CLI', () => {
     const cli = new PolymerCli(['--help']);
     const helpCommand = cli.commands.get('help');
     const helpCommandSpy = sinon.spy(helpCommand!, 'run');
+    const getOutput = interceptOutput();
     await cli.run();
+    const output = getOutput();
     assert.isOk(helpCommandSpy.calledOnce);
     assert.deepEqual(helpCommandSpy.firstCall.args[0], {command: null});
+    assert.include(output, 'Usage: `polymer <command>');
   });
 
   test('displays general help when unknown command is called', async () => {
     const cli = new PolymerCli(['THIS_IS_SOME_UNKNOWN_COMMAND']);
     const helpCommand = cli.commands.get('help');
     const helpCommandSpy = sinon.spy(helpCommand!, 'run');
+    const getOutput = interceptOutput();
     await cli.run();
+    const output = getOutput();
     assert.isOk(helpCommandSpy.calledOnce);
     assert.deepEqual(
         helpCommandSpy.firstCall.args[0],
         {command: 'THIS_IS_SOME_UNKNOWN_COMMAND'});
+    assert.include(output, 'Usage: `polymer <command>');
   });
 
   test('displays command help when called with the --help flag', async () => {
     const cli = new PolymerCli(['build', '--help']);
     const helpCommand = cli.commands.get('help');
     const helpCommandSpy = sinon.spy(helpCommand!, 'run');
+    const getOutput = interceptOutput();
     await cli.run();
+    const output = getOutput();
     assert.isOk(helpCommandSpy.calledOnce);
     assert.deepEqual(helpCommandSpy.firstCall.args[0], {command: 'build'});
+    assert.include(output, 'polymer build');
+    assert.include(output, 'Command Options');
+    assert.include(output, '--bundle');
   });
 
   test('displays command help when called with the -h flag', async () => {
     const cli = new PolymerCli(['init', '-h']);
     const helpCommand = cli.commands.get('help');
     const helpCommandSpy = sinon.spy(helpCommand!, 'run');
+    const getOutput = interceptOutput();
     await cli.run();
+    const output = getOutput();
     assert.isOk(helpCommandSpy.calledOnce);
     assert.deepEqual(helpCommandSpy.firstCall.args[0], {command: 'init'});
+    assert.include(output, 'polymer init');
+    assert.include(output, 'Command Options');
+    assert.include(output, '--name');
   });
 
   testName = 'displays version information when called with the --version flag';
   test(testName, async () => {
     const cli = new PolymerCli(['--version']);
-    const consoleLogSpy = sinon.spy(console, 'log');
+    const getOutput = interceptOutput();
     await cli.run();
-    assert.isOk(consoleLogSpy.calledWithExactly(packageJSON.version));
-    consoleLogSpy.restore();
+    const output = getOutput();
+    assert.match(output, /^\d+\.\d+\.\d+$/m);
   });
 
   testName = `sets the appropriate log levels when ` +

--- a/src/test/unit/commands/cli_test.ts
+++ b/src/test/unit/commands/cli_test.ts
@@ -17,15 +17,13 @@ import * as sinon from 'sinon';
 import {PolymerCli} from '../../../polymer-cli';
 import {interceptOutput} from '../../util';
 
-const packageJSON = require('../../../../package.json');
-
 suite('The general CLI', () => {
 
   test('displays general help when no command is called', async () => {
     const cli = new PolymerCli([]);
-    const getOutput = interceptOutput();
-    await cli.run();
-    const output = getOutput();
+    const output = await interceptOutput(async () => {
+      await cli.run();
+    });
     assert.include(output, 'Usage: `polymer <command>');
   });
 
@@ -33,25 +31,25 @@ suite('The general CLI', () => {
       'displays general help when no command is called with the --help flag';
   test(testName, async () => {
     const cli = new PolymerCli(['--help']);
-    const getOutput = interceptOutput();
-    await cli.run();
-    const output = getOutput();
+    const output = await interceptOutput(async () => {
+      await cli.run();
+    });
     assert.include(output, 'Usage: `polymer <command>');
   });
 
   test('displays general help when unknown command is called', async () => {
     const cli = new PolymerCli(['THIS_IS_SOME_UNKNOWN_COMMAND']);
-    const getOutput = interceptOutput();
-    await cli.run();
-    const output = getOutput();
+    const output = await interceptOutput(async () => {
+      await cli.run();
+    });
     assert.include(output, 'Usage: `polymer <command>');
   });
 
   test('displays command help when called with the --help flag', async () => {
     const cli = new PolymerCli(['build', '--help']);
-    const getOutput = interceptOutput();
-    await cli.run();
-    const output = getOutput();
+    const output = await interceptOutput(async () => {
+      await cli.run();
+    });
     assert.include(output, 'polymer build');
     assert.include(output, 'Command Options');
     assert.include(output, '--bundle');
@@ -59,9 +57,9 @@ suite('The general CLI', () => {
 
   test('displays command help when called with the -h flag', async () => {
     const cli = new PolymerCli(['init', '-h']);
-    const getOutput = interceptOutput();
-    await cli.run();
-    const output = getOutput();
+    const output = await interceptOutput(async () => {
+      await cli.run();
+    });
     assert.include(output, 'polymer init');
     assert.include(output, 'Command Options');
     assert.include(output, '--name');
@@ -70,9 +68,9 @@ suite('The general CLI', () => {
   testName = 'displays version information when called with the --version flag';
   test(testName, async () => {
     const cli = new PolymerCli(['--version']);
-    const getOutput = interceptOutput();
-    await cli.run();
-    const output = getOutput();
+    const output = await interceptOutput(async () => {
+      await cli.run();
+    });
     assert.match(output, /^\d+\.\d+\.\d+$/m);
   });
 

--- a/src/test/unit/commands/cli_test.ts
+++ b/src/test/unit/commands/cli_test.ts
@@ -23,13 +23,9 @@ suite('The general CLI', () => {
 
   test('displays general help when no command is called', async () => {
     const cli = new PolymerCli([]);
-    const helpCommand = cli.commands.get('help');
-    const helpCommandSpy = sinon.spy(helpCommand!, 'run');
     const getOutput = interceptOutput();
     await cli.run();
     const output = getOutput();
-    assert.isOk(helpCommandSpy.calledOnce);
-    assert.deepEqual(helpCommandSpy.firstCall.args[0], {command: null});
     assert.include(output, 'Usage: `polymer <command>');
   });
 
@@ -37,39 +33,25 @@ suite('The general CLI', () => {
       'displays general help when no command is called with the --help flag';
   test(testName, async () => {
     const cli = new PolymerCli(['--help']);
-    const helpCommand = cli.commands.get('help');
-    const helpCommandSpy = sinon.spy(helpCommand!, 'run');
     const getOutput = interceptOutput();
     await cli.run();
     const output = getOutput();
-    assert.isOk(helpCommandSpy.calledOnce);
-    assert.deepEqual(helpCommandSpy.firstCall.args[0], {command: null});
     assert.include(output, 'Usage: `polymer <command>');
   });
 
   test('displays general help when unknown command is called', async () => {
     const cli = new PolymerCli(['THIS_IS_SOME_UNKNOWN_COMMAND']);
-    const helpCommand = cli.commands.get('help');
-    const helpCommandSpy = sinon.spy(helpCommand!, 'run');
     const getOutput = interceptOutput();
     await cli.run();
     const output = getOutput();
-    assert.isOk(helpCommandSpy.calledOnce);
-    assert.deepEqual(
-        helpCommandSpy.firstCall.args[0],
-        {command: 'THIS_IS_SOME_UNKNOWN_COMMAND'});
     assert.include(output, 'Usage: `polymer <command>');
   });
 
   test('displays command help when called with the --help flag', async () => {
     const cli = new PolymerCli(['build', '--help']);
-    const helpCommand = cli.commands.get('help');
-    const helpCommandSpy = sinon.spy(helpCommand!, 'run');
     const getOutput = interceptOutput();
     await cli.run();
     const output = getOutput();
-    assert.isOk(helpCommandSpy.calledOnce);
-    assert.deepEqual(helpCommandSpy.firstCall.args[0], {command: 'build'});
     assert.include(output, 'polymer build');
     assert.include(output, 'Command Options');
     assert.include(output, '--bundle');
@@ -77,13 +59,9 @@ suite('The general CLI', () => {
 
   test('displays command help when called with the -h flag', async () => {
     const cli = new PolymerCli(['init', '-h']);
-    const helpCommand = cli.commands.get('help');
-    const helpCommandSpy = sinon.spy(helpCommand!, 'run');
     const getOutput = interceptOutput();
     await cli.run();
     const output = getOutput();
-    assert.isOk(helpCommandSpy.calledOnce);
-    assert.deepEqual(helpCommandSpy.firstCall.args[0], {command: 'init'});
     assert.include(output, 'polymer init');
     assert.include(output, 'Command Options');
     assert.include(output, '--name');

--- a/src/test/unit/commands/help_test.ts
+++ b/src/test/unit/commands/help_test.ts
@@ -26,15 +26,9 @@ suite('help', () => {
       'displays help for a specific command when called with that command';
   test(testName, async () => {
     const cli = new PolymerCli(['help', 'build']);
-    const helpCommand = cli.commands.get('help')!;
-    const helpCommandSpy = sinon.spy(helpCommand, 'run');
     const getOutput = interceptOutput();
     await cli.run();
     const output = getOutput();
-    assert.isOk(helpCommandSpy.calledOnce);
-    assert.deepEqual(
-        helpCommandSpy.firstCall.args,
-        [{command: 'build'}, expectedDefaultConfig]);
     assert.include(output, 'polymer build');
     assert.include(output, 'Command Options');
     assert.include(output, '--bundle');
@@ -44,14 +38,9 @@ suite('help', () => {
       'displays general help when the help command is called with no arguments';
   test(testName, async () => {
     const cli = new PolymerCli(['help']);
-    const helpCommand = cli.commands.get('help')!;
-    const helpCommandSpy = sinon.spy(helpCommand, 'run');
     const getOutput = interceptOutput();
     await cli.run();
     const output = getOutput();
-    assert.isOk(helpCommandSpy.calledOnce);
-    assert.deepEqual(
-        helpCommandSpy.firstCall.args, [{}, expectedDefaultConfig]);
     assert.include(output, 'Usage: `polymer <command>');
   });
 

--- a/src/test/unit/commands/help_test.ts
+++ b/src/test/unit/commands/help_test.ts
@@ -10,25 +10,18 @@
  */
 
 import {assert} from 'chai';
-import * as path from 'path';
-import {ProjectConfig} from 'polymer-project-config';
-import * as sinon from 'sinon';
 
 import {PolymerCli} from '../../../polymer-cli';
 import {interceptOutput} from '../../util';
 
 suite('help', () => {
-  const expectedDefaultConfig = new ProjectConfig({
-    extraDependencies: [path.resolve('bower_components/webcomponentsjs/*.js')],
-  });
-
   let testName =
       'displays help for a specific command when called with that command';
   test(testName, async () => {
     const cli = new PolymerCli(['help', 'build']);
-    const getOutput = interceptOutput();
-    await cli.run();
-    const output = getOutput();
+    const output = await interceptOutput(async () => {
+      await cli.run();
+    });
     assert.include(output, 'polymer build');
     assert.include(output, 'Command Options');
     assert.include(output, '--bundle');
@@ -38,9 +31,9 @@ suite('help', () => {
       'displays general help when the help command is called with no arguments';
   test(testName, async () => {
     const cli = new PolymerCli(['help']);
-    const getOutput = interceptOutput();
-    await cli.run();
-    const output = getOutput();
+    const output = await interceptOutput(async () => {
+      await cli.run();
+    });
     assert.include(output, 'Usage: `polymer <command>');
   });
 

--- a/src/test/unit/commands/help_test.ts
+++ b/src/test/unit/commands/help_test.ts
@@ -15,6 +15,7 @@ import {ProjectConfig} from 'polymer-project-config';
 import * as sinon from 'sinon';
 
 import {PolymerCli} from '../../../polymer-cli';
+import {interceptOutput} from '../../util';
 
 suite('help', () => {
   const expectedDefaultConfig = new ProjectConfig({
@@ -27,11 +28,16 @@ suite('help', () => {
     const cli = new PolymerCli(['help', 'build']);
     const helpCommand = cli.commands.get('help')!;
     const helpCommandSpy = sinon.spy(helpCommand, 'run');
+    const getOutput = interceptOutput();
     await cli.run();
+    const output = getOutput();
     assert.isOk(helpCommandSpy.calledOnce);
     assert.deepEqual(
         helpCommandSpy.firstCall.args,
         [{command: 'build'}, expectedDefaultConfig]);
+    assert.include(output, 'polymer build');
+    assert.include(output, 'Command Options');
+    assert.include(output, '--bundle');
   });
 
   testName =
@@ -40,10 +46,13 @@ suite('help', () => {
     const cli = new PolymerCli(['help']);
     const helpCommand = cli.commands.get('help')!;
     const helpCommandSpy = sinon.spy(helpCommand, 'run');
+    const getOutput = interceptOutput();
     await cli.run();
+    const output = getOutput();
     assert.isOk(helpCommandSpy.calledOnce);
     assert.deepEqual(
         helpCommandSpy.firstCall.args, [{}, expectedDefaultConfig]);
+    assert.include(output, 'Usage: `polymer <command>');
   });
 
 });

--- a/src/test/util.ts
+++ b/src/test/util.ts
@@ -9,6 +9,8 @@
  * rights grant found at http://polymer.github.io/PATENTS.txt
  */
 
+import * as logging from 'plylog';
+
 export async function invertPromise(p: Promise<any>): Promise<any> {
   let result;
   try {
@@ -17,4 +19,31 @@ export async function invertPromise(p: Promise<any>): Promise<any> {
     return e;
   }
   throw new Error(`Expected an error, got ${result}`);
+}
+
+/**
+ * Call to begin capturing all output. Call the returned function to
+ * stop capturing output and get the contents as a string.
+ *
+ * Captures output from console methods. Does not capture plylog, which doesn't
+ * seem to be very easy to intercept.
+ */
+export function interceptOutput(): () => string {
+  const originalLog = console.log;
+  const originalError = console.error;
+  const originalWarn = console.warn;
+  const buffer: string[] = [];
+  const capture = (...args: any[]) => {
+    buffer.push(args.join(' '));
+  };
+  console.log = capture;
+  console.error = capture;
+  console.warn = capture;
+  const cleanupAndRestoreBuffer = () => {
+    console.log = originalLog;
+    console.error = originalError;
+    console.warn = originalWarn;
+    return buffer.join('\n');
+  };
+  return cleanupAndRestoreBuffer;
 }


### PR DESCRIPTION
This captures all non-plylog output and lets us assert on it rather than logging it from the test runner.

It does not intercept plylog, as plylog is really hard to intercept. For the editor service, when it was a hard requirement, the only way I was able to do it was by importing a special log interceptor module before any plylog-using modules.

<!--
  Thanks for the PR!

  If this change has a user visible change (including
  bug fixes, new features, etc) please describe the change in
  CHANGELOG.md.

  If the change is an entirely package-internal reshuffling/refactoring
  should the change not be described in the CHANGELOG.

  Consider also updating the README.

  More info: http://keepachangelog.com/en/0.3.0/
 -->

 - [x] CHANGELOG.md not been updated, internal change
