### PR TITLE
Use strict type checking.

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,25 +1,26 @@
 {
   "compilerOptions": {
+    // Targeted standard
     "target": "es6",
     "lib": [
       "es2017",
       "esnext.asynciterable"
     ],
+    // Module system
     "module": "commonjs",
     "moduleResolution": "node",
-    "isolatedModules": false,
-    "declaration": false,
-    "strictNullChecks": true,
-    "noImplicitAny": true,
+    // Strictness
+    "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
+    "skipLibCheck": true,
+    // Output
+    "sourceMap": true,
     "removeComments": false,
     "preserveConstEnums": true,
-    "suppressImplicitAnyIndexErrors": false,
+    "declaration": false,
     "outDir": "lib",
-    "rootDir": "src",
-    "sourceMap": true,
-    "skipLibCheck": true
+    "rootDir": "src"
   },
   "include": [
     "custom_typings/**/*.ts",


### PR DESCRIPTION
<!--
  Thanks for the PR!

  If this change has a user visible change (including
  bug fixes, new features, etc) please describe the change in
  CHANGELOG.md.

  If the change is an entirely package-internal reshuffling/refactoring
  should the change not be described in the CHANGELOG.

  Consider also updating the README.

  More info: http://keepachangelog.com/en/0.3.0/
 -->

 - [x] CHANGELOG.md not updated, noop change


Stubbed my toe on an implicitly `any` `this`. This will opt us into all the strictness.