### PR TITLE
Fix serve with --module-resolution and prepare release 1.7.0-pre.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Changelog
 
 <!-- Add new, unreleased items here. -->
-## Unreleased
+<!-- ## Unreleased -->
+
+## v1.7.0-pre.2 [03-22-2018]
 - Fixed issue where the `--module-resolution` wasn't being handled for the `serve` command.
 
 ## v1.7.0-pre.1 [03-21-2018]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 <!-- Add new, unreleased items here. -->
 ## Unreleased
+- Fixed issue where the `--module-resolution` wasn't being handled for the `serve` command.
 
 ## v1.7.0-pre.1 [03-21-2018]
 - Added `--npm` and `--component-dir` global flags, which are passed to the `build`, `lint`, `test`, and `serve` commands.

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -70,6 +70,7 @@ export class ServeCommand implements Command {
       browser: options['browser'],
       openPath: options['open-path'],
       npm: config.npm,
+      moduleResolution: config.moduleResolution,
       componentDir: config.componentDir,
       packageName: options['package-name'],
       protocol: options['protocol'],

--- a/src/test/unit/commands/cli_test.ts
+++ b/src/test/unit/commands/cli_test.ts
@@ -71,7 +71,7 @@ suite('The general CLI', () => {
     const output = await interceptOutput(async () => {
       await cli.run();
     });
-    assert.match(output, /^\d+\.\d+\.\d+$/m);
+    assert.match(output, /^\d+\.\d+\.\d+(?:-[\da-z-.]+)?$/m);
   });
 
   testName = `sets the appropriate log levels when ` +


### PR DESCRIPTION
Fixed issue where the `--module-resolution` wasn't being handled for the `serve` command.
Prepare 1.7.0-pre.2

 - [c] CHANGELOG.md has been updated
