### PR TITLE
If there are multiple builds, add the `basePath` flag to each build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
   - Also works with `--fix` to automatically fix and report warnings as you work!
 - `build` Added a CLI argument for setting the `basePath` option: `--base-path`.
 - Derives node version check from the package.json.
+- If there are multiple builds, add the `basePath` option to each build for the `prpl-server` support.
 
 ## v1.5.7 [10-11-2017]
 - Updated css-slam, bower and other dependencies.

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -177,8 +177,15 @@ export class BuildCommand implements Command {
     // If no build flags were passed but 1+ polymer.json build configuration(s)
     // exist, generate a build for each configuration found.
     if (config.builds) {
-      const promises = config.builds.map(
-          (buildOptions) => build(buildOptions, polymerProject));
+      const promises = config.builds.map((buildOptions) => {
+        // If there are multiple builds, add the `basePath` option to each build
+        // for the `prpl-server` support
+        if (config.builds.length > 1) {
+          buildOptions.basePath = true;
+        }
+
+        return build(buildOptions, polymerProject);
+      });
       promises.push(mzfs.writeFile(
           path.join(mainBuildDirectoryName, 'polymer.json'), config.toJSON()));
       await Promise.all(promises);


### PR DESCRIPTION
If there are multiple builds, add the `basePath` flag to each build for the `prpl-server` support.

<!--
  Thanks for the PR!

  If this change has a user visible change (including
  bug fixes, new features, etc) please describe the change in
  CHANGELOG.md.

  If the change is an entirely package-internal reshuffling/refactoring
  should the change not be described in the CHANGELOG.

  Consider also updating the README.

  More info: http://keepachangelog.com/en/0.3.0/
 -->

 - [x] CHANGELOG.md has been updated
