### PR TITLE
Speed up Travis builds from 13 minutes to 5 minutes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,15 @@ addons:
       - google-chrome
     packages:
       - google-chrome-stable
+cache:
+  directories:
+    - node_modules/
+env:
+  - TEST_SUITE=smoke-lint
+  - TEST_SUITE=integration
 language: node_js
 node_js:
   - "node"
   - "6"
 script:
-  - xvfb-run npm test
-  - xvfb-run npm run test:integration
+  - xvfb-run npm run test:$TEST_SUITE

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "build": "gulp build",
     "test": "gulp test lint",
     "test:smoke": "gulp test",
+    "test:smoke-lint": "gulp test lint",
     "test:integration": "gulp test:integration",
     "format": "find src gulpfile.js \\( -iname '*.ts' -o -iname '*.js' \\) -not -path '*fixtures*' | xargs clang-format --style=file -i"
   },


### PR DESCRIPTION
This change improves Travis build times on pull requests. It does this by:
 - caching `node_modules/`. `npm install` is still run and used, it just starts from the last builds cached `node_modules`.
 - uses parallel builds to run smoke tests and integration tests.